### PR TITLE
Ignore timeout when WebAuthn mediation is used

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -47,6 +47,8 @@ configure({
 });
 ```
 
+> Note: When WebAuthn mediation is used (for example `conditional` or `immediate`), the configured FIDO2 `timeout` is ignored and the browser's default mediation behavior determines timing.
+
 ### Sign Up
 
 If your User Pool is enabled for self sign-up, users can sign up like so:

--- a/client/__tests__/fido2-core.test.ts
+++ b/client/__tests__/fido2-core.test.ts
@@ -257,6 +257,28 @@ describe("FIDO2 Core Functionality", () => {
       );
     });
 
+    it("omits timeout when mediation is specified", async () => {
+      const getSpy = jest.fn().mockResolvedValue(MOCK_ASSERTION_CREDENTIAL);
+
+      cleanup = setupWebAuthnMock({
+        customCredentials: {
+          get: getSpy,
+          create: jest.fn(),
+        } as any,
+      });
+
+      await fido2getCredential({
+        challenge: TEST_CHALLENGES.basic,
+        timeout: 45000,
+        mediation: "immediate",
+      });
+
+      expect(getSpy).toHaveBeenCalledTimes(1);
+      const callArgs = getSpy.mock.calls[0][0];
+      expect(callArgs.mediation).toBe("immediate");
+      expect(callArgs.publicKey.timeout).toBeUndefined();
+    });
+
     it("uses config extensions when available with known values", async () => {
       const knownExtensions = {
         credProps: true,
@@ -407,7 +429,7 @@ describe("FIDO2 Core Functionality", () => {
       const credentialGetterArgs = credentialGetter.mock.calls[0][0];
       expect(credentialGetterArgs.challenge).toBe("server-challenge");
       expect(credentialGetterArgs.relyingPartyId).toBe(TEST_RP.id);
-      expect(credentialGetterArgs.timeout).toBe(baseConfig.fido2.timeout);
+      expect(credentialGetterArgs.timeout).toBeUndefined();
       expect(credentialGetterArgs.userVerification).toBe(
         baseConfig.fido2.authenticatorSelection.userVerification
       );


### PR DESCRIPTION
# Ignore WebAuthn timeout when using mediation modes

This PR improves WebAuthn authentication behavior by ignoring the configured timeout value when using WebAuthn mediation modes (`conditional` or `immediate`). This aligns with the WebAuthn specification, which states that browsers should manage their own timeout behavior during mediation flows.

Changes include:
- Added documentation note in README explaining that timeout is ignored with mediation
- Modified `fido2getCredential` to explicitly remove timeout when mediation is specified
- Updated `prepareFido2SignIn` to conditionally apply timeout based on mediation presence
- Added test case to verify timeout is omitted with mediation
- Enhanced documentation in the `authenticateWithFido2` function to clarify timeout behavior
- Fixed MFA status handling to properly recover from errors

These changes ensure proper behavior when using WebAuthn mediation modes for authentication flows.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ignore WebAuthn timeout when using mediation modes and improve MFA status handling, with corresponding docs and test updates.
> 
> - **FIDO2/WebAuthn**:
>   - `fido2getCredential`: Ignore `timeout` whenever `mediation` is provided; enforce `userVerification="preferred"` for `conditional`; add debug notes.
>   - `prepareFido2SignIn`: Pass `timeout: undefined` when `mediation` is set for both username and usernameless flows.
>   - Docs/JSDoc: Clarify timeout is ignored for `conditional` and `immediate` mediation.
> - **Tests**:
>   - Add test to ensure `timeout` is omitted when `mediation` is specified.
>   - Update expectations to reflect `timeout` is `undefined` in mediated flows.
> - **React Hooks (MFA)**:
>   - On `getUser`/refresh errors: log error detail, set `mfaStatusReady` true, clear last fetched token, and trigger `INCREMENT_RECHECK_STATUS`.
>   - Include `recheckSignInStatus` in dependencies; set `mfaStatusReady` true on `refreshTotpMfaStatus` errors.
> - **Docs**:
>   - `client/README.md`: Add note that FIDO2 `timeout` is ignored with WebAuthn mediation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 274eb73ef02aa2f6ac62fb4d36b76d2d371d4fab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->