### PR TITLE
Renew Cognito session while conditional passkey request is pending

### DIFF
--- a/client/__tests__/fido2-core.test.ts
+++ b/client/__tests__/fido2-core.test.ts
@@ -17,9 +17,14 @@ import {
   fido2getCredential,
   prepareFido2SignIn,
   authenticateWithFido2,
+  COGNITO_AUTH_SESSION_RENEWAL_INTERVAL_MS,
 } from "../fido2.js";
 import { configure } from "../config.js";
-import { Fido2CredentialError, Fido2ValidationError } from "../errors.js";
+import {
+  Fido2AbortError,
+  Fido2CredentialError,
+  Fido2ValidationError,
+} from "../errors.js";
 import {
   MOCK_ASSERTION_CREDENTIAL,
   EXPECTED_TRANSFORMED_CREDENTIAL,
@@ -540,6 +545,167 @@ describe("FIDO2 Core Functionality", () => {
       await expect(prepareFido2SignIn({ credentialGetter })).rejects.toThrow(
         "Username is required for initiating sign-in"
       );
+    });
+
+    describe("conditional mediation session renewal", () => {
+      const parsedAssertion = {
+        credentialIdB64: "cred-renewal",
+        authenticatorDataB64: "auth-data",
+        clientDataJSON_B64: "client-data",
+        signatureB64: "signature",
+        userHandleB64: null,
+      };
+
+      const challengeResponse = (n: number) =>
+        ({
+          ChallengeParameters: {
+            fido2options: JSON.stringify({
+              challenge: `server-challenge-${n}`,
+              relyingPartyId: "server-rp",
+            }),
+          },
+          Session: `session-${n}`,
+        }) as any;
+
+      // A conditional credentials.get() that stays pending until aborted,
+      // mimicking the browser's autofill behavior
+      const pendingUntilAborted = ({ signal }: { signal?: AbortSignal }) =>
+        new Promise<never>((_, reject) => {
+          signal?.addEventListener("abort", () =>
+            reject(new Fido2AbortError())
+          );
+        });
+
+      afterEach(() => {
+        jest.useRealTimers();
+      });
+
+      it("renews the Cognito session with a fresh challenge when the conditional request outlives the renewal interval", async () => {
+        jest.useFakeTimers();
+        mockInitiateAuth
+          .mockResolvedValueOnce(challengeResponse(1))
+          .mockResolvedValueOnce(challengeResponse(2));
+
+        const credentialGetter = jest
+          .fn()
+          .mockImplementationOnce(pendingUntilAborted)
+          .mockResolvedValueOnce(parsedAssertion);
+
+        const prepared = prepareFido2SignIn({
+          username: "alice",
+          mediation: "conditional",
+          credentialGetter,
+        });
+
+        await jest.advanceTimersByTimeAsync(
+          COGNITO_AUTH_SESSION_RENEWAL_INTERVAL_MS
+        );
+
+        await expect(prepared).resolves.toEqual({
+          username: "alice",
+          credential: parsedAssertion,
+          session: "session-2",
+          existingDeviceKey: undefined,
+        });
+
+        // The whole CUSTOM_AUTH flow restarted: new session, new challenge
+        expect(mockInitiateAuth).toHaveBeenCalledTimes(2);
+        expect(credentialGetter).toHaveBeenCalledTimes(2);
+        expect(credentialGetter.mock.calls[0][0].challenge).toBe(
+          "server-challenge-1"
+        );
+        expect(credentialGetter.mock.calls[1][0].challenge).toBe(
+          "server-challenge-2"
+        );
+      });
+
+      it("renews repeatedly while the conditional request stays pending", async () => {
+        jest.useFakeTimers();
+        mockInitiateAuth
+          .mockResolvedValueOnce(challengeResponse(1))
+          .mockResolvedValueOnce(challengeResponse(2))
+          .mockResolvedValueOnce(challengeResponse(3));
+
+        const credentialGetter = jest
+          .fn()
+          .mockImplementationOnce(pendingUntilAborted)
+          .mockImplementationOnce(pendingUntilAborted)
+          .mockResolvedValueOnce(parsedAssertion);
+
+        const prepared = prepareFido2SignIn({
+          username: "alice",
+          mediation: "conditional",
+          credentialGetter,
+        });
+
+        await jest.advanceTimersByTimeAsync(
+          COGNITO_AUTH_SESSION_RENEWAL_INTERVAL_MS
+        );
+        await jest.advanceTimersByTimeAsync(
+          COGNITO_AUTH_SESSION_RENEWAL_INTERVAL_MS
+        );
+
+        await expect(prepared).resolves.toEqual(
+          expect.objectContaining({ session: "session-3" })
+        );
+        expect(mockInitiateAuth).toHaveBeenCalledTimes(3);
+        expect(credentialGetter).toHaveBeenCalledTimes(3);
+      });
+
+      it("does not renew when the credential resolves before the renewal interval", async () => {
+        mockInitiateAuth.mockResolvedValueOnce(challengeResponse(1));
+        const credentialGetter = jest.fn().mockResolvedValue(parsedAssertion);
+
+        const result = await prepareFido2SignIn({
+          username: "alice",
+          mediation: "conditional",
+          credentialGetter,
+        });
+
+        expect(result.session).toBe("session-1");
+        expect(mockInitiateAuth).toHaveBeenCalledTimes(1);
+        expect(credentialGetter).toHaveBeenCalledTimes(1);
+      });
+
+      it("propagates caller aborts instead of renewing", async () => {
+        mockInitiateAuth.mockResolvedValueOnce(challengeResponse(1));
+        const credentialGetter = jest
+          .fn()
+          .mockImplementationOnce(pendingUntilAborted);
+        const abortController = new AbortController();
+
+        const prepared = prepareFido2SignIn({
+          username: "alice",
+          mediation: "conditional",
+          credentialGetter,
+          signal: abortController.signal,
+        });
+
+        // Let the flow reach the pending credential request, then abort
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        abortController.abort();
+
+        await expect(prepared).rejects.toThrow(Fido2AbortError);
+        expect(mockInitiateAuth).toHaveBeenCalledTimes(1);
+        expect(credentialGetter).toHaveBeenCalledTimes(1);
+      });
+
+      it("passes the caller signal straight through for non-conditional mediation", async () => {
+        mockInitiateAuth.mockResolvedValueOnce(challengeResponse(1));
+        const credentialGetter = jest.fn().mockResolvedValue(parsedAssertion);
+        const abortController = new AbortController();
+
+        await prepareFido2SignIn({
+          username: "alice",
+          mediation: "immediate",
+          credentialGetter,
+          signal: abortController.signal,
+        });
+
+        expect(credentialGetter.mock.calls[0][0].signal).toBe(
+          abortController.signal
+        );
+      });
     });
 
     it("rejects authenticateWithFido2 when provided username mismatches prepared bundle", async () => {

--- a/client/fido2.ts
+++ b/client/fido2.ts
@@ -37,6 +37,7 @@ import {
   Fido2ValidationError,
   Fido2AuthError,
   fromDOMException,
+  isFido2AbortError,
 } from "./errors.js";
 
 // Enhanced type definitions for mediation support
@@ -206,10 +207,28 @@ export interface ParsedFido2Assertion {
 
 export interface PreparedFido2SignIn {
   username: string;
+  /**
+   * Cognito session for the CUSTOM_AUTH challenge. Note: Cognito invalidates
+   * this session after `AuthSessionValidity` minutes (3 by default), so pass
+   * the prepared bundle to authenticateWithFido2() promptly after it resolves.
+   */
   session: string;
   credential: ParsedFido2Assertion;
   existingDeviceKey?: string;
 }
+
+/**
+ * How long to let a conditional-mediation (autofill) credential request stay
+ * pending on a single Cognito CUSTOM_AUTH session before renewing the session.
+ *
+ * Cognito invalidates a challenge session after `AuthSessionValidity` minutes
+ * (3 by default, configurable 3-15), whereas a conditional
+ * navigator.credentials.get() may stay pending indefinitely, until the user
+ * picks an autofill suggestion. Renewing slightly below the minimum session
+ * validity ensures the assertion is always signed over a challenge whose
+ * Cognito session is still valid.
+ */
+export const COGNITO_AUTH_SESSION_RENEWAL_INTERVAL_MS = 150_000; // 2.5 minutes
 
 type AuthenticatorAttestationResponseWithOptionalMembers =
   AuthenticatorAttestationResponse & {
@@ -858,6 +877,14 @@ async function requestUsernamelessSignInChallenge() {
  *
  * Password managers typically store usernames, so username-based flow is recommended.
  *
+ * **Session validity**: Cognito invalidates a challenge session after
+ * `AuthSessionValidity` minutes (3 by default). For the username-based flow with
+ * conditional mediation, this function transparently renews the session (and its
+ * FIDO2 challenge) while the autofill request is pending, so users can pick a
+ * passkey from autofill long after page load. Once the returned promise resolves
+ * though, the contained session is subject to expiry: pass the prepared bundle
+ * to authenticateWithFido2() promptly.
+ *
  * @example
  * ```typescript
  * // ✅ Recommended: Fast path with username
@@ -927,47 +954,124 @@ export async function prepareFido2SignIn({
       mediation,
     });
 
+    const usernameForAuth = resolvedUsername;
     existingDeviceKey = await retrieveDeviceKey(resolvedUsername);
-    const initAuthResponse = await initiateAuth({
-      authflow: "CUSTOM_AUTH",
-      authParameters: {
-        USERNAME: resolvedUsername,
-        ...(existingDeviceKey ? { DEVICE_KEY: existingDeviceKey } : {}),
-      },
-      abort: signal,
-    });
+    const deviceKeyForAuth = existingDeviceKey;
 
-    assertIsChallengeResponse(initAuthResponse);
-    if (!initAuthResponse.ChallengeParameters.fido2options) {
-      throw new Error("Server did not send a FIDO2 challenge");
+    const initiateFido2Challenge = async () => {
+      const initAuthResponse = await initiateAuth({
+        authflow: "CUSTOM_AUTH",
+        authParameters: {
+          USERNAME: usernameForAuth,
+          ...(deviceKeyForAuth ? { DEVICE_KEY: deviceKeyForAuth } : {}),
+        },
+        abort: signal,
+      });
+
+      assertIsChallengeResponse(initAuthResponse);
+      if (!initAuthResponse.ChallengeParameters.fido2options) {
+        throw new Error("Server did not send a FIDO2 challenge");
+      }
+
+      const fido2options: unknown = JSON.parse(
+        initAuthResponse.ChallengeParameters.fido2options
+      );
+      assertIsFido2Options(fido2options);
+      debug?.("FIDO2 challenge received from Cognito");
+      return { fido2options, session: initAuthResponse.Session };
+    };
+
+    const getCredentialForChallenge = (
+      fido2options: Fido2Options,
+      credentialSignal?: AbortSignal
+    ) =>
+      credentialGetter({
+        ...fido2options,
+        relyingPartyId: fido2.rp?.id ?? fido2options.relyingPartyId,
+        timeout: fido2.timeout ?? fido2options.timeout,
+        userVerification:
+          fido2.authenticatorSelection?.userVerification ??
+          fido2options.userVerification,
+        credentials: (fido2options.credentials ?? []).concat(
+          credentials?.filter(
+            (cred) =>
+              !fido2options.credentials?.find(
+                (optionsCred) => cred.id === optionsCred.id
+              )
+          ) ?? []
+        ),
+        mediation,
+        signal: credentialSignal,
+      });
+
+    if (mediation === "conditional") {
+      // Conditional mediation is "set and forget": the pending
+      // navigator.credentials.get() only resolves when the user eventually
+      // picks an autofill suggestion, which can easily take longer than the
+      // Cognito auth session stays valid (AuthSessionValidity, 3 minutes by
+      // default). Proactively renew the session (and the FIDO2 challenge that
+      // comes with it) before it expires, by aborting the pending conditional
+      // request and restarting it with the fresh challenge. Pending
+      // conditional requests show no UI, so renewal is invisible to the user.
+      const RENEW_SESSION = Symbol("renew-session");
+      for (;;) {
+        const challenge = await initiateFido2Challenge();
+        const renewalAbort = new AbortController();
+        const forwardAbort = () => renewalAbort.abort();
+        if (signal?.aborted) {
+          renewalAbort.abort();
+        } else {
+          signal?.addEventListener("abort", forwardAbort, { once: true });
+        }
+        let renewalTimer: ReturnType<typeof setTimeout> | undefined;
+        const credentialPromise = getCredentialForChallenge(
+          challenge.fido2options,
+          renewalAbort.signal
+        );
+        try {
+          const raceOutcome = await Promise.race([
+            credentialPromise,
+            new Promise<typeof RENEW_SESSION>((resolve) => {
+              renewalTimer = setTimeout(
+                () => resolve(RENEW_SESSION),
+                COGNITO_AUTH_SESSION_RENEWAL_INTERVAL_MS
+              );
+            }),
+          ]);
+          if (raceOutcome !== RENEW_SESSION) {
+            assertion = raceOutcome;
+            session = challenge.session;
+            break;
+          }
+          debug?.(
+            "🔄 Cognito auth session nearing expiry while conditional request pending - renewing challenge"
+          );
+          renewalAbort.abort();
+          try {
+            // The user may have picked a credential just as the renewal timer
+            // fired - if so, the current session is still valid, use it
+            assertion = await credentialPromise;
+            session = challenge.session;
+            break;
+          } catch (err) {
+            if (!isFido2AbortError(err) || signal?.aborted) {
+              throw err;
+            }
+            // Aborted by us for renewal - loop around for a fresh challenge
+          }
+        } finally {
+          clearTimeout(renewalTimer);
+          signal?.removeEventListener("abort", forwardAbort);
+        }
+      }
+    } else {
+      const challenge = await initiateFido2Challenge();
+      assertion = await getCredentialForChallenge(
+        challenge.fido2options,
+        signal
+      );
+      session = challenge.session;
     }
-
-    const fido2options: unknown = JSON.parse(
-      initAuthResponse.ChallengeParameters.fido2options
-    );
-    assertIsFido2Options(fido2options);
-    debug?.("FIDO2 challenge received from Cognito");
-
-    assertion = await credentialGetter({
-      ...fido2options,
-      relyingPartyId: fido2.rp?.id ?? fido2options.relyingPartyId,
-      timeout: fido2.timeout ?? fido2options.timeout,
-      userVerification:
-        fido2.authenticatorSelection?.userVerification ??
-        fido2options.userVerification,
-      credentials: (fido2options.credentials ?? []).concat(
-        credentials?.filter(
-          (cred) =>
-            !fido2options.credentials?.find(
-              (optionsCred) => cred.id === optionsCred.id
-            )
-        ) ?? []
-      ),
-      mediation,
-      signal,
-    });
-
-    session = initAuthResponse.Session;
   }
   // ⚠️ Flow 2: Usernameless - SLOWER but works when username unknown
   // Only use this when password manager doesn't have username stored
@@ -1142,6 +1246,8 @@ export function authenticateWithFido2({
    * Optional pre-fetched WebAuthn assertion bundle returned by prepareFido2SignIn().
    * When provided, authenticateWithFido2() will skip navigator.credentials.get()
    * and directly complete the Cognito challenge using this data.
+   * Note: the bundle's Cognito session expires after `AuthSessionValidity`
+   * minutes (3 by default), so use it promptly after preparation.
    */
   prepared?: PreparedFido2SignIn;
 }) {


### PR DESCRIPTION
## Summary
Fixes the conditional-mediation (autofill) FIDO2 fast path so that users who pick an autofill passkey more than ~3 minutes after page load no longer fail sign-in with an expired Cognito session. While the conditional `navigator.credentials.get()` is pending, the library now proactively renews the Cognito CUSTOM_AUTH session (and its FIDO2 challenge) before it expires.

## Finding
- **Severity**: HIGH (externally validated)
- **Confidence**: High
- **Where**: `client/fido2.ts` — `prepareFido2SignIn` username flow (previously lines 924-970), recommended at page load by the docstring (lines 851-874); conditional timeout deliberately stripped around line 706.
- **Failure scenario**: `prepareFido2SignIn({ username, mediation: "conditional" })` calls `initiateAuth` (CUSTOM_AUTH) first, obtaining the FIDO2 challenge and a Cognito Session, then awaits a set-and-forget conditional `credentials.get()` that resolves only when the user eventually picks an autofill suggestion. Cognito's `AuthSessionValidity` is 3 minutes by default (configurable 3-15). Any user selecting their passkey from autofill more than ~3 minutes after page load completes the WebAuthn ceremony successfully and then fails at `respondToAuthChallenge` with an expired session — surfaced as `FIDO2_SIGNIN_FAILED` after the user did everything right.
- **Constraint**: the assertion signs over the challenge delivered in the Cognito custom challenge, so the flow cannot simply re-initiate after the assertion resolves — a new session comes with a new challenge that invalidates the old assertion.

## Fix
Proactive session renewal loop for the conditional path in the username flow of `prepareFido2SignIn`:
- A named constant `COGNITO_AUTH_SESSION_RENEWAL_INTERVAL_MS` (2.5 minutes, safely below the 3-minute minimum session validity) bounds how long a single session is used while the conditional request is pending.
- When the interval elapses with the request still pending, the pending conditional `credentials.get()` is aborted via an internal `AbortController`, `initiateAuth` is re-run for a fresh challenge + session, and the conditional request restarts with the new challenge. Pending conditional requests show no UI, so renewal is invisible to the user.
- The loop stops when the credential resolves (including a credential that lands just as the renewal timer fires — the still-valid current session is used), on any non-abort error, or when the caller's `AbortSignal` fires (caller aborts are forwarded to the internal controller and propagate as before).
- Non-conditional mediation behavior is unchanged: the caller signal is passed straight through and no renewal loop runs.
- Documented the `AuthSessionValidity` constraint on `PreparedFido2SignIn.session`, the `prepared` parameter of `authenticateWithFido2`, and in the `prepareFido2SignIn` docstring.

## Test plan
New regression tests in `client/__tests__/fido2-core.test.ts` (jest fake timers + mocked `initiateAuth`/credential getter):
- renews the session with a fresh challenge when the conditional request outlives the renewal interval (asserts second `initiateAuth`, fresh challenge passed to the restarted getter, final bundle carries the fresh session)
- renews repeatedly while the request stays pending across multiple intervals
- does not renew when the credential resolves before the interval
- propagates caller aborts (rejects with `Fido2AbortError`, no renewal)
- passes the caller signal straight through for non-conditional mediation

Verification gates, all green:
- `npx tsc --project client/tsconfig.json --noEmit`
- `npx eslint client/fido2.ts client/__tests__/fido2-core.test.ts`
- `npx jest client/__tests__/` — 10 suites, 131 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core FIDO2 sign-in timing and CUSTOM_AUTH session handling; behavior change is scoped to conditional mediation with username, with regression tests and unchanged non-conditional paths.
> 
> **Overview**
> Fixes conditional (autofill) passkey sign-in when users pick a passkey long after page load: Cognito CUSTOM_AUTH sessions expire in ~3 minutes while conditional `credentials.get()` can stay pending indefinitely, so sign-in used to fail after a valid WebAuthn ceremony.
> 
> For the **username + `mediation: "conditional"`** path in `prepareFido2SignIn`, the library now runs a renewal loop bounded by **`COGNITO_AUTH_SESSION_RENEWAL_INTERVAL_MS`** (2.5 minutes). When that interval elapses with the autofill request still pending, it aborts the in-flight credential request, re-runs `initiateAuth` for a fresh FIDO2 challenge and session, and restarts conditional `credentials.get()` with the new challenge. Caller aborts still propagate; non-conditional mediation is unchanged (caller `AbortSignal` passed through, no loop). Docs note **`AuthSessionValidity`** on prepared bundles and `authenticateWithFido2`.
> 
> Tests cover single and repeated renewal, no renewal when the credential resolves early, caller abort behavior, and non-conditional signal forwarding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b6af4149208e7dbdafc1f076858e2c4957d3cdd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->