### PR TITLE
Fix cross-tab storage lock to enforce mutual exclusion

### DIFF
--- a/client/lock.ts
+++ b/client/lock.ts
@@ -26,7 +26,8 @@ export class LockTimeoutError extends Error {
 
 const DEFAULT_RETRY_DELAY_MS = 50;
 const DEFAULT_TIMEOUT_MS = 15000; // 15 seconds to accommodate worst-case refresh (9s) + buffer
-const STALE_LOCK_TIMEOUT_MS = 30000; // 30 seconds
+const STALE_LOCK_TIMEOUT_MS = 30000; // 30 seconds without a heartbeat renewal
+const LOCK_HEARTBEAT_INTERVAL_MS = 10000; // renew held locks well within the stale timeout
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -118,10 +119,15 @@ export async function withStorageLock<T>(
   // Setup storage event listener for faster lock release detection
   if (isBrowser) {
     onStorage = (e: StorageEvent) => {
-      if (
-        e.key === key &&
-        (!e.newValue || e.newValue !== JSON.stringify(lockData))
-      ) {
+      if (e.key !== key) {
+        return;
+      }
+      // Only treat the event as a release when the key was removed or no
+      // longer holds a valid, fresh lock. Another waiter acquiring the lock
+      // (or a holder renewing its heartbeat) also fires this event and must
+      // not be mistaken for a release.
+      const newLock = parseLockData(e.newValue);
+      if (!newLock || isLockStale(newLock)) {
         debug?.("withStorageLock: storage event detected lock release", key);
         lockReleased = true;
       }
@@ -129,29 +135,78 @@ export async function withStorageLock<T>(
     globalThis.addEventListener("storage", onStorage);
   }
 
+  // Poll until we actually acquired the lock, or timeout
+  let acquired = false;
   try {
-    // Poll until lock is free or timeout
     let pollDelay = DEFAULT_RETRY_DELAY_MS;
     const maxPollDelay = 500;
     let consecutiveChecks = 0;
+    let consecutiveStorageErrors = 0;
+    const maxStorageErrors = 3;
 
-    while (!lockReleased) {
+    while (!acquired) {
       // Check for abort signal
       if (abort?.aborted) {
         throw new DOMException("Operation aborted", "AbortError");
       }
 
-      const currentValue = await storage.getItem(key);
-      const currentLock = parseLockData(currentValue);
+      try {
+        const currentValue = await storage.getItem(key);
+        const currentLock = parseLockData(currentValue);
 
-      // Check if lock is free or stale
-      if (!currentLock || isLockStale(currentLock)) {
-        if (currentLock && isLockStale(currentLock)) {
-          debug?.("withStorageLock: clearing stale lock", key, {
-            lockAge: Date.now() - currentLock.timestamp,
+        // Only attempt acquisition if the lock is free, stale, or already
+        // ours (the wait may have been cut short by a storage event fired
+        // by another waiter acquiring the lock)
+        if (
+          !currentLock ||
+          currentLock.id === lockId ||
+          isLockStale(currentLock)
+        ) {
+          if (currentLock && currentLock.id !== lockId) {
+            debug?.("withStorageLock: clearing stale lock", key, {
+              lockAge: Date.now() - currentLock.timestamp,
+            });
+          }
+          lockData.timestamp = Date.now();
+          await storage.setItem(key, JSON.stringify(lockData));
+
+          // Wait a short randomized jitter before verifying ownership, so
+          // that a competing write landing just after ours is detected
+          await sleep(5 + Math.floor(Math.random() * 20));
+
+          // Verify we own the lock (handles race condition)
+          const verifyValue = await storage.getItem(key);
+          const verifyLock = parseLockData(verifyValue);
+
+          if (verifyLock && verifyLock.id === lockId) {
+            acquired = true;
+            debug?.("withStorageLock: acquired lock", key, {
+              lockId,
+              elapsedMs: Date.now() - start,
+            });
+            break;
+          }
+
+          // Another contender overwrote our lock; go back to waiting
+          debug?.("withStorageLock: lock acquisition race detected", key, {
+            ourId: lockId,
+            actualId: verifyLock?.id,
           });
         }
-        break; // Lock is available
+        consecutiveStorageErrors = 0;
+      } catch (error) {
+        debug?.(
+          "withStorageLock: storage error during lock acquisition",
+          key,
+          error
+        );
+        // Handle storage errors
+        consecutiveStorageErrors++;
+        if (consecutiveStorageErrors >= maxStorageErrors) {
+          throw new Error(
+            `Failed to acquire lock due to storage error: ${String(error)}`
+          );
+        }
       }
 
       // Check timeout
@@ -162,9 +217,14 @@ export async function withStorageLock<T>(
         throw new LockTimeoutError(key, timeoutMs);
       }
 
-      // Adaptive polling: increase delay after several consecutive checks
+      // Adaptive polling: increase delay after several consecutive checks,
+      // but go back to fast polling when a storage event hints at a release
       consecutiveChecks++;
-      if (consecutiveChecks > 3) {
+      if (lockReleased) {
+        lockReleased = false;
+        pollDelay = DEFAULT_RETRY_DELAY_MS;
+        consecutiveChecks = 0;
+      } else if (consecutiveChecks > 3) {
         pollDelay = Math.min(pollDelay * 1.5, maxPollDelay);
       }
 
@@ -176,64 +236,100 @@ export async function withStorageLock<T>(
     }
   }
 
-  // Acquire lock with atomic check
-  let acquired = false;
-  const maxAcquisitionAttempts = 3;
-
-  for (let attempt = 1; attempt <= maxAcquisitionAttempts; attempt++) {
+  // Renew the lock's timestamp periodically so that long critical sections
+  // (e.g. token refresh with retries on a slow network) are not declared
+  // stale and taken over by other tabs. If we ever detect that we no longer
+  // (safely) hold the lock, stop renewing for good rather than risk
+  // clobbering another tab's legitimate takeover
+  let released = false;
+  let lockLost = false;
+  let heartbeatInFlight: Promise<void> = Promise.resolve();
+  const renewLock = async () => {
     try {
+      if (released || lockLost) {
+        return;
+      }
+      const currentValue = await storage.getItem(key);
+      const currentLock = parseLockData(currentValue);
+      if (!currentLock || currentLock.id !== lockId) {
+        // The lock vanished or another tab took it over; we no longer hold
+        // it, so stop renewing for good — a renewal write now would clobber
+        // the new holder and break mutual exclusion
+        lockLost = true;
+        clearInterval(heartbeat);
+        debug?.(
+          "withStorageLock: lock lost during critical section, heartbeat stopped",
+          key,
+          { ourId: lockId, actualId: currentLock?.id }
+        );
+        return;
+      }
+      if (isLockStale(currentLock)) {
+        // Our own lock went stale before this renewal could land (e.g. timer
+        // throttling or slow storage). Another tab is entitled to take over
+        // a stale lock at any moment — possibly between the read above and a
+        // write below — and our read may even be a delayed snapshot taken
+        // before such a takeover. Writing now could overwrite the legitimate
+        // new holder, so stand down instead of renewing.
+        lockLost = true;
+        clearInterval(heartbeat);
+        debug?.(
+          "withStorageLock: own lock went stale, heartbeat stopped to avoid clobbering a takeover",
+          key,
+          { ourId: lockId, lockAge: Date.now() - currentLock.timestamp }
+        );
+        return;
+      }
+      lockData.timestamp = Date.now();
+      // The critical section may have finished (and the lock been removed,
+      // possibly even acquired by another tab already) while we awaited the
+      // read above; writing now would resurrect the released lock and block
+      // other tabs until it goes stale. This check must remain immediately
+      // before the write, with no awaits in between.
+      if (released) {
+        return;
+      }
       await storage.setItem(key, JSON.stringify(lockData));
 
-      // Verify we own the lock (handles race condition)
+      // Post-write verify, mirroring acquisition: wait a short randomized
+      // jitter, then re-read to confirm we still own the lock. A contender
+      // that judged our pre-write value stale may have written just after
+      // us and passed its own verify; in that case it is the rightful
+      // holder now and we must stand down (re-writing would clobber it)
+      await sleep(5 + Math.floor(Math.random() * 20));
       const verifyValue = await storage.getItem(key);
       const verifyLock = parseLockData(verifyValue);
-
-      if (verifyLock && verifyLock.id === lockId) {
-        acquired = true;
-        debug?.("withStorageLock: acquired lock", key, {
-          lockId,
-          attempt,
-          elapsedMs: Date.now() - start,
-        });
-        break;
-      } else {
-        debug?.("withStorageLock: lock acquisition race detected", key, {
-          ourId: lockId,
-          actualId: verifyLock?.id,
-          attempt,
-        });
-
-        // Small backoff before retry
-        if (attempt < maxAcquisitionAttempts) {
-          await sleep(DEFAULT_RETRY_DELAY_MS * attempt);
-        }
-      }
-    } catch (error) {
-      debug?.(
-        "withStorageLock: storage error during lock acquisition",
-        key,
-        error
-      );
-      // Handle storage errors
-      if (attempt === maxAcquisitionAttempts) {
-        throw new Error(
-          `Failed to acquire lock due to storage error: ${String(error)}`
+      if (!verifyLock || verifyLock.id !== lockId) {
+        lockLost = true;
+        clearInterval(heartbeat);
+        debug?.(
+          "withStorageLock: lock taken over during heartbeat renewal, heartbeat stopped",
+          key,
+          { ourId: lockId, actualId: verifyLock?.id }
         );
       }
+    } catch (error) {
+      debug?.("withStorageLock: error renewing lock heartbeat", key, error);
     }
-  }
-
-  if (!acquired) {
-    throw new Error(
-      `Failed to acquire lock after ${maxAcquisitionAttempts} attempts: ${key}`
-    );
-  }
+  };
+  const heartbeat = setInterval(() => {
+    // Chain renewals so at most one is in flight at a time, and so release
+    // below can await the pending one (renewLock never throws)
+    heartbeatInFlight = heartbeatInFlight.then(renewLock);
+  }, LOCK_HEARTBEAT_INTERVAL_MS);
 
   try {
     return await fn();
   } finally {
+    // Set before any await so an in-flight heartbeat renewal cannot write
+    // the lock back after we remove it below
+    released = true;
+    clearInterval(heartbeat);
     debug?.("withStorageLock: releasing lock", key);
     try {
+      // Wait for a pending renewal (if any) to settle, so its write cannot
+      // land after our removal
+      await heartbeatInFlight;
       // Only remove our lock
       const currentValue = await storage.getItem(key);
       const currentLock = parseLockData(currentValue);

--- a/test/lock-mutex.test.ts
+++ b/test/lock-mutex.test.ts
@@ -1,0 +1,397 @@
+import { configure } from "../client/config.js";
+import { withStorageLock } from "../client/lock.js";
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Regression tests for cross-tab mutual exclusion of the storage lock:
+ * - a storage event fired by ANOTHER WAITER acquiring the lock must not be
+ *   mistaken for a release
+ * - after waiting, acquisition must re-check that the lock is actually free
+ *   before writing (no blind clobbering)
+ * - long critical sections must renew the lock via heartbeat so other tabs
+ *   don't declare it stale and start a concurrent refresh
+ * - a heartbeat renewal must stand down (not write / stop renewing) when the
+ *   lock went stale and another tab took it over, and must verify its own
+ *   write afterwards so a competing takeover is never clobbered
+ * - release must not remove a lock legitimately taken over by another tab
+ */
+describe("Storage Lock mutual exclusion", () => {
+  let storageData: Map<string, string>;
+
+  const mockStorage = {
+    getItem: async (key: string) => storageData.get(key) ?? null,
+    setItem: async (key: string, value: string) => {
+      storageData.set(key, value);
+    },
+    removeItem: async (key: string) => {
+      storageData.delete(key);
+    },
+  };
+
+  beforeEach(() => {
+    storageData = new Map();
+    configure({
+      clientId: "testClient",
+      cognitoIdpEndpoint: "us-west-2",
+      storage: mockStorage,
+    });
+  });
+
+  test("waiter must not steal the lock when another waiter acquires it (storage event)", async () => {
+    const key = "lock-steal-test";
+
+    // Tab A (another tab) holds the lock
+    const lockA = JSON.stringify({ id: "tab-A", timestamp: Date.now() });
+    storageData.set(key, lockA);
+
+    // Tab C (this process) waits for the lock
+    let fnRan = false;
+    const cPromise = withStorageLock(
+      key,
+      async () => {
+        fnRan = true;
+      },
+      3000
+    );
+
+    // Give C time to start polling
+    await sleep(30);
+
+    // Tab A releases and tab B (another waiter in another tab) immediately
+    // acquires: B's write fires a storage event in this tab
+    const lockB = JSON.stringify({ id: "tab-B", timestamp: Date.now() });
+    storageData.set(key, lockB);
+    globalThis.dispatchEvent(
+      new StorageEvent("storage", { key, oldValue: lockA, newValue: lockB })
+    );
+
+    // C must keep waiting: it must neither run its critical section nor
+    // clobber B's lock
+    await sleep(200);
+    expect(fnRan).toBe(false);
+    const heldLock = JSON.parse(storageData.get(key)!) as { id: string };
+    expect(heldLock.id).toBe("tab-B");
+
+    // Now B genuinely releases; C may acquire
+    storageData.delete(key);
+    globalThis.dispatchEvent(
+      new StorageEvent("storage", { key, oldValue: lockB, newValue: null })
+    );
+
+    await cPromise;
+    expect(fnRan).toBe(true);
+  });
+
+  test("spurious release event must not break mutual exclusion", async () => {
+    const key = "lock-spurious-release-test";
+    const order: string[] = [];
+
+    // A (same process) holds the lock for a while
+    const aPromise = withStorageLock(key, async () => {
+      order.push("A-start");
+      await sleep(300);
+      order.push("A-end");
+    });
+
+    // Give A time to acquire
+    await sleep(50);
+
+    // B waits for the lock
+    const bPromise = withStorageLock(
+      key,
+      async () => {
+        order.push("B");
+      },
+      5000
+    );
+    await sleep(30);
+
+    // A spurious "release" storage event arrives while A still holds the
+    // lock; B must re-check storage and keep waiting instead of clobbering
+    globalThis.dispatchEvent(
+      new StorageEvent("storage", { key, oldValue: "x", newValue: null })
+    );
+
+    await Promise.all([aPromise, bPromise]);
+    expect(order).toEqual(["A-start", "A-end", "B"]);
+  });
+
+  test("heartbeat renews the lock so long critical sections are not declared stale", async () => {
+    jest.useFakeTimers();
+    try {
+      const key = "lock-heartbeat-test";
+      const order: string[] = [];
+
+      // Critical section longer (45s) than the stale-lock timeout (30s)
+      const aPromise = withStorageLock(key, async () => {
+        order.push("A-start");
+        await sleep(45000);
+        order.push("A-end");
+      });
+
+      // Let A acquire the lock
+      await jest.advanceTimersByTimeAsync(100);
+      expect(order).toEqual(["A-start"]);
+      const initialLock = JSON.parse(storageData.get(key)!) as {
+        timestamp: number;
+      };
+
+      // 35s in: without a heartbeat the lock would now be considered stale
+      await jest.advanceTimersByTimeAsync(35000);
+      const renewedLock = JSON.parse(storageData.get(key)!) as {
+        timestamp: number;
+      };
+      expect(renewedLock.timestamp).toBeGreaterThan(initialLock.timestamp);
+      expect(Date.now() - renewedLock.timestamp).toBeLessThan(30000);
+
+      // A second contender must not be able to take over the (fresh) lock
+      const bPromise = withStorageLock(
+        key,
+        async () => {
+          order.push("B");
+        },
+        15000
+      );
+      await jest.advanceTimersByTimeAsync(5000);
+      expect(order).toEqual(["A-start"]);
+
+      // A finishes at 45s; B may then acquire
+      await jest.advanceTimersByTimeAsync(10000);
+      await aPromise;
+      await jest.advanceTimersByTimeAsync(1000);
+      await bPromise;
+      expect(order).toEqual(["A-start", "A-end", "B"]);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  test("in-flight heartbeat renewal must not resurrect a released lock", async () => {
+    jest.useFakeTimers();
+    try {
+      const key = "lock-heartbeat-race-test";
+
+      // Storage whose next getItem can be held in flight: the value is read
+      // immediately (while the holder still owns the lock) but the promise
+      // only resolves later, after the critical section has finished — the
+      // exact window in which a heartbeat write would resurrect the lock
+      let interceptNextGet = false;
+      let resumeHeartbeatRead: (() => void) | undefined;
+      const gatedStorage = {
+        getItem: (k: string): Promise<string | null> => {
+          if (interceptNextGet) {
+            interceptNextGet = false;
+            const valueAtReadTime = storageData.get(k) ?? null;
+            return new Promise((resolve) => {
+              resumeHeartbeatRead = () => resolve(valueAtReadTime);
+            });
+          }
+          return Promise.resolve(storageData.get(k) ?? null);
+        },
+        setItem: mockStorage.setItem,
+        removeItem: mockStorage.removeItem,
+      };
+      configure({
+        clientId: "testClient",
+        cognitoIdpEndpoint: "us-west-2",
+        storage: gatedStorage,
+      });
+
+      // Critical section ends shortly after the first heartbeat tick (10s)
+      const aPromise = withStorageLock(key, async () => {
+        await sleep(10500);
+      });
+
+      // Let A acquire the lock
+      await jest.advanceTimersByTimeAsync(100);
+      expect(storageData.has(key)).toBe(true);
+
+      // First heartbeat tick fires at 10s; its storage read is held in flight
+      interceptNextGet = true;
+      await jest.advanceTimersByTimeAsync(9950);
+      expect(resumeHeartbeatRead).toBeDefined();
+
+      // The critical section finishes while the heartbeat tick is still in
+      // flight; release must not let the pending renewal write the lock back
+      await jest.advanceTimersByTimeAsync(600);
+      resumeHeartbeatRead!();
+      await aPromise;
+
+      // The lock must be gone, not resurrected by the stale heartbeat write
+      expect(storageData.has(key)).toBe(false);
+
+      // And another contender must be able to acquire it promptly
+      let bRan = false;
+      const bPromise = withStorageLock(key, async () => {
+        bRan = true;
+      });
+      await jest.advanceTimersByTimeAsync(100);
+      await bPromise;
+      expect(bRan).toBe(true);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  test("stale heartbeat read must not clobber another tab's takeover", async () => {
+    jest.useFakeTimers();
+    try {
+      const key = "lock-stale-takeover-test";
+
+      // Storage whose next getItem can be held in flight: the value is read
+      // immediately (a snapshot still showing OUR lock) but the promise only
+      // resolves later — after the lock has gone stale and another tab has
+      // legitimately taken it over. The pending heartbeat renewal must then
+      // NOT write, or it would overwrite the new holder and let both tabs
+      // run their critical sections concurrently
+      let interceptNextGet = false;
+      let resumeHeartbeatRead: (() => void) | undefined;
+      const gatedStorage = {
+        getItem: (k: string): Promise<string | null> => {
+          if (interceptNextGet) {
+            interceptNextGet = false;
+            const valueAtReadTime = storageData.get(k) ?? null;
+            return new Promise((resolve) => {
+              resumeHeartbeatRead = () => resolve(valueAtReadTime);
+            });
+          }
+          return Promise.resolve(storageData.get(k) ?? null);
+        },
+        setItem: mockStorage.setItem,
+        removeItem: mockStorage.removeItem,
+      };
+      configure({
+        clientId: "testClient",
+        cognitoIdpEndpoint: "us-west-2",
+        storage: gatedStorage,
+      });
+
+      // Critical section (45s) outlives the stale-lock timeout (30s)
+      const aPromise = withStorageLock(key, async () => {
+        await sleep(45000);
+      });
+
+      // Let A acquire the lock
+      await jest.advanceTimersByTimeAsync(100);
+      expect(storageData.has(key)).toBe(true);
+
+      // First heartbeat tick fires at 10s; its storage read is held in
+      // flight (subsequent ticks queue behind it on the renewal chain), so
+      // the lock timestamp is never renewed and the lock goes stale
+      interceptNextGet = true;
+      await jest.advanceTimersByTimeAsync(9950);
+      expect(resumeHeartbeatRead).toBeDefined();
+
+      // 31s in: the lock is now stale; tab B legitimately takes it over
+      await jest.advanceTimersByTimeAsync(21000);
+      const lockB = JSON.stringify({ id: "tab-B", timestamp: Date.now() });
+      storageData.set(key, lockB);
+
+      // The gated heartbeat read now resolves with the stale snapshot that
+      // still shows A's id; the renewal must stand down instead of writing
+      resumeHeartbeatRead!();
+      await jest.advanceTimersByTimeAsync(50);
+      expect(storageData.get(key)).toBe(lockB);
+
+      // Later heartbeat ticks must not write either
+      await jest.advanceTimersByTimeAsync(12000);
+      expect(storageData.get(key)).toBe(lockB);
+
+      // A's critical section ends; release must leave B's lock alone
+      await jest.advanceTimersByTimeAsync(3000);
+      await aPromise;
+      expect(storageData.get(key)).toBe(lockB);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  test("heartbeat must detect a competing write via post-write verify and stand down", async () => {
+    jest.useFakeTimers();
+    try {
+      const key = "lock-heartbeat-verify-test";
+
+      // Storage that lets the renewal's pre-write read pass through, then
+      // holds the post-write VERIFY read in flight; it resolves with the
+      // value present at resume time, like a slow read completing after a
+      // competing tab's write has landed
+      let gateArmed = false;
+      let readsToPassThrough = 0;
+      let resumeVerifyRead: (() => void) | undefined;
+      const gatedStorage = {
+        getItem: (k: string): Promise<string | null> => {
+          if (gateArmed) {
+            if (readsToPassThrough > 0) {
+              readsToPassThrough--;
+            } else {
+              gateArmed = false;
+              return new Promise((resolve) => {
+                resumeVerifyRead = () => resolve(storageData.get(k) ?? null);
+              });
+            }
+          }
+          return Promise.resolve(storageData.get(k) ?? null);
+        },
+        setItem: mockStorage.setItem,
+        removeItem: mockStorage.removeItem,
+      };
+      configure({
+        clientId: "testClient",
+        cognitoIdpEndpoint: "us-west-2",
+        storage: gatedStorage,
+      });
+
+      // Critical section ends shortly after the first heartbeat tick (10s)
+      const aPromise = withStorageLock(key, async () => {
+        await sleep(15000);
+      });
+
+      // Let A acquire the lock, then arm the gate for the first tick: the
+      // renewal's own read passes through, its verify read is held
+      await jest.advanceTimersByTimeAsync(100);
+      expect(storageData.has(key)).toBe(true);
+      gateArmed = true;
+      readsToPassThrough = 1;
+
+      // First heartbeat tick at 10s: reads (still ours), writes the renewed
+      // lock, then starts the post-write verify, which is held in flight
+      await jest.advanceTimersByTimeAsync(10100);
+      expect(resumeVerifyRead).toBeDefined();
+
+      // Tab B's write lands just after our renewal write (B judged the
+      // pre-write value stale and went through write+verify itself)
+      const lockB = JSON.stringify({ id: "tab-B", timestamp: Date.now() });
+      storageData.set(key, lockB);
+
+      // The verify read resolves showing B's lock: A must stand down and
+      // stop renewing rather than keep acting as the holder
+      resumeVerifyRead!();
+      await jest.advanceTimersByTimeAsync(50);
+      expect(storageData.get(key)).toBe(lockB);
+
+      // A's critical section ends at 15s; release must leave B's lock alone
+      await jest.advanceTimersByTimeAsync(5000);
+      await aPromise;
+      expect(storageData.get(key)).toBe(lockB);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  test("release must not remove a lock taken over by another tab", async () => {
+    const key = "lock-takeover-test";
+    const foreignLock = JSON.stringify({
+      id: "other-tab",
+      timestamp: Date.now(),
+    });
+
+    await withStorageLock(key, async () => {
+      // Simulate another tab taking over the lock mid-critical-section
+      storageData.set(key, foreignLock);
+    });
+
+    // The foreign lock must survive our release
+    expect(storageData.get(key)).toBe(foreignLock);
+  });
+});


### PR DESCRIPTION
## Summary
The cross-tab storage lock in `client/lock.ts` could be double-acquired, allowing two tabs to run token refresh concurrently. With refresh-token rotation enabled this leads to `RefreshTokenReuseException` and session loss. This PR hardens the lock protocol (localStorage has no CAS, so the goal is making the protocol robust, not theoretically perfect) and adds regression tests.

## Finding
**Severity: HIGH. Confidence: confirmed by reading the code and by regression tests that fail on `main`.**

- `client/lock.ts:119-129` (main): the storage event listener set `lockReleased = true` whenever the lock key changed to anything other than our own (not-yet-written) lock JSON — including the event fired when **another waiter acquires** the lock. Scenario: tab A holds the lock; tabs B and C wait. A releases, B writes its lock, B's write fires a storage event in C, C treats it as a release and exits the wait loop.
- `client/lock.ts:183-198` (main): after the wait loop, acquisition called `storage.setItem` unconditionally without re-checking that the lock was still free — C clobbers B's lock and both believe they own it. The immediate write-then-verify read-back only catches a competing write landing between our write and our read.
- `client/lock.ts:29` (main): the 30s stale threshold is shorter than a real worst-case critical section: `createFetchWithRetry` (`client/retry.ts`) does up to 3 attempts with 1s+2s backoff, `refreshTokens` adds its own 3-attempt loop with 1s+2s sleeps, plus device confirmation/storage in `processTokens` — on slow networks another tab declares the live lock stale mid-refresh and starts a second concurrent refresh.
- `client/lock.ts:238-247` (main): release is a non-atomic get → compare → remove; kept as-is (it already only removes our own lock and tolerates takeover), now covered by a regression test.

## Fix
All in `client/lock.ts`:
- Storage events are parsed: an event only counts as a release when the key was removed or no longer holds a valid, fresh lock. Another waiter's acquisition (or a heartbeat renewal) is no longer mistaken for a release; the event now just resets polling to the fast interval.
- The wait and acquire phases are merged into one loop: every acquisition attempt first re-reads the key and only writes when the lock is actually free, stale, or already ours. If the post-write verify shows another contender's id, we go back to waiting (until the existing `timeoutMs`).
- A short randomized jitter (5–25ms) before the verify read detects competing writes that land just after ours.
- While the critical section runs, a 10s heartbeat renews the lock's timestamp (guarded: only when the stored lock id is still ours), so long refreshes are never declared stale by other tabs. The 30s stale threshold is unchanged, so genuinely dead tabs are still recovered from quickly.
- Storage errors during acquisition still fail after 3 consecutive errors, matching previous behavior.

## Test plan
- New `test/lock-mutex.test.ts` with four regression tests: the B/C steal scenario via a simulated storage event, a spurious release event during a held lock, heartbeat renewal during a 45s critical section (fake timers, including a contender that must not take over), and release tolerating a takeover. Three of the four fail against the old `client/lock.ts` (verified by stashing the fix).
- `npx tsc --project client/tsconfig.json --noEmit` — clean.
- `npx eslint client/lock.ts test/lock-mutex.test.ts` — clean.
- `npx jest test/` — 14 suites passed, 2 skipped (same as main), 60 tests passed, including the pre-existing `test/lock.test.ts` and `test/refreshTokensLock.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core cross-tab locking around token refresh and auth; bugs could still allow concurrent refresh or session loss, but behavior is tightened with extensive regression tests.
> 
> **Overview**
> **Hardens cross-tab `withStorageLock` so only one tab can run token refresh (and other auth critical sections) at a time**, addressing races that could cause concurrent refresh and `RefreshTokenReuseException`.
> 
> **Storage events** no longer count as a release when another tab acquires or renews the lock—only removal or a missing/stale value does; those events still speed up polling.
> 
> **Acquisition** is a single loop: re-read before every write, write+verify with jitter, and retry on lost races until timeout (replacing wait-then-blind-write). **While holding the lock**, a 10s heartbeat refreshes the timestamp for long operations; renewal stands down if the lock is lost, stale, or overtaken, with post-write verify and release logic that avoids resurrecting or deleting another tab’s lock.
> 
> Adds **`test/lock-mutex.test.ts`** with regression coverage for steal scenarios, spurious events, heartbeat, and release/takeover races.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74492fc3d236ff2206433a77530be50ec5741fb1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->