### PR TITLE
Fix refreshTokens/forceRefreshTokens failing when access token is already expired

### DIFF
--- a/client/refresh.ts
+++ b/client/refresh.ts
@@ -84,7 +84,9 @@ const TAB_ID =
 async function shouldAttemptRefresh(): Promise<boolean> {
   try {
     const { storage, clientId } = configure();
-    const tokens = await retrieveTokens();
+    // Use retrieveTokensForRefresh: the access token may already be expired,
+    // which is precisely when a refresh attempt matters most
+    const tokens = await retrieveTokensForRefresh();
     if (!tokens?.username) return false;
 
     const attemptKey = `Passwordless.${clientId}.${tokens.username}.lastRefreshAttempt`;
@@ -147,7 +149,9 @@ async function shouldAttemptRefresh(): Promise<boolean> {
 async function clearRefreshAttemptLock(): Promise<void> {
   try {
     const { storage, clientId } = configure();
-    const tokens = await retrieveTokens();
+    // Use retrieveTokensForRefresh: this runs on failure paths where the
+    // access token may be expired, but the lock must still be cleared
+    const tokens = await retrieveTokensForRefresh();
     if (!tokens?.username) return;
 
     const attemptKey = `Passwordless.${clientId}.${tokens.username}.lastRefreshAttempt`;
@@ -169,7 +173,7 @@ async function markRefreshCompleted(): Promise<void> {
   for (let attempt = 1; attempt <= maxRetries; attempt++) {
     try {
       const { storage, clientId } = configure();
-      const tokens = await retrieveTokens();
+      const tokens = await retrieveTokensForRefresh();
       if (!tokens?.username) return;
 
       const completedKey = `Passwordless.${clientId}.${tokens.username}.lastRefreshCompleted`;
@@ -591,7 +595,9 @@ export async function refreshTokens({
   const { clientId } = configure();
   let userIdentifier: string | undefined = tokens?.username;
   if (!userIdentifier) {
-    const storedTokens = await retrieveTokens();
+    // Use retrieveTokensForRefresh: the access token may already be expired
+    // (e.g. device woke from sleep), but the refresh token can still be valid
+    const storedTokens = await retrieveTokensForRefresh();
     userIdentifier = storedTokens?.username;
   }
   if (!userIdentifier) {
@@ -619,7 +625,8 @@ export async function refreshTokens({
       isRefreshingCb?.(true);
 
       if (!tokens) {
-        tokens = await retrieveTokens();
+        // Use retrieveTokensForRefresh to include expired tokens
+        tokens = await retrieveTokensForRefresh();
       }
 
       const refreshToken = tokens?.refreshToken;
@@ -697,7 +704,7 @@ export async function refreshTokens({
                   debug?.(
                     "Refresh token reuse detected; retrying with latest stored refresh token"
                   );
-                  const latestStored = await retrieveTokens();
+                  const latestStored = await retrieveTokensForRefresh();
                   const latestToken = latestStored?.refreshToken;
                   if (latestToken && latestToken !== currentRefreshToken) {
                     currentRefreshToken = latestToken;
@@ -929,8 +936,9 @@ export async function forceRefreshTokens(
 ): Promise<TokensFromRefresh> {
   logDebug("Forcing immediate token refresh");
 
-  // Get username to clear the right timer
-  const tokens = await retrieveTokens();
+  // Get username to clear the right timer (include expired tokens, since
+  // forcing a refresh is most relevant when the access token already expired)
+  const tokens = await retrieveTokensForRefresh();
   const username = tokens?.username;
   const state = getRefreshState(username);
 

--- a/test/refresh-expired-bug.test.ts
+++ b/test/refresh-expired-bug.test.ts
@@ -1,5 +1,10 @@
 import { configure } from "../client/config.js";
-import { scheduleRefresh } from "../client/refresh.js";
+import {
+  scheduleRefresh,
+  refreshTokens,
+  forceRefreshTokens,
+  cleanupRefreshSystem,
+} from "../client/refresh.js";
 import { storeTokens, retrieveTokens } from "../client/storage.js";
 
 // Helper to create JWT tokens
@@ -188,5 +193,147 @@ describe("CRITICAL BUG: Expired Token Handling", () => {
     console.log(
       "User had a valid refresh token but it was dropped with the expired access token!"
     );
+  });
+});
+
+describe("REGRESSION: refreshTokens/forceRefreshTokens with expired access token", () => {
+  let fetchMock: jest.Mock;
+  let debugLogs: string[] = [];
+  let storageData: Map<string, string>;
+
+  const storeExpiredSession = async () => {
+    const now = Date.now();
+    await storeTokens({
+      accessToken: createJWT({
+        sub: "user123",
+        username: "testuser",
+        exp: Math.floor((now - 600000) / 1000), // Expired 10 minutes ago
+        iat: Math.floor((now - 4200000) / 1000),
+      }),
+      refreshToken: "still-valid-refresh-token",
+      username: "testuser",
+      expireAt: new Date(now - 600000),
+    });
+  };
+
+  const mockSuccessfulRefresh = () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        AuthenticationResult: {
+          AccessToken: createJWT({
+            sub: "user123",
+            username: "testuser",
+            exp: Math.floor((Date.now() + 3600000) / 1000),
+            iat: Math.floor(Date.now() / 1000),
+          }),
+          IdToken: createJWT({
+            sub: "user123",
+            email: "test@example.com",
+            exp: Math.floor((Date.now() + 3600000) / 1000),
+            iat: Math.floor(Date.now() / 1000),
+          }),
+          RefreshToken: "new-refresh-token",
+          ExpiresIn: 3600,
+          TokenType: "Bearer",
+        },
+      }),
+    });
+  };
+
+  beforeEach(() => {
+    storageData = new Map<string, string>();
+    fetchMock = jest.fn();
+    debugLogs = [];
+
+    configure({
+      clientId: "testClient",
+      cognitoIdpEndpoint: "us-west-2",
+      fetch: fetchMock,
+      storage: {
+        getItem: (key: string) => Promise.resolve(storageData.get(key) ?? null),
+        setItem: (key: string, value: string) => {
+          storageData.set(key, value);
+          return Promise.resolve();
+        },
+        removeItem: (key: string) => {
+          storageData.delete(key);
+          return Promise.resolve();
+        },
+      },
+      debug: (...args: unknown[]) => {
+        debugLogs.push(args.map(String).join(" "));
+      },
+    });
+  });
+
+  afterEach(() => {
+    cleanupRefreshSystem();
+  });
+
+  test("refreshTokens() with no args refreshes an expired session", async () => {
+    await storeExpiredSession();
+    mockSuccessfulRefresh();
+
+    // Must not throw "Cannot determine user identity for refresh lock":
+    // the expired access token must not hide the valid refresh token
+    const refreshed = await refreshTokens();
+
+    expect(refreshed.username).toBe("testuser");
+    expect(refreshed.refreshToken).toBe("new-refresh-token");
+    expect(refreshed.expireAt.valueOf()).toBeGreaterThan(Date.now());
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("forceRefreshTokens() with no args refreshes an expired session", async () => {
+    await storeExpiredSession();
+    mockSuccessfulRefresh();
+
+    const refreshed = await forceRefreshTokens();
+
+    expect(refreshed.username).toBe("testuser");
+    expect(refreshed.refreshToken).toBe("new-refresh-token");
+    expect(refreshed.expireAt.valueOf()).toBeGreaterThan(Date.now());
+  });
+
+  test("RefreshTokenReuseException recovery retries with latest stored refresh token even when access token is expired", async () => {
+    const now = Date.now();
+    await storeExpiredSession();
+
+    // Caller passes stale tokens (e.g. captured before another tab rotated
+    // the refresh token); storage holds the latest refresh token
+    const staleTokens = {
+      accessToken: createJWT({
+        sub: "user123",
+        username: "testuser",
+        exp: Math.floor((now - 600000) / 1000),
+        iat: Math.floor((now - 4200000) / 1000),
+      }),
+      refreshToken: "stale-rotated-out-refresh-token",
+      username: "testuser",
+      expireAt: new Date(now - 600000),
+    };
+
+    // First attempt with the stale token fails with reuse exception
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+      json: async () => ({
+        __type: "RefreshTokenReuseException",
+        message: "Refresh token has been revoked",
+      }),
+    });
+    // Retry with the latest stored token succeeds
+    mockSuccessfulRefresh();
+
+    const refreshed = await refreshTokens({ tokens: staleTokens, force: true });
+
+    expect(refreshed.refreshToken).toBe("new-refresh-token");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    // Second call must use the refresh token from storage, not the stale one
+    const secondCallBody = JSON.parse(
+      (fetchMock.mock.calls[1][1] as { body: string }).body
+    ) as { RefreshToken: string };
+    expect(secondCallBody.RefreshToken).toBe("still-valid-refresh-token");
   });
 });


### PR DESCRIPTION
## Summary
`refreshTokens()` and `forceRefreshTokens()` (called with no `tokens` argument) failed with "Cannot determine user identity for refresh lock" precisely when the stored access token had already expired — the single most important moment to refresh. The refresh-path call sites now use `retrieveTokensForRefresh()`, which does not gate on access-token expiry.

## Finding
- Severity: HIGH; Confidence: confirmed by code reading and failing regression tests on `main`.
- `retrieveTokens()` (client/storage.ts:294-299) deliberately returns `undefined` when the stored access token's `exp` is in the past.
- `refreshTokens()` used it to resolve the username for the refresh lock (client/refresh.ts:594 on main) and to load the refresh token (client/refresh.ts:622), so an expired access token caused a hard throw even with a perfectly valid refresh token in storage.
- The `RefreshTokenReuseException` recovery (client/refresh.ts:700) had the same flaw: `retrieveTokens()` returns `undefined` for the just-expired session, so the retry-with-latest-token branch could never trigger when it mattered.
- `shouldAttemptRefresh()` (client/refresh.ts:87), `clearRefreshAttemptLock()` (client/refresh.ts:152), and `markRefreshCompleted()` (client/refresh.ts:173) shared the flaw, making the non-force path fail with "Another tab is handling refresh" and leaving stale cross-tab coordination locks for expired sessions.
- Concrete failure scenario: laptop sleeps past token expiry → app gets a 401 → calls the public `forceRefreshTokens()` → hard failure → user logged out, despite holding a valid refresh token.

## Fix
Switch the refresh-subsystem call sites in client/refresh.ts from `retrieveTokens()` to `retrieveTokensForRefresh()` (same `TokensFromStorage` shape, but does not drop tokens whose access token is expired):
- lock-user lookup and token load in `refreshTokens()`
- `RefreshTokenReuseException` recovery (retry with latest stored refresh token)
- `shouldAttemptRefresh()`, `clearRefreshAttemptLock()`, `markRefreshCompleted()` cross-tab coordination helpers
- `forceRefreshTokens()` timer-owner lookup

Read-only call sites that already degrade gracefully (`scheduleRefresh` wrapper, the wait-for-other-tab access-token comparison) are left untouched to keep the diff focused.

## Test plan
- Added three regression tests to test/refresh-expired-bug.test.ts (expired access token + valid refresh token in storage, network mocked):
  - `refreshTokens()` with no args refreshes the expired session
  - `forceRefreshTokens()` with no args refreshes the expired session
  - reuse-exception recovery retries with the latest stored refresh token while the access token is expired
- Verified all three fail on unfixed `main` and pass with the fix.
- Gates: `npx tsc --project client/tsconfig.json --noEmit` clean; `npx eslint client/refresh.ts test/refresh-expired-bug.test.ts` clean; `npx jest test/` → 13 suites passed, 2 skipped; 59 passed, 19 skipped, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core auth refresh and multi-tab coordination; behavior change is intentional but affects session recovery on 401/sleep paths.
> 
> **Overview**
> **Fixes session recovery when the access token is already expired** — the case where refresh matters most (e.g. device wake, 401 handler calling `forceRefreshTokens()`).
> 
> Refresh coordination and token loading in `client/refresh.ts` now use **`retrieveTokensForRefresh()`** instead of **`retrieveTokens()`**, which intentionally drops sessions whose access JWT is past `exp`. That change covers lock username resolution and token load in **`refreshTokens()`** / **`forceRefreshTokens()`**, cross-tab helpers (`shouldAttemptRefresh`, `clearRefreshAttemptLock`, `markRefreshCompleted`), and **`RefreshTokenReuseException`** retry logic so storage can still supply the latest refresh token.
> 
> Adds regression tests in **`test/refresh-expired-bug.test.ts`** for no-arg **`refreshTokens()`** / **`forceRefreshTokens()`** with an expired access token plus valid refresh token, and for reuse-exception recovery using the stored refresh token.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 963f74b2a2e25feaada5d958163000c44df5a035. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->