### PR TITLE
Add WebAuthn conditional mediation and passkey autofill support

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -5,9 +5,9 @@
 To use the library, you need to first configure it:
 
 ```javascript
-import { Passwordless } from "@joinmeow/cognito-passwordless-auth/react";
+import { configure } from "@joinmeow/cognito-passwordless-auth";
 
-Passwordless.configure({
+configure({
   cognitoIdpEndpoint: "us-east-2", // you can also use the full endpoint URL, potentially to use a proxy
   clientId: "<client id>",
   // optional, only required if you want to use FIDO2:
@@ -41,7 +41,7 @@ Passwordless.configure({
     "<header 1>": "<value 1>",
     "<header 2>": "<value 2>",
   },
-  storage: localStorage, // Optional, default to localStorage
+  storage: localStorage, // Optional, defaults to localStorage
   // Whether to use the new GetTokensFromRefreshToken API
   useGetTokensFromRefreshToken: true, // Default is true
 });
@@ -139,7 +139,7 @@ import { timeAgo } from "@joinmeow/cognito-passwordless-auth/util";
 
 const now = timeAgo(Date.now(), new Date()); // Just now
 const seconds = timeAgo(Date.now(), new Date(Date.now() - 30 * 1000)); // 30 seconds ago
-const hours = timeAgo(Date.now(), newDate(Date.now() - 2 * 3600 * 1000)); // 2 hours ago
+const hours = timeAgo(Date.now(), new Date(Date.now() - 2 * 3600 * 1000)); // 2 hours ago
 ```
 
 ## Refresh Token Rotation

--- a/client/react/README.md
+++ b/client/react/README.md
@@ -119,6 +119,45 @@ sequenceDiagram
     H-->>C: signedIn Promise resolves
 ```
 
+#### Conditional mediation & passkey autofill
+
+```tsx
+import { useEffect } from "react";
+import { detectMediationCapabilities } from "@joinmeow/cognito-passwordless-auth";
+import { usePasswordless } from "@joinmeow/cognito-passwordless-auth/react";
+
+function AutofillSignInButton() {
+  const { authenticateWithFido2, fido2CreateCredential } = usePasswordless();
+
+  useEffect(() => {
+    (async () => {
+      const { conditional } = await detectMediationCapabilities();
+      if (!conditional) return;
+
+      // Automatically create a passkey after password login
+      await fido2CreateCredential({
+        friendlyName: "My Passkey",
+        conditionalCreate: true,
+      });
+
+      // Start conditional mediation on page load (autofill UI)
+      authenticateWithFido2({ mediation: "conditional" });
+    })();
+  }, [authenticateWithFido2, fido2CreateCredential]);
+
+  return (
+    <button onClick={() => authenticateWithFido2({ mediation: "immediate" })}>
+      Sign in with passkey
+    </button>
+  );
+}
+```
+
+`detectMediationCapabilities()` safely determines whether the browser supports
+conditional (autofill) or immediate (fast fail) mediation modes. Import
+`getClientCapabilities()` from the core package if you need the full WebAuthn
+capability matrix.
+
 ### 3.2 SRP Password
 
 ```mermaid


### PR DESCRIPTION
# Enhanced WebAuthn Support with Conditional Mediation and Passkey Autofill

This PR adds support for WebAuthn's conditional mediation and passkey autofill capabilities, making the authentication experience more seamless for users.

Key changes:
- Added `detectMediationCapabilities()` and `getClientCapabilities()` helpers to safely detect browser WebAuthn capabilities
- Enhanced `authenticateWithFido2()` with a new `mediation` parameter supporting "conditional", "immediate", and other WebAuthn mediation modes
- Added `conditionalCreate` option to `fido2CreateCredential()` for passkey autofill support
- Updated API examples to demonstrate the new WebAuthn features
- Renamed the main configuration function from `Passwordless.configure()` to `configure()` for better consistency
- Added explicit imports for `authenticateWithFido2` and `authenticateWithSRP` in examples

The PR includes documentation and examples showing how to implement passkey autofill, which allows users to sign in with a single tap when returning to your site.