### PR TITLE
Tolerate client clock skew when validating token expiry (fixes desktop login loop)

### DIFF
--- a/client/common.ts
+++ b/client/common.ts
@@ -28,6 +28,7 @@ import {
   busyState,
 } from "./model.js";
 import { scheduleRefresh, cleanupRefreshSystem } from "./refresh.js";
+import { computeClockDriftMs } from "./util.js";
 import { handleDeviceConfirmation } from "./device.js";
 import { withStorageLock, LockTimeoutError } from "./lock.js";
 import { parseJwtPayload } from "./util.js";
@@ -154,6 +155,34 @@ async function processTokensInternal(
 
   // 2. Store tokens for persistence
   debug?.("🔄 [Process Tokens] Storing tokens for persistence");
+
+  // Capture client clock drift at token receipt. The access token's `iat` is
+  // server-trusted and "now" here ≈ receipt time, so this measures the device's
+  // clock offset (not the token's age). Persisting it lets token expiry be
+  // evaluated against a skew-corrected clock, so a wrong device clock can't make
+  // freshly-issued tokens look expired and trap the user in a logout loop.
+  const clockDriftMs = computeClockDriftMs(normalizedTokens.accessToken);
+  normalizedTokens.clockDriftMs = clockDriftMs;
+  const { clockSkewWarningThresholdMs, onClockSkewDetected } = configure();
+  const skewThresholdMs = clockSkewWarningThresholdMs ?? 5 * 60 * 1000;
+  if (Math.abs(clockDriftMs) > skewThresholdMs) {
+    debug?.(
+      `⏰ [Process Tokens] Client clock skew detected: ~${Math.round(
+        clockDriftMs / 1000
+      )}s vs server (threshold ${Math.round(
+        skewThresholdMs / 1000
+      )}s). Token expiry will be evaluated against a corrected clock.`
+    );
+    try {
+      onClockSkewDetected?.({
+        clockDriftMs,
+        thresholdMs: skewThresholdMs,
+        username: normalizedTokens.username,
+      });
+    } catch (err) {
+      debug?.("[Process Tokens] onClockSkewDetected callback threw:", err);
+    }
+  }
 
   // Store the already normalized tokens
   await storeTokens(normalizedTokens);

--- a/client/common.ts
+++ b/client/common.ts
@@ -417,6 +417,9 @@ export const signOut = (props?: {
           ),
           storage.removeItem(`${amplifyKeyPrefix}.${tokens.username}.userData`),
           storage.removeItem(`${amplifyKeyPrefix}.LastAuthUser`),
+          storage.removeItem(
+            `${amplifyKeyPrefix}.${tokens.username}.clockDriftMs`
+          ),
           storage.removeItem(`${customKeyPrefix}.${tokens.username}.expireAt`),
           storage.removeItem(
             `Passwordless.${clientId}.${tokens.username}.refreshingTokens`

--- a/client/config.ts
+++ b/client/config.ts
@@ -58,6 +58,26 @@ export interface Config {
      */
     useActivityTracking?: boolean;
   };
+  /**
+   * Threshold (ms) of client-vs-server clock drift above which
+   * `onClockSkewDetected` is invoked. Drift is measured at token receipt from
+   * the access token's `iat` claim. Token validity is always corrected for
+   * drift regardless of this threshold; this only gates the warning callback.
+   * Default: 300000 (5 minutes).
+   */
+  clockSkewWarningThresholdMs?: number;
+  /**
+   * Called when the device clock differs from server time by more than
+   * `clockSkewWarningThresholdMs`. Use this to warn the user that their device
+   * clock is wrong. Without it the skew is corrected silently for token
+   * validity, but a badly wrong clock can still cause confusing behavior
+   * elsewhere, so surfacing it lets the user fix the root cause.
+   */
+  onClockSkewDetected?: (info: {
+    clockDriftMs: number;
+    thresholdMs: number;
+    username?: string;
+  }) => void;
   /** FIDO2 (WebAuthn) configuration */
   fido2?: {
     /** The base URL (i.e. the URL with path "/") of your FIDO2 API */

--- a/client/model.ts
+++ b/client/model.ts
@@ -34,6 +34,12 @@ export interface TokensFromSignIn {
    * Used for token refresh to determine how to refresh tokens
    */
   authMethod?: "SRP" | "FIDO2" | "PLAINTEXT" | "REDIRECT";
+  /**
+   * Client clock drift (ms) measured at token receipt: local time minus the
+   * access token's `iat`. Positive => device clock is ahead of server time.
+   * Used to evaluate token expiry against a skew-corrected clock.
+   */
+  clockDriftMs?: number;
 }
 export interface TokensFromRefresh {
   accessToken: string;
@@ -51,6 +57,12 @@ export interface TokensFromRefresh {
    * Used for token refresh to determine how to refresh tokens
    */
   authMethod?: "SRP" | "FIDO2" | "PLAINTEXT" | "REDIRECT";
+  /**
+   * Client clock drift (ms) measured at token receipt: local time minus the
+   * access token's `iat`. Positive => device clock is ahead of server time.
+   * Used to evaluate token expiry against a skew-corrected clock.
+   */
+  clockDriftMs?: number;
 }
 
 export const busyState = [

--- a/client/react/hooks.tsx
+++ b/client/react/hooks.tsx
@@ -911,8 +911,10 @@ function _usePasswordless() {
     // No tokens = not signed in
     if (!expiresAt) return "NOT_SIGNED_IN";
 
-    // Check if tokens are expired
-    const now = Date.now();
+    // Check if tokens are expired, against a skew-corrected clock: a wrong
+    // device clock must not make valid, freshly-issued tokens look expired
+    // (which would bounce the user straight back to sign-in).
+    const now = Date.now() - (tokens?.clockDriftMs ?? 0);
     const expireAtTime =
       expiresAt instanceof Date
         ? expiresAt.valueOf()
@@ -944,6 +946,7 @@ function _usePasswordless() {
     initiallyRetrievingTokensFromStorage,
     signingInStatus,
     tokens?.expireAt,
+    tokens?.clockDriftMs,
     tokensParsed?.expireAt,
     isRefreshingTokens,
   ]);

--- a/client/refresh.ts
+++ b/client/refresh.ts
@@ -883,6 +883,11 @@ export async function refreshTokens({
             ...(currentTokens.authMethod && {
               authMethod: currentTokens.authMethod,
             }),
+            // Carry over the clock drift persisted by the tab that refreshed,
+            // so the skew-corrected expiry check stays correct in this tab too.
+            ...(currentTokens.clockDriftMs !== undefined && {
+              clockDriftMs: currentTokens.clockDriftMs,
+            }),
           };
 
           if (tokensCb) {

--- a/client/refresh.ts
+++ b/client/refresh.ts
@@ -308,7 +308,10 @@ async function scheduleRefreshUnlocked({
     clearExistingTimer();
 
     const tokenExpiryTime = tokens.expireAt.valueOf();
-    const currentTime = Date.now();
+    // Evaluate against a skew-corrected clock (local time minus the drift
+    // captured at receipt) so a wrong device clock doesn't make us treat valid
+    // tokens as already-expired and refresh in a tight loop.
+    const currentTime = Date.now() - (tokens.clockDriftMs ?? 0);
     const timeUntilExpiry = tokenExpiryTime - currentTime;
 
     // If token is already expired or expires very soon, refresh immediately

--- a/client/storage.ts
+++ b/client/storage.ts
@@ -40,6 +40,12 @@ export interface TokensToStore {
    * Helps the refresh mechanism determine how to refresh tokens
    */
   authMethod?: "SRP" | "FIDO2" | "PLAINTEXT" | "REDIRECT";
+  /**
+   * Client clock drift (ms) captured at token receipt (local time minus the
+   * access token's `iat`). Persisted so token expiry can be evaluated against
+   * a skew-corrected clock. Absent => treated as 0 (previous behavior).
+   */
+  clockDriftMs?: number;
 }
 export interface TokensFromStorage {
   accessToken?: string;
@@ -50,6 +56,8 @@ export interface TokensFromStorage {
   deviceKey?: string;
   /** The authentication method used with these tokens */
   authMethod?: "SRP" | "FIDO2" | "PLAINTEXT" | "REDIRECT";
+  /** Client clock drift (ms) captured at token receipt; 0 when unknown. */
+  clockDriftMs?: number;
 }
 
 /**
@@ -89,6 +97,21 @@ export async function retrieveAuthMethod(
   }
 
   return undefined;
+}
+
+/**
+ * Retrieve the client clock drift (ms) captured at the last token receipt.
+ * Returns 0 when not present (e.g. legacy tokens stored before this field
+ * existed), preserving the prior uncorrected behavior for those.
+ */
+export async function retrieveClockDriftMs(username: string): Promise<number> {
+  if (!username) return 0;
+  const { clientId, storage } = configure();
+  const key = `CognitoIdentityServiceProvider.${clientId}.${username}.clockDriftMs`;
+  const raw = await storage.getItem(key);
+  if (!raw) return 0;
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : 0;
 }
 
 export async function storeTokens(tokens: TokensToStore) {
@@ -210,6 +233,21 @@ export async function storeTokens(tokens: TokensToStore) {
     )
   );
 
+  // Persist the clock drift captured at token receipt so expiry can later be
+  // evaluated against a skew-corrected clock (see retrieveTokens). Only written
+  // when known, so legacy/test paths that don't set it default to 0.
+  if (
+    typeof tokens.clockDriftMs === "number" &&
+    Number.isFinite(tokens.clockDriftMs)
+  ) {
+    promises.push(
+      storage.setItem(
+        `${amplifyKeyPrefix}.${username}.clockDriftMs`,
+        String(Math.round(tokens.clockDriftMs))
+      )
+    );
+  }
+
   // --------- 6. Execute writes ---------
   await Promise.all(promises.filter(Boolean));
 
@@ -246,8 +284,14 @@ export async function retrieveTokens(): Promise<TokensFromStorage | undefined> {
     }
   }
 
+  // Evaluate expiry against a skew-corrected "now" (local clock minus the drift
+  // captured at token receipt). This prevents a wrong device clock from making
+  // valid, freshly-issued tokens look expired and dropping the whole session.
+  const clockDriftMs = await retrieveClockDriftMs(username);
+  const correctedNow = Date.now() - clockDriftMs;
+
   // Safety-net: if we don't have a valid future expiry timestamp, discard all tokens
-  if (!expireAtDate || expireAtDate.valueOf() <= Date.now()) {
+  if (!expireAtDate || expireAtDate.valueOf() <= correctedNow) {
     debug?.(
       "[retrieveTokens] Tokens missing valid future expiry. Dropping cached tokens."
     );
@@ -268,6 +312,7 @@ export async function retrieveTokens(): Promise<TokensFromStorage | undefined> {
     username,
     deviceKey,
     authMethod,
+    clockDriftMs,
   };
 }
 
@@ -327,6 +372,7 @@ export async function retrieveTokensForRefresh(): Promise<
   // Get device key and auth method
   const deviceKey = await retrieveDeviceKey(username);
   const authMethod = await retrieveAuthMethod(username);
+  const clockDriftMs = await retrieveClockDriftMs(username);
 
   return {
     idToken: idToken ?? undefined,
@@ -336,6 +382,7 @@ export async function retrieveTokensForRefresh(): Promise<
     username,
     deviceKey,
     authMethod,
+    clockDriftMs,
   };
 }
 

--- a/client/util.ts
+++ b/client/util.ts
@@ -56,6 +56,28 @@ export function parseJwtPayload<
 }
 
 /**
+ * Compute the client clock drift (in ms) at the moment a token is received:
+ * the local wall clock minus the access token's server-issued `iat` claim.
+ *
+ * Positive => the device clock is AHEAD of server time (the case that makes a
+ * freshly-issued token look already-expired and forces a logout loop). This is
+ * anchored at receipt (when `iat` ≈ server "now"), so it measures the clock
+ * offset, not the token's age. Returns 0 when it can't be determined, which
+ * preserves the previous (uncorrected) behavior. Mirrors the `clockDrift` that
+ * AWS Cognito's CognitoUserSession computes for its `isValid()` check.
+ */
+export function computeClockDriftMs(accessToken?: string): number {
+  if (!accessToken) return 0;
+  try {
+    const { iat } = parseJwtPayload<CognitoAccessTokenPayload>(accessToken);
+    if (typeof iat !== "number" || !Number.isFinite(iat) || iat <= 0) return 0;
+    return Date.now() - iat * 1000;
+  } catch {
+    return 0;
+  }
+}
+
+/**
  * Schedule a callback once, like setTimeout, but count
  * time spent sleeping also as time spent. This way, if the browser tab
  * where this is happening is activated again after sleeping,

--- a/test/clock-skew.test.ts
+++ b/test/clock-skew.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Regression tests for client clock-skew tolerance.
+ *
+ * Before this fix, token validity was `serverExp <= Date.now()` with no skew
+ * correction, so a device whose clock was hours fast saw every freshly-issued
+ * token as already-expired: `retrieveTokens()` dropped the session and the app
+ * bounced signin -> / -> logout -> signin without ever calling the API.
+ *
+ * The fix captures the client clock drift at token receipt (local time minus
+ * the access token's `iat`) and evaluates expiry against a corrected clock.
+ * Crucially the drift is anchored at receipt, so a genuinely-expired/aged token
+ * is still treated as expired.
+ */
+// jsdom doesn't define TextDecoder/TextEncoder, which the real parseJwtPayload
+// (used internally by computeClockDriftMs) relies on. Provide Node's.
+import { TextEncoder, TextDecoder } from "util";
+Object.assign(globalThis, {
+  TextEncoder: globalThis.TextEncoder ?? TextEncoder,
+  TextDecoder: globalThis.TextDecoder ?? TextDecoder,
+});
+
+import { configure } from "../client/config.js";
+import { storeTokens, retrieveTokens } from "../client/storage.js";
+import { computeClockDriftMs } from "../client/util.js";
+
+const HOUR = 3600_000;
+
+// Minimal unsigned JWT builder (matches the helper used in the other tests)
+const createJWT = (claims: Record<string, unknown>) => {
+  const enc = (obj: unknown) =>
+    btoa(JSON.stringify(obj))
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+  return `${enc({ alg: "HS256", typ: "JWT" })}.${enc(claims)}.sig`;
+};
+
+describe("client clock-skew tolerance", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    configure({
+      clientId: "testClient",
+      cognitoIdpEndpoint: "us-west-2",
+      fetch: jest.fn(),
+    });
+  });
+
+  describe("computeClockDriftMs", () => {
+    test("reports a positive drift (~3h) when the device clock is ahead", () => {
+      const now = Date.now();
+      // iat is 3h in the past relative to the (correct) test clock => the
+      // device that issued this "now" reading is ~3h ahead of the server.
+      const token = createJWT({ iat: Math.floor((now - 3 * HOUR) / 1000) });
+      const drift = computeClockDriftMs(token);
+      expect(drift).toBeGreaterThan(3 * HOUR - 60_000);
+      expect(drift).toBeLessThan(3 * HOUR + 60_000);
+    });
+
+    test("returns 0 for a freshly issued token (no skew)", () => {
+      const token = createJWT({ iat: Math.floor(Date.now() / 1000) });
+      expect(Math.abs(computeClockDriftMs(token))).toBeLessThan(60_000);
+    });
+
+    test("returns 0 for missing / unparseable tokens (preserves old behavior)", () => {
+      expect(computeClockDriftMs(undefined)).toBe(0);
+      expect(computeClockDriftMs("not-a-jwt")).toBe(0);
+      expect(computeClockDriftMs(createJWT({ sub: "u" }))).toBe(0); // no iat
+    });
+  });
+
+  describe("retrieveTokens expiry evaluation", () => {
+    test("FAST CLOCK: a token that looks expired locally but is valid in server time is retained", async () => {
+      const now = Date.now();
+      const driftMs = 3 * HOUR; // device clock 3h fast, captured at receipt
+      await storeTokens({
+        accessToken: createJWT({
+          sub: "u",
+          username: "fastuser",
+          // server time: issued ~now-drift; expires 2h ago in *client* time
+          iat: Math.floor((now - driftMs) / 1000),
+          exp: Math.floor((now - 2 * HOUR) / 1000),
+        }),
+        refreshToken: "r",
+        username: "fastuser",
+        expireAt: new Date(now - 2 * HOUR),
+        clockDriftMs: driftMs,
+      });
+
+      const retrieved = await retrieveTokens();
+      // Without the fix this is undefined (token dropped). With it, the session survives.
+      expect(retrieved).toBeDefined();
+      expect(retrieved?.username).toBe("fastuser");
+      expect(retrieved?.clockDriftMs).toBe(driftMs);
+    });
+
+    test("GENUINELY EXPIRED (no drift): token is still dropped", async () => {
+      const now = Date.now();
+      await storeTokens({
+        accessToken: createJWT({
+          sub: "u",
+          username: "expireduser",
+          iat: Math.floor((now - 2 * HOUR) / 1000),
+          exp: Math.floor((now - 1 * HOUR) / 1000),
+        }),
+        refreshToken: "r",
+        username: "expireduser",
+        expireAt: new Date(now - 1 * HOUR),
+        // no clockDriftMs => correction defaults to 0 => previous behavior
+      });
+
+      expect(await retrieveTokens()).toBeUndefined();
+    });
+
+    test("FAST CLOCK but token truly past its lifetime: still dropped (no false validity)", async () => {
+      const now = Date.now();
+      const driftMs = 3 * HOUR;
+      await storeTokens({
+        accessToken: createJWT({
+          sub: "u",
+          username: "staleuser",
+          iat: Math.floor((now - driftMs - 1 * HOUR) / 1000),
+          // expired ~1h ago even after correcting for the 3h drift
+          exp: Math.floor((now - 4 * HOUR) / 1000),
+        }),
+        refreshToken: "r",
+        username: "staleuser",
+        expireAt: new Date(now - 4 * HOUR),
+        clockDriftMs: driftMs,
+      });
+
+      expect(await retrieveTokens()).toBeUndefined();
+    });
+
+    test("CORRECT CLOCK: a normal valid token is retained with ~0 drift", async () => {
+      const now = Date.now();
+      await storeTokens({
+        accessToken: createJWT({
+          sub: "u",
+          username: "okuser",
+          iat: Math.floor(now / 1000),
+          exp: Math.floor((now + 1 * HOUR) / 1000),
+        }),
+        refreshToken: "r",
+        username: "okuser",
+        expireAt: new Date(now + 1 * HOUR),
+        clockDriftMs: 0,
+      });
+
+      const retrieved = await retrieveTokens();
+      expect(retrieved).toBeDefined();
+      expect(retrieved?.clockDriftMs).toBe(0);
+    });
+  });
+});

--- a/test/clock-skew.test.ts
+++ b/test/clock-skew.test.ts
@@ -21,6 +21,7 @@ Object.assign(globalThis, {
 
 import { configure } from "../client/config.js";
 import { storeTokens, retrieveTokens } from "../client/storage.js";
+import { signOut } from "../client/common.js";
 import { computeClockDriftMs } from "../client/util.js";
 
 const HOUR = 3600_000;
@@ -149,6 +150,34 @@ describe("client clock-skew tolerance", () => {
       const retrieved = await retrieveTokens();
       expect(retrieved).toBeDefined();
       expect(retrieved?.clockDriftMs).toBe(0);
+    });
+  });
+
+  describe("sign-out cleanup", () => {
+    test("removes the persisted clockDriftMs key on sign-out", async () => {
+      const now = Date.now();
+      await storeTokens({
+        accessToken: createJWT({
+          sub: "u",
+          username: "souser",
+          iat: Math.floor(now / 1000),
+          exp: Math.floor((now + HOUR) / 1000),
+        }),
+        refreshToken: "r",
+        username: "souser",
+        expireAt: new Date(now + HOUR),
+        clockDriftMs: 2 * HOUR,
+      });
+
+      const { storage } = configure();
+      const driftKey =
+        "CognitoIdentityServiceProvider.testClient.souser.clockDriftMs";
+      expect(await storage.getItem(driftKey)).not.toBeNull();
+
+      const { signedOut } = signOut({ skipTokenRevocation: true });
+      await signedOut;
+
+      expect(await storage.getItem(driftKey)).toBeNull();
     });
   });
 });


### PR DESCRIPTION
## Problem

Users whose device clock is wrong by more than an access token's lifetime **cannot log in**. After authenticating, the app lands on the authenticated route and immediately bounces `/` → `/logout?redirectTo=/` → `/signin`, **never calling the API**. It reproduces in every desktop browser + incognito, survives self-serve password resets, but works fine on a correctly-set phone. Diagnosed from a production case where a customer's desktop clock was ~3 hours fast.

## Root cause

Token validity compares the server-issued `exp` claim against the local `Date.now()` with **no skew correction**:

- `client/storage.ts` `retrieveTokens()` drops the whole session when `expireAtDate.valueOf() <= Date.now()`.
- `client/react/hooks.tsx` `signInStatus` returns `NOT_SIGNED_IN` when `now >= expireAtTime` (the only tolerance is a 30s refresh grace period).
- `client/refresh.ts` `scheduleRefresh` treats the token as expired when `expireAt − Date.now() <= 60s`.

`expireAt` comes from the access token's `exp` (server time). A client clock ~3h fast makes a token issued seconds ago (exp ≈ server-now + 1h) read as expired by ~2h **immediately** — and a refreshed token is also stamped in server time, so refreshing never recovers. The library reports no valid session, attaches no bearer token, and the app logs the user out in a loop.

A fixed `clockTolerance` (jose/jsonwebtoken default 30–60s; RFC 7519 suggests "a few minutes") cannot cover a multi-hour skew. AWS solves this for Cognito sessions with a **`clockDrift`** derived from the token's trusted `iat`.

## Fix

Capture the client clock drift at token **receipt** — `Date.now() − iat*1000`, where `iat` is server-trusted and "now" ≈ receipt time — and evaluate expiry against a skew-corrected clock everywhere:

- New `computeClockDriftMs()` in `util.ts`.
- `processTokens` computes the drift for **all** auth flows and persists it via `storeTokens` (`…​.clockDriftMs`).
- `retrieveTokens` / `retrieveTokensForRefresh`, the React `signInStatus` check, and `scheduleRefresh` subtract the drift from `Date.now()`.

Because drift is anchored at **receipt** (not recomputed from `iat` at check time), a genuinely aged/expired token is still treated as expired — **no false validity**. This mirrors AWS Cognito `CognitoUserSession`'s `clockDrift`.

### Boot-time clock-skew warning

Added optional config `onClockSkewDetected` (gated by `clockSkewWarningThresholdMs`, default 5 min). Validity is corrected silently, but a badly wrong clock can still cause confusing behavior elsewhere — this lets integrators surface a "your device clock is wrong" message instead of failing silently.

```ts
Passwordless.configure({
  // …
  clockSkewWarningThresholdMs: 5 * 60 * 1000,
  onClockSkewDetected: ({ clockDriftMs }) =>
    toast.warn(`Your device clock looks off by ~${Math.round(clockDriftMs / 60000)} min — please enable automatic date & time.`),
});
```

## Backward compatibility

Drift defaults to **0** when unknown (legacy stored tokens, non-JWT/`iat`-less tokens, parse failures), so behavior on correctly-set clocks and for previously-stored sessions is unchanged.

## Testing

- New `test/clock-skew.test.ts`: fast-clock token retained; genuinely-expired token still dropped; fast-clock-but-truly-past-lifetime still dropped; correct-clock unchanged; `computeClockDriftMs` unit cases.
- Full suite: **181 passed, 0 failed** (`npm test`); `tsc --noEmit` clean; eslint clean.

## Files

`util.ts` (drift helper), `common.ts` (capture + warn on receipt), `storage.ts` (persist + skew-corrected `retrieveTokens`), `react/hooks.tsx` (`signInStatus`), `refresh.ts` (`scheduleRefresh`), `config.ts` + `model.ts` (types/config).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core session validity and refresh timing across storage, React hooks, and refresh scheduling; behavior is backward-compatible when drift is unknown but incorrect drift math could affect who stays signed in.
> 
> **Overview**
> Fixes a **post-login logout loop** when the device clock is far ahead of server time: access tokens were compared to `Date.now()` with no skew, so freshly issued tokens could look expired immediately after sign-in.
> 
> The PR adds **`computeClockDriftMs`** (`Date.now() − iat`) at token receipt in **`processTokens`**, persists it as **`clockDriftMs`**, and uses **`Date.now() − clockDriftMs`** for expiry in **`retrieveTokens`**, React **`signInStatus`**, and **`scheduleRefresh`**. Drift is anchored at receipt (Cognito-style), so truly expired tokens are still rejected. Optional **`onClockSkewDetected`** / **`clockSkewWarningThresholdMs`** let apps warn users; missing drift defaults to **0** for legacy sessions. Sign-out clears the stored drift key; **`test/clock-skew.test.ts`** covers fast clock, real expiry, and cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4aa962ebfbd165d758c0810ad2dc3c9bc29ad6d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->