### PR TITLE
Prevent multiple OAuth callback processing

### DIFF
--- a/client/react/hooks.tsx
+++ b/client/react/hooks.tsx
@@ -750,6 +750,13 @@ function _usePasswordless() {
       );
 
       if (urlParams.has("code") || hashParams.has("access_token")) {
+        // Prevent multiple simultaneous OAuth callback processing
+        if (oauthProcessingRef.current) {
+          debug?.("OAuth callback already being processed, skipping...");
+          return;
+        }
+        oauthProcessingRef.current = true;
+
         debug?.("OAuth callback detected, processing...");
         try {
           setSigninInStatus("STARTING_SIGN_IN_WITH_REDIRECT");
@@ -1016,6 +1023,9 @@ function _usePasswordless() {
   // Track last fetch time to prevent spam
   const lastMfaFetchTimeRef = useRef<number>(0);
   const MFA_FETCH_COOLDOWN = 5000; // 5 second cooldown between fetches
+
+  // Track OAuth callback processing to prevent multiple executions
+  const oauthProcessingRef = useRef(false);
 
   // Fetch TOTP MFA status when the user is signed in – with rate limiting
   useEffect(() => {


### PR DESCRIPTION
### TL;DR

Added protection against multiple simultaneous OAuth callback processing in the passwordless authentication hook.

### What changed?

- Added a new `oauthProcessingRef` to track when an OAuth callback is being processed
- Added a check at the beginning of the OAuth callback processing to prevent multiple simultaneous executions
- Set the processing flag to `true` when starting to handle an OAuth callback

### How to test?

1. Initiate an OAuth sign-in flow
2. When redirected back with the OAuth callback, verify that only one processing attempt occurs
3. Check the debug logs to confirm that any duplicate processing attempts are skipped with the message "OAuth callback already being processed, skipping..."

### Why make this change?

This change prevents race conditions that could occur when multiple OAuth callback processing attempts happen simultaneously. This can happen in certain browser conditions or when the callback processing is triggered multiple times. By tracking the processing state, we ensure the authentication flow completes cleanly without duplicate attempts that could cause unexpected behavior.