### PR TITLE
Add params to let users select which google account to sign in from

### DIFF
--- a/client/hosted-oauth.ts
+++ b/client/hosted-oauth.ts
@@ -25,7 +25,12 @@ const OAUTH_IN_PROGRESS_KEY = "cognito_oauth_in_progress";
 export async function signInWithRedirect({
   provider = "COGNITO",
   customState,
-}: { provider?: string; customState?: string } = {}) {
+  oauthParams,
+}: {
+  provider?: string;
+  customState?: string;
+  oauthParams?: Record<string, string>;
+} = {}) {
   const cfg = configure();
   const { debug } = cfg;
 
@@ -76,6 +81,7 @@ export async function signInWithRedirect({
     scope: (scopes ?? ["openid", "email", "profile"]).join(" "),
     state,
     identity_provider: provider,
+    ...oauthParams,
   };
   if (responseType === "code") {
     query.code_challenge = challenge;

--- a/client/react/hooks.tsx
+++ b/client/react/hooks.tsx
@@ -1771,9 +1771,11 @@ function _usePasswordless() {
     signInWithRedirect: ({
       provider = "Google",
       customState,
+      oauthParams,
     }: {
       provider?: string;
       customState?: string;
+      oauthParams?: Record<string, string>;
     } = {}) => {
       const { debug } = configure();
       debug?.("Starting sign-in via Hosted UI redirect");
@@ -1783,7 +1785,7 @@ function _usePasswordless() {
         type: "SET_SIGNING_STATUS",
         payload: "STARTING_SIGN_IN_WITH_REDIRECT",
       });
-      hostedSignInWithRedirect({ provider, customState }).catch(
+      hostedSignInWithRedirect({ provider, customState, oauthParams }).catch(
         (err: unknown) => {
           debug?.("Failed to initiate redirect sign-in:", err);
           dispatch({


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


This will allow us to pass custom params into the oAuth client. This _should_ let us prompt google for the account selection step.