### PR TITLE
publish.yml: create GitHub Release via gh CLI (fix startup_failure from Actions allowlist)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -77,21 +77,35 @@ jobs:
       # Provenance attestations are generated automatically.
       - run: npm publish
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: v${{ steps.version.outputs.new_version }}
-          name: v${{ steps.version.outputs.new_version }}
-          body: |
-            ## What's Changed
-            ${{ github.event.inputs.release_notes || 'Version ' }}${{ steps.version.outputs.new_version }} (${{ github.event.inputs.version_bump }} release)
-
-            ### Changes since v${{ steps.version.outputs.current_version }}
-
-            To install this version:
-            ```bash
-            npm install @joinmeow/cognito-passwordless-auth@${{ steps.version.outputs.new_version }}
-            ```
-          draft: false
-          prerelease: false
-          generate_release_notes: ${{ github.event.inputs.release_notes == '' }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+        # Use the pre-installed gh CLI rather than a third-party action: the
+        # repo's Actions allowlist (allowed_actions=selected) blocks
+        # softprops/action-gh-release, which fails the run at startup. Inputs
+        # are passed via env to avoid shell injection from release_notes.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NEW_VERSION: ${{ steps.version.outputs.new_version }}
+          CURRENT_VERSION: ${{ steps.version.outputs.current_version }}
+          VERSION_BUMP: ${{ github.event.inputs.version_bump }}
+          RELEASE_NOTES: ${{ github.event.inputs.release_notes }}
+        run: |
+          {
+            echo "## What's Changed"
+            echo
+            if [ -n "$RELEASE_NOTES" ]; then
+              echo "$RELEASE_NOTES"
+            else
+              echo "Version $NEW_VERSION ($VERSION_BUMP release)"
+            fi
+            echo
+            echo "### Changes since v$CURRENT_VERSION"
+            echo
+            echo "To install this version:"
+            echo '```bash'
+            echo "npm install @joinmeow/cognito-passwordless-auth@$NEW_VERSION"
+            echo '```'
+          } > release_notes.md
+          if [ -z "$RELEASE_NOTES" ]; then
+            gh release create "v$NEW_VERSION" --title "v$NEW_VERSION" --notes-file release_notes.md --generate-notes
+          else
+            gh release create "v$NEW_VERSION" --title "v$NEW_VERSION" --notes-file release_notes.md
+          fi


### PR DESCRIPTION
## Problem
Dispatching **Publish Client Package to npm** fails immediately with **`startup_failure`** — no steps run. Root cause: the repo restricts Actions to an allowlist (`allowed_actions: selected`; `github_owned_allowed` + a fixed `patterns_allowed` list), and the workflow's release step uses **`softprops/action-gh-release@v2`**, which is **not** on that allowlist. GitHub rejects the workflow at startup. (It worked in Nov 2025 because the allowlist was tightened since.)

Confirmed by two dispatches (runs `26716180638`, `26716232228`) — both `startup_failure`. `main` was untouched (still 1.0.98, no stray tags).

## Fix
Replace the third-party action with the pre-installed **`gh` CLI** (`gh release create`):
- No allowlist entry needed; one fewer third-party action on the release path.
- Release-notes input passed via **env** (not inline `${{ }}`) to avoid shell injection.
- Preserves the prior output: custom body (version + install snippet) plus auto-generated notes when `release_notes` is empty.

No other workflow change. Once merged, re-dispatch publishes 1.0.98 → 1.0.99 via OIDC.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to the release step; publish and OIDC steps are untouched, with similar release output and safer env-based input handling.
> 
> **Overview**
> The **Publish Client Package to npm** workflow’s GitHub release step no longer uses `softprops/action-gh-release@v2`. It now builds release notes in a shell script and runs **`gh release create`**, which works under the repo’s **selected** Actions allowlist (the third-party action caused **`startup_failure`** before any step ran).
> 
> Release metadata (`new_version`, `current_version`, `version_bump`, `release_notes`) is passed through **environment variables** instead of interpolating inputs directly in the script. Behavior is unchanged: custom notes when `release_notes` is set, otherwise a default header plus **`--generate-notes`**, including the npm install snippet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6af2cb9293fef832520adf912e2b8850412eeda3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->