### PR TITLE
Propagate background token refresh into React state in the same tab

### DIFF
--- a/client/__tests__/react-hooks-coverage.test.tsx
+++ b/client/__tests__/react-hooks-coverage.test.tsx
@@ -21,7 +21,7 @@ import {
   usePasswordless,
 } from "../react/hooks.js";
 import { configure } from "../config.js";
-import { retrieveTokens } from "../storage.js";
+import { retrieveTokens, onTokensStored } from "../storage.js";
 import { handleCognitoOAuthCallback } from "../hosted-oauth.js";
 import {
   prepareFido2SignIn as prepareFido2SignInCore,
@@ -55,6 +55,9 @@ jest.mock("../fido2", () => {
 const mockConfigure = configure as jest.MockedFunction<typeof configure>;
 const mockRetrieveTokens = retrieveTokens as jest.MockedFunction<
   typeof retrieveTokens
+>;
+const mockOnTokensStored = onTokensStored as jest.MockedFunction<
+  typeof onTokensStored
 >;
 const mockHandleOAuth = handleCognitoOAuthCallback as jest.MockedFunction<
   typeof handleCognitoOAuthCallback
@@ -94,6 +97,9 @@ describe("React hooks coverage for hooks.tsx branches", () => {
 
     // By default, no cached tokens
     mockRetrieveTokens.mockResolvedValue(undefined);
+
+    // onTokensStored returns an unsubscribe function
+    mockOnTokensStored.mockReturnValue(() => {});
   });
 
   it("synthesizes idToken for REDIRECT tokens missing idToken", async () => {

--- a/client/__tests__/react-oauth-simple.test.tsx
+++ b/client/__tests__/react-oauth-simple.test.tsx
@@ -21,7 +21,7 @@ import {
 } from "../react/hooks.js";
 import { signInWithRedirect } from "../hosted-oauth.js";
 import { configure } from "../config.js";
-import { retrieveTokens } from "../storage.js";
+import { retrieveTokens, onTokensStored } from "../storage.js";
 import type { ConfigWithDefaults } from "../config.js";
 
 // Mock dependencies
@@ -35,6 +35,9 @@ const mockSignInWithRedirect = signInWithRedirect as jest.MockedFunction<
 const mockConfigure = configure as jest.MockedFunction<typeof configure>;
 const mockRetrieveTokens = retrieveTokens as jest.MockedFunction<
   typeof retrieveTokens
+>;
+const mockOnTokensStored = onTokensStored as jest.MockedFunction<
+  typeof onTokensStored
 >;
 
 describe("React OAuth Integration - Simple", () => {
@@ -56,6 +59,7 @@ describe("React OAuth Integration - Simple", () => {
     mockConfigure.mockReturnValue(mockConfig as ConfigWithDefaults);
     mockSignInWithRedirect.mockResolvedValue(undefined);
     mockRetrieveTokens.mockResolvedValue(undefined); // No tokens initially
+    mockOnTokensStored.mockReturnValue(() => {}); // Returns unsubscribe function
   });
 
   const wrapper = ({ children }: { children: React.ReactNode }) => (

--- a/client/__tests__/react-same-tab-token-store.test.tsx
+++ b/client/__tests__/react-same-tab-token-store.test.tsx
@@ -1,0 +1,194 @@
+/**
+ * Copyright Amazon.com, Inc. and its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You
+ * may not use this file except in compliance with the License. A copy of
+ * the License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+// Regression test: background token refresh writes tokens to storage from the
+// SAME document, and per the WHATWG HTML spec the "storage" event never fires
+// in the document that performed the write. The React hook must therefore be
+// notified of same-context token stores (via onTokensStored) — otherwise its
+// tokens/tokensParsed state stays stale in the active tab until the access
+// token expires and the user is bounced to login.
+
+import React from "react";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import {
+  usePasswordless,
+  PasswordlessContextProvider,
+} from "../react/hooks.js";
+import { configure } from "../config.js";
+import { storeTokens, onTokensStored } from "../storage.js";
+import type { ConfigWithDefaults } from "../config.js";
+
+jest.mock("../config");
+
+const mockConfigure = configure as jest.MockedFunction<typeof configure>;
+
+// Helper to create JWT tokens (header.payload.signature, base64url payload)
+const createJWT = (claims: Record<string, unknown>) => {
+  const header = btoa(JSON.stringify({ alg: "HS256", typ: "JWT" }))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+  const payload = btoa(JSON.stringify(claims))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+  return `${header}.${payload}.signature`;
+};
+
+const username = "test-user";
+
+const makeTokenBundle = (expInSeconds: number, marker: string) => {
+  const now = Math.floor(Date.now() / 1000);
+  const exp = now + expInSeconds;
+  return {
+    accessToken: createJWT({
+      sub: "test-sub",
+      username,
+      iat: now,
+      exp,
+      scope: "aws.cognito.signin.user.admin",
+      marker,
+    }),
+    idToken: createJWT({
+      sub: "test-sub",
+      "cognito:username": username,
+      email: "test@example.com",
+      iat: now,
+      exp,
+      marker,
+    }),
+    refreshToken: `refresh-token-${marker}`,
+    expireAt: new Date(exp * 1000),
+    username,
+    authMethod: "SRP" as const,
+  };
+};
+
+describe("Same-tab token store propagation", () => {
+  let memoryStorage: Map<string, string>;
+
+  beforeEach(() => {
+    memoryStorage = new Map<string, string>();
+    const mockConfig: Partial<ConfigWithDefaults> = {
+      clientId: "test-client-id",
+      debug: undefined,
+      storage: {
+        getItem: (key: string) => memoryStorage.get(key) ?? null,
+        setItem: (key: string, value: string) => {
+          memoryStorage.set(key, value);
+        },
+        removeItem: (key: string) => {
+          memoryStorage.delete(key);
+        },
+      },
+    };
+    mockConfigure.mockReturnValue(mockConfig as ConfigWithDefaults);
+  });
+
+  describe("onTokensStored", () => {
+    it("notifies subscribers after storeTokens persists tokens, until unsubscribed", async () => {
+      const listener = jest.fn();
+      const unsubscribe = onTokensStored(listener);
+      try {
+        const tokens = makeTokenBundle(3600, "initial");
+        await storeTokens(tokens);
+        expect(listener).toHaveBeenCalledTimes(1);
+        expect(listener).toHaveBeenCalledWith(
+          expect.objectContaining({ accessToken: tokens.accessToken })
+        );
+        // Tokens must already be in storage when the listener fires
+        expect(
+          memoryStorage.get(
+            `CognitoIdentityServiceProvider.test-client-id.${username}.accessToken`
+          )
+        ).toBe(tokens.accessToken);
+      } finally {
+        unsubscribe();
+      }
+      await storeTokens(makeTokenBundle(3600, "after-unsubscribe"));
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("usePasswordless", () => {
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <PasswordlessContextProvider>{children}</PasswordlessContextProvider>
+    );
+
+    it("picks up tokens stored by a background refresh in the same tab", async () => {
+      // Sign-in state: valid tokens already in storage at mount
+      const initialTokens = makeTokenBundle(3600, "initial");
+      await storeTokens(initialTokens);
+
+      const { result, unmount } = renderHook(() => usePasswordless(), {
+        wrapper,
+      });
+
+      await waitFor(() => {
+        expect(result.current.tokens?.accessToken).toBe(
+          initialTokens.accessToken
+        );
+      });
+      expect(result.current.signInStatus).toBe("SIGNED_IN");
+
+      // Simulate a background refresh: the core refresh machinery persists the
+      // refreshed tokens via storeTokens in THIS document. No "storage" event
+      // fires for same-document writes, so this is the only signal the hook
+      // gets in the active tab.
+      const refreshedTokens = makeTokenBundle(7200, "refreshed");
+      await act(async () => {
+        await storeTokens(refreshedTokens);
+      });
+
+      await waitFor(() => {
+        expect(result.current.tokens?.accessToken).toBe(
+          refreshedTokens.accessToken
+        );
+      });
+      expect(result.current.tokens?.refreshToken).toBe(
+        refreshedTokens.refreshToken
+      );
+      expect(result.current.tokensParsed?.expireAt.valueOf()).toBe(
+        refreshedTokens.expireAt.valueOf()
+      );
+      expect(result.current.signInStatus).toBe("SIGNED_IN");
+
+      unmount();
+    });
+
+    it("stops listening for token stores after unmount", async () => {
+      const initialTokens = makeTokenBundle(3600, "initial");
+      await storeTokens(initialTokens);
+
+      const { result, unmount } = renderHook(() => usePasswordless(), {
+        wrapper,
+      });
+      await waitFor(() => {
+        expect(result.current.tokens?.accessToken).toBe(
+          initialTokens.accessToken
+        );
+      });
+
+      unmount();
+
+      // Storing tokens after unmount must not blow up or update unmounted state
+      // (React would log a warning / act error if it did)
+      await storeTokens(makeTokenBundle(7200, "post-unmount"));
+      expect(result.current.tokens?.accessToken).toBe(
+        initialTokens.accessToken
+      );
+    });
+  });
+});

--- a/client/react/hooks.tsx
+++ b/client/react/hooks.tsx
@@ -32,6 +32,7 @@ import {
   storeDeviceKey,
   getRememberedDevice,
   setRememberedDevice,
+  onTokensStored,
   TokensFromStorage,
 } from "../storage.js";
 import {
@@ -800,9 +801,20 @@ function _usePasswordless() {
       globalThis.addEventListener("storage", handleStorageChange);
     }
 
+    // The "storage" event above only fires in *other* documents, never in the
+    // document that performed the write. Background token refreshes write the
+    // refreshed tokens to storage from THIS document, so subscribe to
+    // same-context token stores too — otherwise React state would keep the
+    // stale (expiring) tokens in the active tab.
+    const unsubscribeTokensStored = onTokensStored(() => {
+      debug?.("Tokens stored in this context, reloading tokens from storage");
+      void loadTokens();
+    });
+
     // Cleanup function
     return () => {
       abortController.abort();
+      unsubscribeTokensStored();
       if (typeof globalThis !== "undefined" && globalThis.removeEventListener) {
         globalThis.removeEventListener("storage", handleStorageChange);
       }

--- a/client/storage.ts
+++ b/client/storage.ts
@@ -60,6 +60,30 @@ export interface TokensFromStorage {
   clockDriftMs?: number;
 }
 
+type TokensStoredListener = (tokens: TokensToStore) => void;
+
+// In-memory registry of same-context subscribers, notified whenever tokens
+// are persisted via storeTokens. Needed because the WHATWG "storage" event
+// only fires in *other* documents, never in the document that performed the
+// write — so without this, a background token refresh in the active tab
+// would update storage without any way for UI state (e.g. the React hook)
+// to find out.
+const tokensStoredListeners = new Set<TokensStoredListener>();
+
+/**
+ * Subscribe to token stores performed in this JavaScript context.
+ * The listener is invoked after the tokens have been persisted to storage.
+ *
+ * @param listener Called with the tokens that were just stored
+ * @returns A function that unsubscribes the listener
+ */
+export function onTokensStored(listener: TokensStoredListener): () => void {
+  tokensStoredListeners.add(listener);
+  return () => {
+    tokensStoredListeners.delete(listener);
+  };
+}
+
 /**
  * Store the authentication method used for the current user
  * This helps refresh token logic determine how to refresh tokens
@@ -254,6 +278,18 @@ export async function storeTokens(tokens: TokensToStore) {
   debug?.(
     `[storeTokens] Completed storage${tokens.refreshToken ? ", refreshToken stored under key " + amplifyKeyPrefix + "." + username + ".refreshToken" : ""}`
   );
+
+  // --------- 7. Notify same-context subscribers ---------
+  // The "storage" event never fires in the document that performed the write,
+  // so subscribers in this context (e.g. the React hook) rely on this callback
+  // to pick up tokens written by background refreshes in the same tab.
+  for (const listener of tokensStoredListeners) {
+    try {
+      listener(tokens);
+    } catch (err) {
+      debug?.("[storeTokens] onTokensStored listener threw:", err);
+    }
+  }
 }
 
 export async function retrieveTokens(): Promise<TokensFromStorage | undefined> {


### PR DESCRIPTION
## Summary
Background token refreshes wrote refreshed tokens to storage but never reached the React hook's state in the tab that performed the refresh, so the active tab appeared to sign the user out at first access-token expiry. This PR adds a same-context token-store notification in the core and subscribes the React hook to it.

## Finding
- Severity: CRITICAL; Confidence: verified mechanism
- `client/react/hooks.tsx` (~line 612): the hook does no refresh scheduling ("handled by processTokens").
- `client/common.ts` (~lines 250-261): `processTokens` schedules background refresh with a no-op `tokensCb` — refreshed tokens are only persisted to storage (via `storeTokens` when the refreshed bundle is re-processed).
- `client/react/hooks.tsx` (~lines 779-801): the hook's only re-sync path is the `storage` event listener. Per the WHATWG HTML spec, the `storage` event never fires in the document that performed the write — only in other same-origin documents.
- Concrete failure: in the active tab, the core silently refreshes and storage holds fresh tokens, but the hook's `tokens`/`tokensParsed` stay stale. Apps send the expired JWT, and the `signInStatus` memo computes `now >= expireAtTime` → `NOT_SIGNED_IN`, bouncing a validly-refreshed user to login.

## Fix
- `client/storage.ts`: add a lightweight in-memory subscriber registry — `onTokensStored(listener)` returns an unsubscribe function; `storeTokens` notifies subscribers after the writes complete (listener errors are caught and logged via `debug`). Exported through the existing `export * from "./storage.js"` in `client/index.ts`, so the public API change is additive only; no new dependencies.
- `client/react/hooks.tsx`: in the mount effect, subscribe via `onTokensStored` and reload tokens from storage when notified (the existing `loadTokens` path, which already respects the effect's abort controller). Unsubscribe in the effect cleanup, so unmount/sign-out teardown is handled.
- Updated the two react tests that auto-mock `../storage` to have the mocked `onTokensStored` return an unsubscribe function.

## Test plan
- New regression test `client/__tests__/react-same-tab-token-store.test.tsx` (jsdom):
  - `onTokensStored` notifies after `storeTokens` persists, and unsubscribe stops notifications.
  - With the hook mounted and valid tokens loaded, calling the real `storeTokens` in the same document (no `storage` event) updates the hook's `tokens`/`tokensParsed` and keeps `signInStatus` = `SIGNED_IN`. Verified this test fails without the hook change.
  - After unmount, further stores do not update state.
- `npx tsc --project client/tsconfig.json --noEmit`: clean.
- `npx eslint` on changed files: clean.
- Full `npx jest`: 24 suites passed, 2 skipped (skips pre-existing); 185 tests passed, 19 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches session/token state synchronization in the React auth path; behavior is additive with targeted tests, but incorrect reload timing could still affect sign-in status or API calls using stale tokens.
> 
> **Overview**
> Fixes a bug where **background token refresh** updated persisted Cognito tokens in the active tab but **`usePasswordless` React state stayed on the old JWTs**, because cross-tab `storage` events never fire for writes in the same document.
> 
> **`storage.ts`** adds an additive **`onTokensStored`** API (in-memory subscribers, unsubscribe on return) and invokes listeners after **`storeTokens`** finishes persisting; listener throws are caught and logged.
> 
> **`react/hooks.tsx`** subscribes in the mount effect and reloads tokens from storage when notified, with cleanup on unmount alongside the existing `storage` listener.
> 
> Tests mock **`onTokensStored`** where storage is fully mocked, and a new regression suite covers subscriber behavior, same-tab refresh propagation, and no updates after unmount.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2a61dfa38912ec5bd2860ba1a8c1286e6ce41d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->