### PR TITLE
Add typed error handling for WebAuthn operations

### DIFF
--- a/ERROR_HANDLING.md
+++ b/ERROR_HANDLING.md
@@ -1,0 +1,360 @@
+# Error Handling Guide
+
+## Custom Error Classes
+
+The library now provides typed error classes for better error handling in your application.
+
+### Error Hierarchy
+
+```typescript
+Fido2Error (base class)
+├── Fido2AbortError          - Operation cancelled by user or application
+├── Fido2CredentialError     - Credential operations failed
+├── Fido2ConfigError         - Configuration missing or invalid
+├── Fido2ValidationError     - Validation of data failed
+├── Fido2AuthError          - Authentication/authorization failed
+└── Fido2NetworkError       - Server/network requests failed
+```
+
+## Usage Examples
+
+### Basic Error Handling
+
+```typescript
+import {
+  authenticateWithFido2,
+  Fido2AbortError,
+  Fido2CredentialError,
+  Fido2ConfigError,
+  isFido2AbortError,
+} from "@joinmeow/cognito-passwordless-auth";
+
+try {
+  const { signedIn } = authenticateWithFido2({ username: "user@example.com" });
+  const tokens = await signedIn;
+
+  // Success!
+  console.log("Signed in:", tokens);
+} catch (error) {
+  if (error instanceof Fido2AbortError) {
+    // User cancelled the passkey prompt - don't show error
+    console.log("User cancelled authentication");
+    return;
+  }
+
+  if (error instanceof Fido2CredentialError) {
+    // No passkey found or credential error
+    setError("No passkey found. Please use password or register a passkey.");
+    return;
+  }
+
+  if (error instanceof Fido2ConfigError) {
+    // Developer error - WebAuthn not configured
+    console.error("WebAuthn not configured properly", error);
+    setError("Authentication unavailable. Please contact support.");
+    return;
+  }
+
+  // Note: DOMExceptions are automatically converted to Fido2Error subclasses
+  // by the library, so you don't need to handle them separately!
+
+  // Unknown error
+  console.error("Unexpected error:", error);
+  setError("Something went wrong. Please try again.");
+}
+```
+
+### Using Type Guards
+
+```typescript
+import {
+  isFido2Error,
+  isFido2AbortError,
+} from "@joinmeow/cognito-passwordless-auth";
+
+try {
+  await fido2CreateCredential({ friendlyName: "My Device" });
+} catch (error) {
+  if (isFido2AbortError(error)) {
+    // User cancelled
+    return;
+  }
+
+  if (isFido2Error(error)) {
+    // Any Fido2Error subclass
+    console.error(`Error ${error.code}:`, error.message);
+
+    // Access error-specific properties
+    if (error instanceof Fido2ValidationError) {
+      console.log("Invalid value:", error.invalidValue);
+    }
+  }
+}
+```
+
+### React Hook Example
+
+```typescript
+import { useState } from "react";
+import {
+  authenticateWithFido2,
+  Fido2AbortError,
+  Fido2CredentialError,
+  isFido2Error,
+} from "@joinmeow/cognito-passwordless-auth";
+
+function usePasskeyAuth() {
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const signIn = async (username: string, signal?: AbortSignal) => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const { signedIn } = authenticateWithFido2({
+        username,
+        credentialGetter: (options) =>
+          fido2getCredential({ ...options, signal }),
+      });
+
+      const tokens = await signedIn;
+      return tokens;
+    } catch (err) {
+      // User cancelled - don't show error
+      if (err instanceof Fido2AbortError) {
+        return null;
+      }
+
+      // No passkey found
+      if (err instanceof Fido2CredentialError) {
+        setError("No passkey found for this account");
+        return null;
+      }
+
+      // Generic Fido2 error
+      if (isFido2Error(err)) {
+        setError(err.message);
+        return null;
+      }
+
+      // Unknown error
+      setError("Authentication failed");
+      return null;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return { signIn, loading, error };
+}
+```
+
+### Component Cleanup Example
+
+```typescript
+import { useEffect, useRef } from 'react';
+import {
+  fido2getCredential,
+  Fido2AbortError
+} from '@joinmeow/cognito-passwordless-auth';
+
+function PasskeyDialog({ onClose }) {
+  const abortControllerRef = useRef<AbortController>();
+
+  useEffect(() => {
+    const abortController = new AbortController();
+    abortControllerRef.current = abortController;
+
+    const authenticate = async () => {
+      try {
+        const credential = await fido2getCredential({
+          challenge: 'base64-challenge',
+          signal: abortController.signal  // ← Pass signal
+        });
+
+        handleSuccess(credential);
+
+      } catch (error) {
+        // Component unmounted - ignore abort error
+        if (error instanceof Fido2AbortError) {
+          return;
+        }
+
+        handleError(error);
+      }
+    };
+
+    authenticate();
+
+    // Cleanup: abort on unmount
+    return () => {
+      abortController.abort();
+    };
+  }, []);
+
+  return <div>Authenticating...</div>;
+}
+```
+
+## Error Properties
+
+### Fido2Error (base)
+
+- `message: string` - Human-readable error message
+- `code: string` - Machine-readable error code
+- `cause?: unknown` - Original error that caused this error
+- `name: string` - Error class name
+- `stack?: string` - Stack trace
+
+### Fido2ValidationError
+
+- `invalidValue?: unknown` - The value that failed validation
+
+### Fido2NetworkError
+
+- `statusCode?: number` - HTTP status code
+- `response?: unknown` - Server response body
+
+## Error Codes
+
+| Code                     | Error Class          | Meaning                             |
+| ------------------------ | -------------------- | ----------------------------------- |
+| `WEBAUTHN_ABORTED`       | Fido2AbortError      | User cancelled or operation aborted |
+| `CREDENTIAL_ERROR`       | Fido2CredentialError | Credential operation failed         |
+| `CONFIG_ERROR`           | Fido2ConfigError     | Missing or invalid configuration    |
+| `VALIDATION_ERROR`       | Fido2ValidationError | Data validation failed              |
+| `AUTH_ERROR`             | Fido2AuthError       | Authentication/authorization failed |
+| `NETWORK_ERROR`          | Fido2NetworkError    | Server/network request failed       |
+| `WEBAUTHN_UNKNOWN_ERROR` | Fido2Error           | Client-specific unknown error       |
+| `WEBAUTHN_ERROR`         | Fido2Error           | Generic WebAuthn error              |
+
+## Browser DOMException Errors (WebAuthn Level 2 Spec)
+
+The library automatically converts WebAuthn DOMExceptions to appropriate Fido2Error subclasses. This covers all errors defined in the **WebAuthn Level 2** specification.
+
+### navigator.credentials.create() Errors
+
+| DOMException        | Converted To         | When It Occurs                                                                   |
+| ------------------- | -------------------- | -------------------------------------------------------------------------------- |
+| `AbortError`        | Fido2AbortError      | Operation cancelled via AbortController or timeout                               |
+| `NotAllowedError`   | Fido2CredentialError | User cancelled ceremony, no user gesture, or permission denied                   |
+| `InvalidStateError` | Fido2CredentialError | Authenticator recognized entry in excludeCredentials after user consent          |
+| `NotSupportedError` | Fido2ConfigError     | No pubKeyCredParams had type="public-key", or algorithms not supported           |
+| `SecurityError`     | Fido2ConfigError     | Invalid domain, rp.id not valid, or related origins validation failed            |
+| `ConstraintError`   | Fido2ValidationError | residentKey=required but not supported, or userVerification=required unavailable |
+| `UnknownError`      | Fido2Error           | Client-specific error that doesn't fit other categories                          |
+
+### navigator.credentials.get() Errors
+
+| DOMException        | Converted To         | When It Occurs                                                 |
+| ------------------- | -------------------- | -------------------------------------------------------------- |
+| `AbortError`        | Fido2AbortError      | Operation cancelled via AbortController or timeout             |
+| `NotAllowedError`   | Fido2CredentialError | User cancelled ceremony, no user gesture, or permission denied |
+| `InvalidStateError` | Fido2CredentialError | Authenticator is in invalid state                              |
+| `SecurityError`     | Fido2ConfigError     | Invalid domain or HTTPS required                               |
+| `UnknownError`      | Fido2Error           | Client-specific error that doesn't fit other categories        |
+
+### Error Conversion Examples
+
+```typescript
+// Browser throws NotAllowedError
+// Library converts to Fido2CredentialError with cause
+
+try {
+  await fido2getCredential({ challenge });
+} catch (error) {
+  if (error instanceof Fido2CredentialError) {
+    console.log("Error code:", error.code); // "CREDENTIAL_ERROR"
+    console.log("Original DOMException:", error.cause); // NotAllowedError
+  }
+}
+```
+
+## Best Practices
+
+1. **Always handle Fido2AbortError silently** - Don't show errors when users cancel
+2. **Use type guards** - `instanceof` or `isFido2Error()` for type safety
+3. **Check error codes** - Use `error.code` for programmatic handling
+4. **Log unknown errors** - Send to error tracking service (Sentry, etc.)
+5. **Provide helpful messages** - Convert technical errors to user-friendly text
+6. **Pass AbortSignal** - Always pass abort signals for proper cleanup
+
+## Migration from Old Code
+
+**Before:**
+
+```typescript
+try {
+  await fido2getCredential({ challenge });
+} catch (err) {
+  // Can't tell what went wrong!
+  alert("Something failed");
+}
+```
+
+**After:**
+
+```typescript
+try {
+  await fido2getCredential({ challenge });
+} catch (err) {
+  if (err instanceof Fido2AbortError) return;
+
+  if (err instanceof Fido2CredentialError) {
+    alert("No passkey found");
+    return;
+  }
+
+  alert("Authentication failed");
+}
+```
+
+## WebAuthn Specification Compliance
+
+This error handling implementation is fully compliant with the **[WebAuthn Level 2 specification](https://www.w3.org/TR/webauthn-2/)** published by W3C on April 8, 2021.
+
+### Specification Coverage
+
+**All DOMException errors from the spec are handled:**
+
+✅ **navigator.credentials.create()** - 7 error types
+
+- AbortError, ConstraintError, InvalidStateError, NotSupportedError, SecurityError, NotAllowedError, UnknownError
+
+✅ **navigator.credentials.get()** - 5 error types
+
+- AbortError, InvalidStateError, SecurityError, NotAllowedError, UnknownError
+
+✅ **Simple exceptions** (not caught, propagate as-is)
+
+- TypeError for invalid options
+
+### Error Mapping Strategy
+
+The library uses a **defensive error handling** approach:
+
+1. **Wrap WebAuthn API calls** in try-catch blocks
+2. **Detect DOMException** instances thrown by browser
+3. **Convert to typed errors** using `fromDOMException()` helper
+4. **Preserve original error** in the `cause` property for debugging
+5. **Provide user-friendly messages** while maintaining technical accuracy
+
+### Why This Matters
+
+**Type Safety**: Your TypeScript code can use `instanceof` checks for precise error handling
+
+**Debuggability**: Original browser errors preserved in `cause` property
+
+**User Experience**: Translate technical WebAuthn errors into helpful user messages
+
+**Future Proof**: As browsers update WebAuthn implementations, error handling remains consistent
+
+**Cross-Browser**: Same error handling works across Chrome, Safari, Firefox, and Edge
+
+### References
+
+- [WebAuthn Level 2 Specification](https://www.w3.org/TR/webauthn-2/)
+- [WebAuthn Level 3 (Draft)](https://www.w3.org/TR/webauthn-3/)
+- [FIDO Alliance](https://fidoalliance.org/)
+- [MDN Web Authentication API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Authentication_API)

--- a/client/__tests__/errors.test.ts
+++ b/client/__tests__/errors.test.ts
@@ -1,0 +1,308 @@
+/**
+ * Copyright Amazon.com, Inc. and its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You
+ * may not use this file except in compliance with the License. A copy of
+ * the License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+import {
+  Fido2Error,
+  Fido2AbortError,
+  Fido2CredentialError,
+  Fido2ConfigError,
+  Fido2ValidationError,
+  Fido2AuthError,
+  Fido2NetworkError,
+  isFido2Error,
+  isFido2AbortError,
+  fromDOMException,
+} from "../errors.js";
+
+describe("Fido2Error classes", () => {
+  describe("Fido2Error (base class)", () => {
+    it("should create error with message, code, and optional cause", () => {
+      const cause = new Error("original error");
+      const error = new Fido2Error("Test error", "TEST_CODE", cause);
+
+      expect(error.message).toBe("Test error");
+      expect(error.code).toBe("TEST_CODE");
+      expect(error.cause).toBe(cause);
+      expect(error.name).toBe("Fido2Error");
+      expect(error).toBeInstanceOf(Error);
+    });
+
+    it("should work without cause", () => {
+      const error = new Fido2Error("Test error", "TEST_CODE");
+
+      expect(error.message).toBe("Test error");
+      expect(error.code).toBe("TEST_CODE");
+      expect(error.cause).toBeUndefined();
+    });
+
+    it("should have stack trace", () => {
+      const error = new Fido2Error("Test error", "TEST_CODE");
+      expect(error.stack).toBeDefined();
+    });
+  });
+
+  describe("Fido2AbortError", () => {
+    it("should create abort error with default message", () => {
+      const error = new Fido2AbortError();
+
+      expect(error.message).toBe("WebAuthn operation was cancelled");
+      expect(error.code).toBe("WEBAUTHN_ABORTED");
+      expect(error.name).toBe("Fido2AbortError");
+      expect(error).toBeInstanceOf(Fido2Error);
+    });
+
+    it("should create abort error with custom message", () => {
+      const error = new Fido2AbortError("User cancelled");
+
+      expect(error.message).toBe("User cancelled");
+      expect(error.code).toBe("WEBAUTHN_ABORTED");
+    });
+  });
+
+  describe("Fido2CredentialError", () => {
+    it("should create credential error", () => {
+      const cause = new DOMException("Not allowed", "NotAllowedError");
+      const error = new Fido2CredentialError("No credential found", cause);
+
+      expect(error.message).toBe("No credential found");
+      expect(error.code).toBe("CREDENTIAL_ERROR");
+      expect(error.name).toBe("Fido2CredentialError");
+      expect(error.cause).toBe(cause);
+    });
+  });
+
+  describe("Fido2ConfigError", () => {
+    it("should create config error", () => {
+      const error = new Fido2ConfigError("Missing configuration");
+
+      expect(error.message).toBe("Missing configuration");
+      expect(error.code).toBe("CONFIG_ERROR");
+      expect(error.name).toBe("Fido2ConfigError");
+    });
+  });
+
+  describe("Fido2ValidationError", () => {
+    it("should create validation error with invalid value", () => {
+      const invalidValue = { foo: "bar" };
+      const error = new Fido2ValidationError("Invalid options", invalidValue);
+
+      expect(error.message).toBe("Invalid options");
+      expect(error.code).toBe("VALIDATION_ERROR");
+      expect(error.name).toBe("Fido2ValidationError");
+      expect(error.invalidValue).toBe(invalidValue);
+    });
+
+    it("should work without invalidValue", () => {
+      const error = new Fido2ValidationError("Invalid options");
+      expect(error.invalidValue).toBeUndefined();
+    });
+  });
+
+  describe("Fido2AuthError", () => {
+    it("should create auth error", () => {
+      const error = new Fido2AuthError("No token available");
+
+      expect(error.message).toBe("No token available");
+      expect(error.code).toBe("AUTH_ERROR");
+      expect(error.name).toBe("Fido2AuthError");
+    });
+  });
+
+  describe("Fido2NetworkError", () => {
+    it("should create network error with status code and response", () => {
+      const response = { error: "Not found" };
+      const error = new Fido2NetworkError("Request failed", 404, response);
+
+      expect(error.message).toBe("Request failed");
+      expect(error.code).toBe("NETWORK_ERROR");
+      expect(error.name).toBe("Fido2NetworkError");
+      expect(error.statusCode).toBe(404);
+      expect(error.response).toBe(response);
+    });
+
+    it("should work without status code and response", () => {
+      const error = new Fido2NetworkError("Network timeout");
+
+      expect(error.statusCode).toBeUndefined();
+      expect(error.response).toBeUndefined();
+    });
+  });
+});
+
+describe("Type guards", () => {
+  describe("isFido2Error", () => {
+    it("should return true for Fido2Error instances", () => {
+      expect(isFido2Error(new Fido2Error("test", "TEST"))).toBe(true);
+      expect(isFido2Error(new Fido2AbortError())).toBe(true);
+      expect(isFido2Error(new Fido2CredentialError("test"))).toBe(true);
+      expect(isFido2Error(new Fido2ConfigError("test"))).toBe(true);
+      expect(isFido2Error(new Fido2ValidationError("test"))).toBe(true);
+      expect(isFido2Error(new Fido2AuthError("test"))).toBe(true);
+      expect(isFido2Error(new Fido2NetworkError("test"))).toBe(true);
+    });
+
+    it("should return false for non-Fido2Error instances", () => {
+      expect(isFido2Error(new Error("test"))).toBe(false);
+      expect(isFido2Error(new DOMException("test"))).toBe(false);
+      expect(isFido2Error("test")).toBe(false);
+      expect(isFido2Error(null)).toBe(false);
+      expect(isFido2Error(undefined)).toBe(false);
+      expect(isFido2Error({})).toBe(false);
+    });
+  });
+
+  describe("isFido2AbortError", () => {
+    it("should return true for Fido2AbortError instances", () => {
+      expect(isFido2AbortError(new Fido2AbortError())).toBe(true);
+    });
+
+    it("should return false for other error types", () => {
+      expect(isFido2AbortError(new Fido2Error("test", "TEST"))).toBe(false);
+      expect(isFido2AbortError(new Fido2CredentialError("test"))).toBe(false);
+      expect(isFido2AbortError(new Error("test"))).toBe(false);
+      expect(isFido2AbortError(null)).toBe(false);
+    });
+  });
+});
+
+describe("fromDOMException", () => {
+  describe("WebAuthn Level 2 specification compliance", () => {
+    it("should convert AbortError to Fido2AbortError", () => {
+      const domError = new DOMException("User cancelled", "AbortError");
+      const error = fromDOMException(domError);
+
+      expect(error).toBeInstanceOf(Fido2AbortError);
+      expect(error.message).toBe("WebAuthn operation was aborted");
+      expect(error.code).toBe("WEBAUTHN_ABORTED");
+    });
+
+    it("should convert NotAllowedError to Fido2CredentialError", () => {
+      const domError = new DOMException("Not allowed", "NotAllowedError");
+      const error = fromDOMException(domError);
+
+      expect(error).toBeInstanceOf(Fido2CredentialError);
+      expect(error.message).toContain("not allowed");
+      expect(error.code).toBe("CREDENTIAL_ERROR");
+      expect(error.cause).toBe(domError);
+    });
+
+    it("should convert InvalidStateError to Fido2CredentialError", () => {
+      const domError = new DOMException("Invalid state", "InvalidStateError");
+      const error = fromDOMException(domError);
+
+      expect(error).toBeInstanceOf(Fido2CredentialError);
+      expect(error.message).toContain("invalid state");
+      expect(error.code).toBe("CREDENTIAL_ERROR");
+      expect(error.cause).toBe(domError);
+    });
+
+    it("should convert NotSupportedError to Fido2ConfigError", () => {
+      const domError = new DOMException("Not supported", "NotSupportedError");
+      const error = fromDOMException(domError);
+
+      expect(error).toBeInstanceOf(Fido2ConfigError);
+      expect(error.message).toContain("not supported");
+      expect(error.code).toBe("CONFIG_ERROR");
+    });
+
+    it("should convert SecurityError to Fido2ConfigError", () => {
+      const domError = new DOMException("Security error", "SecurityError");
+      const error = fromDOMException(domError);
+
+      expect(error).toBeInstanceOf(Fido2ConfigError);
+      expect(error.message).toContain("Security requirements");
+      expect(error.code).toBe("CONFIG_ERROR");
+    });
+
+    it("should convert ConstraintError to Fido2ValidationError", () => {
+      const domError = new DOMException("Constraint failed", "ConstraintError");
+      const error = fromDOMException(domError);
+
+      expect(error).toBeInstanceOf(Fido2ValidationError);
+      expect(error.message).toContain("constraints not satisfied");
+      expect(error.code).toBe("VALIDATION_ERROR");
+      expect((error as Fido2ValidationError).invalidValue).toBe(domError);
+    });
+
+    it("should convert UnknownError to Fido2Error", () => {
+      const domError = new DOMException("Unknown error", "UnknownError");
+      const error = fromDOMException(domError);
+
+      expect(error).toBeInstanceOf(Fido2Error);
+      expect(error.message).toBe("Unknown WebAuthn error occurred");
+      expect(error.code).toBe("WEBAUTHN_UNKNOWN_ERROR");
+      expect(error.cause).toBe(domError);
+    });
+
+    it("should convert unknown DOMException to generic Fido2Error", () => {
+      const domError = new DOMException("Random error", "RandomError");
+      const error = fromDOMException(domError);
+
+      expect(error).toBeInstanceOf(Fido2Error);
+      expect(error.message).toContain("WebAuthn operation failed");
+      expect(error.message).toContain("Random error");
+      expect(error.code).toBe("WEBAUTHN_ERROR");
+      expect(error.cause).toBe(domError);
+    });
+  });
+
+  describe("Error preservation", () => {
+    it("should preserve original error in cause property", () => {
+      const domError = new DOMException("Test message", "NotAllowedError");
+      const error = fromDOMException(domError);
+
+      expect(error.cause).toBe(domError);
+      expect((error.cause as DOMException).name).toBe("NotAllowedError");
+      expect((error.cause as DOMException).message).toBe("Test message");
+    });
+
+    it("should not preserve cause for AbortError (no cause parameter)", () => {
+      const domError = new DOMException("Aborted", "AbortError");
+      const error = fromDOMException(domError);
+
+      expect(error.cause).toBeUndefined();
+    });
+  });
+});
+
+describe("Error inheritance chain", () => {
+  it("should maintain proper instanceof relationships", () => {
+    const abortError = new Fido2AbortError();
+
+    expect(abortError instanceof Fido2AbortError).toBe(true);
+    expect(abortError instanceof Fido2Error).toBe(true);
+    expect(abortError instanceof Error).toBe(true);
+  });
+
+  it("should allow catching by base class", () => {
+    const errors = [
+      new Fido2AbortError(),
+      new Fido2CredentialError("test"),
+      new Fido2ConfigError("test"),
+      new Fido2ValidationError("test"),
+      new Fido2AuthError("test"),
+      new Fido2NetworkError("test"),
+    ];
+
+    errors.forEach((error) => {
+      try {
+        throw error;
+      } catch (e) {
+        expect(e).toBeInstanceOf(Fido2Error);
+        expect(e).toBeInstanceOf(Error);
+      }
+    });
+  });
+});

--- a/client/__tests__/fido2-errors.test.ts
+++ b/client/__tests__/fido2-errors.test.ts
@@ -1,0 +1,424 @@
+/**
+ * Copyright Amazon.com, Inc. and its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You
+ * may not use this file except in compliance with the License. A copy of
+ * the License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+import {
+  fido2CreateCredential,
+  fido2getCredential,
+  fido2StartCreateCredential,
+  fido2ListCredentials,
+  fido2DeleteCredential,
+  fido2UpdateCredential,
+} from "../fido2.js";
+import {
+  Fido2AbortError,
+  Fido2CredentialError,
+  Fido2ConfigError,
+  Fido2AuthError,
+} from "../errors.js";
+import type { ConfigWithDefaults } from "../config.js";
+import { configure } from "../config.js";
+import type { TokensFromStorage } from "../storage.js";
+import { retrieveTokens } from "../storage.js";
+
+// Mock dependencies
+jest.mock("../config");
+jest.mock("../storage");
+
+const mockConfigure = configure as jest.MockedFunction<typeof configure>;
+const mockRetrieveTokens = retrieveTokens as jest.MockedFunction<
+  typeof retrieveTokens
+>;
+
+// Helper to create a mock config
+const createMockConfig = (
+  overrides: Partial<ConfigWithDefaults> = {}
+): ConfigWithDefaults => ({
+  cognitoIdpEndpoint: "https://cognito-idp.us-east-1.amazonaws.com",
+  clientId: "test-client-id",
+  storage: {
+    getItem: jest.fn(),
+    setItem: jest.fn(),
+    removeItem: jest.fn(),
+  },
+  crypto: {
+    getRandomValues: jest.fn() as unknown as Crypto["getRandomValues"],
+    subtle: {
+      digest: jest.fn(),
+      importKey: jest.fn(),
+      sign: jest.fn(),
+    } as unknown as SubtleCrypto,
+  },
+  fetch: jest.fn(),
+  location: { hostname: "localhost", href: "http://localhost" },
+  history: { pushState: jest.fn() },
+  ...overrides,
+});
+
+describe("fido2.ts error handling", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("Configuration errors", () => {
+    it("should throw Fido2ConfigError when fido2 config is missing", async () => {
+      mockConfigure.mockReturnValue(
+        createMockConfig({
+          fido2: undefined,
+        })
+      );
+
+      await expect(fido2StartCreateCredential()).rejects.toThrow(
+        Fido2ConfigError
+      );
+      await expect(fido2StartCreateCredential()).rejects.toThrow(
+        "Fido2 configuration not initialized"
+      );
+    });
+
+    it("should throw Fido2ConfigError for list credentials without config", async () => {
+      mockConfigure.mockReturnValue(
+        createMockConfig({
+          fido2: undefined,
+        })
+      );
+
+      await expect(fido2ListCredentials()).rejects.toThrow(Fido2ConfigError);
+    });
+
+    it("should throw Fido2ConfigError for delete credential without config", async () => {
+      mockConfigure.mockReturnValue(
+        createMockConfig({
+          fido2: undefined,
+        })
+      );
+
+      await expect(
+        fido2DeleteCredential({ credentialId: "test" })
+      ).rejects.toThrow(Fido2ConfigError);
+    });
+
+    it("should throw Fido2ConfigError for update credential without config", async () => {
+      mockConfigure.mockReturnValue(
+        createMockConfig({
+          fido2: undefined,
+        })
+      );
+
+      await expect(
+        fido2UpdateCredential({ credentialId: "test", friendlyName: "Test" })
+      ).rejects.toThrow(Fido2ConfigError);
+    });
+  });
+
+  describe("Authentication errors", () => {
+    beforeEach(() => {
+      mockConfigure.mockReturnValue(
+        createMockConfig({
+          fido2: { baseUrl: "https://example.com" },
+        })
+      );
+    });
+
+    it("should throw Fido2AuthError when no token available for start create", async () => {
+      mockRetrieveTokens.mockResolvedValue(undefined);
+
+      await expect(fido2StartCreateCredential()).rejects.toThrow(
+        Fido2AuthError
+      );
+      await expect(fido2StartCreateCredential()).rejects.toThrow(
+        "No authentication token available"
+      );
+    });
+
+    it("should throw Fido2AuthError when no token available for list", async () => {
+      mockRetrieveTokens.mockResolvedValue(undefined);
+
+      await expect(fido2ListCredentials()).rejects.toThrow(Fido2AuthError);
+    });
+
+    it("should throw Fido2AuthError when no token available for delete", async () => {
+      mockRetrieveTokens.mockResolvedValue(undefined);
+
+      await expect(
+        fido2DeleteCredential({ credentialId: "test" })
+      ).rejects.toThrow(Fido2AuthError);
+    });
+
+    it("should throw Fido2AuthError when no token available for update", async () => {
+      mockRetrieveTokens.mockResolvedValue(undefined);
+
+      await expect(
+        fido2UpdateCredential({ credentialId: "test", friendlyName: "Test" })
+      ).rejects.toThrow(Fido2AuthError);
+    });
+
+    it("should throw Fido2AuthError when tokens object exists but idToken is missing", async () => {
+      mockRetrieveTokens.mockResolvedValue({
+        username: "testuser",
+        accessToken: "token",
+      } as Partial<TokensFromStorage> as TokensFromStorage);
+
+      await expect(fido2ListCredentials()).rejects.toThrow(Fido2AuthError);
+    });
+  });
+
+  describe("WebAuthn API error conversion", () => {
+    beforeEach(() => {
+      mockConfigure.mockReturnValue(
+        createMockConfig({
+          fido2: { baseUrl: "https://example.com" },
+          debug: jest.fn(),
+        })
+      );
+    });
+
+    describe("fido2CreateCredential", () => {
+      it("should convert DOMException AbortError to Fido2AbortError", async () => {
+        mockRetrieveTokens.mockResolvedValue({
+          username: "testuser",
+          idToken: "test-token",
+        } as Partial<TokensFromStorage> as TokensFromStorage);
+
+        const mockFetch = jest.fn().mockResolvedValue({
+          ok: true,
+          json: async () => ({
+            challenge: "test-challenge",
+            rp: { name: "Test RP" },
+            user: { id: "user-123", name: "test", displayName: "Test User" },
+            pubKeyCredParams: [{ type: "public-key", alg: -7 }],
+            timeout: 60000,
+            excludeCredentials: [],
+            authenticatorSelection: { userVerification: "preferred" },
+          }),
+        });
+
+        mockConfigure.mockReturnValue(
+          createMockConfig({
+            fido2: { baseUrl: "https://example.com" },
+            fetch: mockFetch,
+            debug: jest.fn(),
+          })
+        );
+
+        // Mock navigator.credentials.create to throw AbortError
+        const mockCreate = jest
+          .fn()
+          .mockRejectedValue(new DOMException("Aborted", "AbortError"));
+        Object.defineProperty(global.navigator, "credentials", {
+          value: { create: mockCreate },
+          configurable: true,
+        });
+
+        await expect(
+          fido2CreateCredential({ friendlyName: "Test" })
+        ).rejects.toThrow(Fido2AbortError);
+      });
+
+      it("should convert DOMException NotAllowedError to Fido2CredentialError", async () => {
+        mockRetrieveTokens.mockResolvedValue({
+          username: "testuser",
+          idToken: "test-token",
+        } as Partial<TokensFromStorage> as TokensFromStorage);
+
+        const mockFetch = jest.fn().mockResolvedValue({
+          ok: true,
+          json: async () => ({
+            challenge: "test-challenge",
+            rp: { name: "Test RP" },
+            user: { id: "user-123", name: "test", displayName: "Test User" },
+            pubKeyCredParams: [{ type: "public-key", alg: -7 }],
+            timeout: 60000,
+            excludeCredentials: [],
+            authenticatorSelection: { userVerification: "preferred" },
+          }),
+        });
+
+        mockConfigure.mockReturnValue(
+          createMockConfig({
+            fido2: { baseUrl: "https://example.com" },
+            fetch: mockFetch,
+            debug: jest.fn(),
+          })
+        );
+
+        const mockCreate = jest
+          .fn()
+          .mockRejectedValue(
+            new DOMException("User denied", "NotAllowedError")
+          );
+        Object.defineProperty(global.navigator, "credentials", {
+          value: { create: mockCreate },
+          configurable: true,
+        });
+
+        await expect(
+          fido2CreateCredential({ friendlyName: "Test" })
+        ).rejects.toThrow(Fido2CredentialError);
+      });
+
+      it("should throw Fido2CredentialError when no credential returned", async () => {
+        mockRetrieveTokens.mockResolvedValue({
+          username: "testuser",
+          idToken: "test-token",
+        } as Partial<TokensFromStorage> as TokensFromStorage);
+
+        const mockFetch = jest.fn().mockResolvedValue({
+          ok: true,
+          json: async () => ({
+            challenge: "test-challenge",
+            rp: { name: "Test RP" },
+            user: { id: "user-123", name: "test", displayName: "Test User" },
+            pubKeyCredParams: [{ type: "public-key", alg: -7 }],
+            timeout: 60000,
+            excludeCredentials: [],
+            authenticatorSelection: { userVerification: "preferred" },
+          }),
+        });
+
+        mockConfigure.mockReturnValue(
+          createMockConfig({
+            fido2: { baseUrl: "https://example.com" },
+            fetch: mockFetch,
+            debug: jest.fn(),
+          })
+        );
+
+        const mockCreate = jest.fn().mockResolvedValue(null);
+        Object.defineProperty(global.navigator, "credentials", {
+          value: { create: mockCreate },
+          configurable: true,
+        });
+
+        await expect(
+          fido2CreateCredential({ friendlyName: "Test" })
+        ).rejects.toThrow(Fido2CredentialError);
+        await expect(
+          fido2CreateCredential({ friendlyName: "Test" })
+        ).rejects.toThrow("No credential returned from browser");
+      });
+    });
+
+    describe("fido2getCredential", () => {
+      it("should convert DOMException AbortError to Fido2AbortError", async () => {
+        const mockGet = jest
+          .fn()
+          .mockRejectedValue(new DOMException("Aborted", "AbortError"));
+        Object.defineProperty(global.navigator, "credentials", {
+          value: { get: mockGet },
+          configurable: true,
+        });
+
+        await expect(
+          fido2getCredential({
+            challenge: "test-challenge",
+            relyingPartyId: "example.com",
+          })
+        ).rejects.toThrow(Fido2AbortError);
+      });
+
+      it("should convert DOMException SecurityError to Fido2ConfigError", async () => {
+        const mockGet = jest
+          .fn()
+          .mockRejectedValue(
+            new DOMException("Invalid domain", "SecurityError")
+          );
+        Object.defineProperty(global.navigator, "credentials", {
+          value: { get: mockGet },
+          configurable: true,
+        });
+
+        await expect(
+          fido2getCredential({
+            challenge: "test-challenge",
+            relyingPartyId: "example.com",
+          })
+        ).rejects.toThrow(Fido2ConfigError);
+      });
+
+      it("should throw Fido2CredentialError when no credential returned", async () => {
+        const mockGet = jest.fn().mockResolvedValue(null);
+        Object.defineProperty(global.navigator, "credentials", {
+          value: { get: mockGet },
+          configurable: true,
+        });
+
+        await expect(
+          fido2getCredential({
+            challenge: "test-challenge",
+            relyingPartyId: "example.com",
+          })
+        ).rejects.toThrow(Fido2CredentialError);
+      });
+
+      it("should pass AbortSignal to navigator.credentials.get", async () => {
+        const abortController = new AbortController();
+        const mockGet = jest
+          .fn()
+          .mockRejectedValue(new DOMException("Aborted", "AbortError"));
+        Object.defineProperty(global.navigator, "credentials", {
+          value: { get: mockGet },
+          configurable: true,
+        });
+
+        await expect(
+          fido2getCredential({
+            challenge: "test-challenge",
+            relyingPartyId: "example.com",
+            signal: abortController.signal,
+          })
+        ).rejects.toThrow(Fido2AbortError);
+
+        expect(mockGet).toHaveBeenCalledWith(
+          expect.objectContaining({
+            signal: abortController.signal,
+          })
+        );
+      });
+    });
+  });
+
+  describe("Error code verification", () => {
+    it("should use correct error codes", async () => {
+      mockConfigure.mockReturnValue(
+        createMockConfig({
+          fido2: undefined,
+        })
+      );
+
+      try {
+        await fido2StartCreateCredential();
+        fail("Should have thrown");
+      } catch (error) {
+        expect(error).toBeInstanceOf(Fido2ConfigError);
+        expect((error as Fido2ConfigError).code).toBe("CONFIG_ERROR");
+      }
+
+      mockConfigure.mockReturnValue(
+        createMockConfig({
+          fido2: { baseUrl: "https://example.com" },
+        })
+      );
+      mockRetrieveTokens.mockResolvedValue(undefined);
+
+      try {
+        await fido2StartCreateCredential();
+        fail("Should have thrown");
+      } catch (error) {
+        expect(error).toBeInstanceOf(Fido2AuthError);
+        expect((error as Fido2AuthError).code).toBe("AUTH_ERROR");
+      }
+    });
+  });
+});

--- a/client/errors.ts
+++ b/client/errors.ts
@@ -1,0 +1,208 @@
+/**
+ * Copyright Amazon.com, Inc. and its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You
+ * may not use this file except in compliance with the License. A copy of
+ * the License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+/**
+ * Base error class for all FIDO2/WebAuthn related errors
+ */
+export class Fido2Error extends Error {
+  constructor(
+    message: string,
+    public readonly code: string,
+    public readonly cause?: unknown
+  ) {
+    super(message);
+    this.name = "Fido2Error";
+
+    // Maintains proper stack trace for where our error was thrown (only available on V8)
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, this.constructor);
+    }
+  }
+}
+
+/**
+ * Thrown when WebAuthn operation is cancelled/aborted by user or application
+ *
+ * Example: User closes passkey dialog, component unmounts during authentication
+ */
+export class Fido2AbortError extends Fido2Error {
+  constructor(message = "WebAuthn operation was cancelled") {
+    super(message, "WEBAUTHN_ABORTED");
+    this.name = "Fido2AbortError";
+  }
+}
+
+/**
+ * Thrown when credential operations fail
+ *
+ * Examples:
+ * - No credential returned from browser
+ * - Invalid credential format
+ * - Credential not found
+ */
+export class Fido2CredentialError extends Fido2Error {
+  constructor(message: string, cause?: unknown) {
+    super(message, "CREDENTIAL_ERROR", cause);
+    this.name = "Fido2CredentialError";
+  }
+}
+
+/**
+ * Thrown when FIDO2 configuration is missing or invalid
+ *
+ * Examples:
+ * - Missing fido2 config in configure()
+ * - Invalid baseUrl or rpId
+ */
+export class Fido2ConfigError extends Fido2Error {
+  constructor(message: string) {
+    super(message, "CONFIG_ERROR");
+    this.name = "Fido2ConfigError";
+  }
+}
+
+/**
+ * Thrown when validation of FIDO2 options or responses fails
+ *
+ * Examples:
+ * - Invalid challenge format
+ * - Missing required fields in server response
+ * - Type mismatch in credential response
+ */
+export class Fido2ValidationError extends Fido2Error {
+  constructor(
+    message: string,
+    public readonly invalidValue?: unknown
+  ) {
+    super(message, "VALIDATION_ERROR");
+    this.name = "Fido2ValidationError";
+  }
+}
+
+/**
+ * Thrown when authentication/authorization fails
+ *
+ * Examples:
+ * - No JWT token available
+ * - Token expired
+ * - Insufficient permissions
+ */
+export class Fido2AuthError extends Fido2Error {
+  constructor(message: string) {
+    super(message, "AUTH_ERROR");
+    this.name = "Fido2AuthError";
+  }
+}
+
+/**
+ * Thrown when server/network requests fail
+ *
+ * Examples:
+ * - HTTP error responses
+ * - Network timeout
+ * - Server unreachable
+ */
+export class Fido2NetworkError extends Fido2Error {
+  constructor(
+    message: string,
+    public readonly statusCode?: number,
+    public readonly response?: unknown
+  ) {
+    super(message, "NETWORK_ERROR");
+    this.name = "Fido2NetworkError";
+  }
+}
+
+/**
+ * Type guard to check if error is a Fido2Error
+ */
+export function isFido2Error(error: unknown): error is Fido2Error {
+  return error instanceof Fido2Error;
+}
+
+/**
+ * Type guard to check if error is an abort error
+ */
+export function isFido2AbortError(error: unknown): error is Fido2AbortError {
+  return error instanceof Fido2AbortError;
+}
+
+/**
+ * Helper to convert DOMException (from WebAuthn API) to appropriate Fido2Error
+ *
+ * Based on WebAuthn Level 2 specification:
+ * - navigator.credentials.create() can throw: AbortError, ConstraintError,
+ *   InvalidStateError, NotSupportedError, SecurityError, NotAllowedError, UnknownError
+ * - navigator.credentials.get() can throw: AbortError, InvalidStateError,
+ *   SecurityError, NotAllowedError, UnknownError
+ */
+export function fromDOMException(error: DOMException): Fido2Error {
+  switch (error.name) {
+    case "AbortError":
+      // User cancelled via AbortController or timeout
+      return new Fido2AbortError("WebAuthn operation was aborted");
+
+    case "NotAllowedError":
+      // User cancelled the ceremony, or no user gesture, or permission denied
+      // This is a catch-all covering many scenarios
+      return new Fido2CredentialError(
+        "Operation not allowed (user cancelled, no gesture, or permission denied)",
+        error
+      );
+
+    case "InvalidStateError":
+      // For create(): Authenticator recognized entry in excludeCredentials after user consent
+      // For get(): Authenticator is in invalid state
+      return new Fido2CredentialError(
+        "Authenticator is in invalid state or credential already registered",
+        error
+      );
+
+    case "NotSupportedError":
+      // No pubKeyCredParams had type="public-key", or authenticator doesn't support algorithms
+      return new Fido2ConfigError(
+        "WebAuthn not supported or requested algorithms not available"
+      );
+
+    case "SecurityError":
+      // Invalid domain, rp.id not valid, or related origins validation failed
+      return new Fido2ConfigError(
+        "Security requirements not met (invalid domain, rp.id mismatch, or HTTPS required)"
+      );
+
+    case "ConstraintError":
+      // residentKey=required but not supported, or userVerification=required but unavailable
+      return new Fido2ValidationError(
+        "Authenticator constraints not satisfied (resident key or user verification required)",
+        error
+      );
+
+    case "UnknownError":
+      // Client-specific error that doesn't fit other categories
+      return new Fido2Error(
+        "Unknown WebAuthn error occurred",
+        "WEBAUTHN_UNKNOWN_ERROR",
+        error
+      );
+
+    default:
+      // Catch any other DOMExceptions not in spec
+      return new Fido2Error(
+        `WebAuthn operation failed: ${error.message}`,
+        "WEBAUTHN_ERROR",
+        error
+      );
+  }
+}

--- a/client/index.ts
+++ b/client/index.ts
@@ -37,6 +37,7 @@ export const Passwordless = {
 
 // Re-export everything from the other modules
 export * from "./common.js";
+export * from "./errors.js";
 export * from "./fido2.js";
 export * from "./model.js";
 export * from "./plaintext.js";


### PR DESCRIPTION
# Add Typed Error Handling for WebAuthn Operations

This PR introduces a comprehensive error handling system for WebAuthn/FIDO2 operations, making it easier to handle authentication failures in a type-safe way.

Key improvements:

- Added a hierarchy of typed error classes for different failure scenarios:
  - `Fido2Error` (base class)
  - `Fido2AbortError` for user cancellations
  - `Fido2CredentialError` for credential operation failures
  - `Fido2ConfigError` for configuration issues
  - `Fido2ValidationError` for data validation failures
  - `Fido2AuthError` for authentication failures
  - `Fido2NetworkError` for server/network issues

- Implemented automatic conversion of browser DOMExceptions to appropriate typed errors
- Added type guards (`isFido2Error`, `isFido2AbortError`) for TypeScript type narrowing
- Enhanced credential validation with structural type checks for better cross-browser compatibility
- Added support for AbortController signals in WebAuthn operations
- Created detailed documentation with usage examples in ERROR_HANDLING.md

This change allows developers to handle specific error cases more elegantly:

```typescript
try {
  await fido2getCredential({ challenge });
} catch (error) {
  if (error instanceof Fido2AbortError) {
    // User cancelled - don't show error
    return;
  }
  
  if (error instanceof Fido2CredentialError) {
    // No passkey found
    showMessage("No passkey found for this account");
    return;
  }
  
  // Handle other errors...
}
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a typed WebAuthn error hierarchy, DOMException-to-error conversion, AbortSignal support, and stricter validation across fido2 APIs, with docs and tests.
> 
> - **Core (fido2)**:
>   - Replace generic errors with typed `Fido2*` errors (`Fido2ConfigError`, `Fido2AuthError`, `Fido2CredentialError`, `Fido2ValidationError`).
>   - Convert browser `DOMException`s via `fromDOMException()`; add structural checks for WebAuthn responses.
>   - Add `AbortSignal` support to `fido2getCredential()` and propagate abort handling.
>   - Strengthen option validation (`assertIsFido2Options`) with descriptive validation errors.
> - **New Module**: `client/errors.ts` with error classes, type guards (`isFido2Error`, `isFido2AbortError`), and DOMException mapping.
> - **Exports**: re-export errors from `client/index.ts`.
> - **Docs**: add `ERROR_HANDLING.md` covering hierarchy, usage, codes, and browser error mapping.
> - **Tests**:
>   - `client/__tests__/errors.test.ts` for error classes, guards, and DOMException conversions.
>   - `client/__tests__/fido2-errors.test.ts` validating integration, config/auth failures, AbortError handling, and structural validation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8a9426ee1ab20340848d664d85e2f7a227aa21aa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->