### PR TITLE
Ensure UI never hangs on MFA status loading failures

### DIFF
--- a/client/react/hooks.tsx
+++ b/client/react/hooks.tsx
@@ -1078,12 +1078,12 @@ function _usePasswordless() {
         debug?.("getUser failed; retaining previous TOTP MFA status");
         // Ensure UI never hangs behind a loader due to a transient failure
         dispatch({ type: "SET_MFA_STATUS_READY", payload: true });
-        // Schedule a silent retry with basic backoff + jitter (15–25s)
+        // Schedule a simple early silent retry with jitter (6–8s)
         if (mfaRetryTimeoutRef.current) {
           clearTimeout(mfaRetryTimeoutRef.current);
           mfaRetryTimeoutRef.current = undefined;
         }
-        const jitterMs = 15000 + Math.floor(Math.random() * 10000);
+        const jitterMs = 6000 + Math.floor(Math.random() * 2000);
         mfaRetryTimeoutRef.current = setTimeout(() => {
           // Clear token guard so the effect can try again
           lastFetchedMfaTokenRef.current = undefined;

--- a/client/react/hooks.tsx
+++ b/client/react/hooks.tsx
@@ -1062,6 +1062,8 @@ function _usePasswordless() {
         // falsely disabling security-gated UI. Log for debugging.
         const { debug } = configure();
         debug?.("getUser failed; retaining previous TOTP MFA status");
+        // Ensure UI never hangs behind a loader due to a transient failure
+        dispatch({ type: "SET_MFA_STATUS_READY", payload: true });
       });
 
     return () => {
@@ -1766,6 +1768,8 @@ function _usePasswordless() {
       } catch (error) {
         const { debug } = configure();
         debug?.("refreshTotpMfaStatus failed; not marking ready");
+        // Make the current (last-known) status consumable by the UI
+        dispatch({ type: "SET_MFA_STATUS_READY", payload: true });
       }
     },
     /** Milliseconds since the last user activity (mousemove, keydown, scroll, touch) */


### PR DESCRIPTION
Fix TOTP MFA status loading issues in React hooks

This PR addresses two issues in the TOTP MFA status handling:

1. Adds a dispatch to set MFA status as ready when `getUser()` fails, preventing the UI from hanging behind a loader due to transient failures.

2. Adds a similar dispatch in the `refreshTotpMfaStatus` error handler to make the last-known status consumable by the UI when refresh fails.

Both changes ensure that users don't get stuck in loading states when temporary errors occur during MFA status checks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures MFA status never blocks the UI by marking it ready on failures and introducing a timed silent retry with cleanup and updated effect deps.
> 
> - **React hooks (`client/react/hooks.tsx`)**:
>   - **MFA status resiliency**:
>     - On `getUser`/`refreshTotpMfaStatus` errors, dispatch `SET_MFA_STATUS_READY: true` to prevent loader hangs.
>     - Add silent retry with jitter (6–8s) after `getUser` failure; clear token guard and trigger `INCREMENT_RECHECK_STATUS`.
>     - Cancel scheduled retries on successful/no-MFA responses and during cleanup.
>     - Introduce `mfaRetryTimeoutRef` to manage retry timers.
>   - **Effect dependency update**:
>     - Include `recheckSignInStatus` in the MFA fetching effect deps to allow retriggers after retries.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a6547967f0771cc8e9f476f259d8109b64e8778d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->