### PR TITLE
Add comprehensive debug logging to FIDO2 authentication flows

### DIFF
--- a/client/fido2.ts
+++ b/client/fido2.ts
@@ -915,7 +915,7 @@ export async function prepareFido2SignIn({
 
   let resolvedUsername = username;
   let existingDeviceKey: string | undefined;
-  let session: string;
+  let session: string | undefined;
   let assertion: ParsedFido2Assertion;
 
   // ✅ Flow 1: Username provided - Use fast username-based passkey flow
@@ -986,7 +986,15 @@ export async function prepareFido2SignIn({
       userVerification:
         fido2.authenticatorSelection?.userVerification ??
         fido2options.userVerification,
-      credentials: credentials ?? fido2options.credentials,
+      // Merge server credentials with client-provided credentials (same as username flow)
+      credentials: (fido2options.credentials ?? []).concat(
+        credentials?.filter(
+          (cred) =>
+            !fido2options.credentials?.find(
+              (optionsCred) => cred.id === optionsCred.id
+            )
+        ) ?? []
+      ),
       mediation,
       signal,
     });


### PR DESCRIPTION
# Add comprehensive debug logging to FIDO2 authentication flow

Enhanced the FIDO2 authentication process with detailed debug logging to improve troubleshooting and visibility into the authentication flow. The changes include:

- Added debug logs at key points in the `fido2getCredential` function:
  - Initial function call with parameter details
  - Before calling `navigator.credentials.get()`
  - Success and error handling with detailed context

- Improved error logging for both DOMException and other errors during credential retrieval

- Added detailed logging in `prepareFido2SignIn`:
  - Initial function call with parameter details
  - Monitoring of abort signal events
  - Partial username masking for privacy

- Enhanced `authenticateWithFido2` with:
  - Entry point logging with parameter details
  - Abort signal monitoring
  - Logging when using prepared FIDO2 bundles

These logs will help diagnose authentication issues, especially in complex scenarios involving conditional mediation, timeouts, or aborted operations.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds detailed debug logging, abort monitoring, and docs across FIDO2 flows, plus minor validation tweaks and credential merging in the usernameless path.
> 
> - **FIDO2 WebAuthn**:
>   - `fido2getCredential`: Add granular debug logs (inputs, before/after `navigator.credentials.get`, success/error cases) and validated-credential log.
> - **Sign-in Preparation** (`prepareFido2SignIn`):
>   - Add entry logs with masked username; monitor abort signal.
>   - Distinguish username-based fast path vs. usernameless slow path in logs.
>   - Merge server-provided and client credentials; validate discovered username not empty; refine session error message.
> - **Authentication** (`authenticateWithFido2`):
>   - Add entry/debug logs, abort listener, and logging when using prepared bundles.
> - **Docs**:
>   - Expand JSDoc with usage examples, mediation guidance, and performance tips.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 05d1b382abd905e1e6cace48fba843243a9a4792. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->