### PR TITLE
publish.yml: use npm Trusted Publishing (OIDC) instead of NPM_TOKEN

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,14 +29,19 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup Node.js
-        # Node >= 22.14 is required for npm Trusted Publishing (OIDC)
+        # Node >= 22.14 is required for npm Trusted Publishing (OIDC).
+        # No registry-url on purpose: with it, setup-node writes an empty
+        # `_authToken=` line to .npmrc (NODE_AUTH_TOKEN is unset), which npm
+        # treats as "auth configured" and skips the OIDC exchange. Publishing to
+        # the default registry (registry.npmjs.org) lets OIDC handle auth.
         uses: actions/setup-node@v4
         with:
           node-version: "22.x"
-          registry-url: https://registry.npmjs.org/
       - name: Upgrade npm for Trusted Publishing
-        # Trusted Publishing (OIDC) needs npm >= 11.5.1; Node 22 still ships npm 10.x
-        run: npm install -g npm@latest
+        # Trusted Publishing (OIDC) needs npm >= 11.5.1; Node 22 still ships npm 10.x.
+        # Pinned (not @latest) to avoid a mutable dependency on the privileged
+        # publish path.
+        run: npm install -g npm@11.5.1
       - name: Configure Git
         run: |
           git config --local user.email "action@github.com"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,8 @@ on:
         type: string
 
 permissions:
-  contents: write
+  contents: write # version commit/tag/push + GitHub release
+  id-token: write # OIDC token for npm Trusted Publishing
 
 jobs:
   build-and-publish:
@@ -28,10 +29,14 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup Node.js
+        # Node >= 22.14 is required for npm Trusted Publishing (OIDC)
         uses: actions/setup-node@v4
         with:
-          node-version: "20.x"
+          node-version: "22.x"
           registry-url: https://registry.npmjs.org/
+      - name: Upgrade npm for Trusted Publishing
+        # Trusted Publishing (OIDC) needs npm >= 11.5.1; Node 22 still ships npm 10.x
+        run: npm install -g npm@latest
       - name: Configure Git
         run: |
           git config --local user.email "action@github.com"
@@ -62,9 +67,10 @@ jobs:
           git push
           git push --tags
       - run: npm run dist
+      # Authenticated via OIDC Trusted Publishing — no NPM_TOKEN. Requires a
+      # trusted publisher configured on npmjs.com for this repo + publish.yml.
+      # Provenance attestations are generated automatically.
       - run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:


### PR DESCRIPTION
## What
Switches the **Publish Client Package to npm** workflow (`.github/workflows/publish.yml`) from a long-lived `NPM_TOKEN` to **npm Trusted Publishing (OIDC)**.

## Changes
- Added `id-token: write` permission (kept `contents: write` for the version commit/tag/push + GitHub release).
- Bumped Node to **22.x** and added an `npm install -g npm@latest` step — Trusted Publishing requires **Node ≥ 22.14 and npm ≥ 11.5.1** (Node 22 still ships npm 10.x).
- Removed `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` from the publish step. Provenance attestations are now generated automatically.

## ⚠️ Required before this can publish (one-time, registry-side)
On npmjs.com → package **`@joinmeow/cognito-passwordless-auth`** → **Settings → Trusted Publisher → GitHub Actions**, add:
| Field | Value |
|---|---|
| Organization or user | `joinmeow` |
| Repository | `amazon-cognito-passwordless-auth` |
| Workflow filename | `publish.yml` |
| Environment | *(leave blank — none used)* |
| Allowed action | `npm publish` |

Until that publisher is configured, `npm publish` will fail to authenticate via OIDC. After the first successful OIDC publish, the **`NPM_TOKEN` repo secret can be deleted**.

## Testing notes
- This workflow only runs on `workflow_dispatch`, so PR CI can't exercise it — it'll be validated on the next manual release run.
- `main.yml` (test CI) is unchanged.

Refs: [npm Trusted Publishing docs](https://docs.npmjs.com/trusted-publishers/), [GitHub changelog (GA 2025-07-31)](https://github.blog/changelog/2025-07-31-npm-trusted-publishing-with-oidc-is-generally-available/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how production npm packages are authenticated; publish will fail until npm trusted publisher is configured, but removes long-lived secret exposure once migrated.
> 
> **Overview**
> The **Publish Client Package to npm** workflow (`.github/workflows/publish.yml`) now publishes with **npm Trusted Publishing (OIDC)** instead of a repo `NPM_TOKEN`.
> 
> **Permissions:** `id-token: write` is added so the job can mint an OIDC token for npm; `contents: write` stays for version bumps, tags, and GitHub releases.
> 
> **Runtime:** Node is bumped from **20.x** to **22.x**, and a step installs **npm@11.5.1** globally (pinned) so publish meets Trusted Publishing’s Node/npm minimums. `setup-node` no longer sets `registry-url`, avoiding an empty `.npmrc` token that would block the OIDC auth path.
> 
> **Publish step:** `NODE_AUTH_TOKEN` / `secrets.NPM_TOKEN` are removed; `npm publish` relies on OIDC once a trusted publisher is configured on npm for this repo and `publish.yml`. Comments note automatic provenance attestations and the one-time npm registry setup requirement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce9931bc89fd32ea77ce44e6926c34df2c16efaf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->