### PR TITLE
Require hostedUi.domain for OAuth2 endpoints instead of broken cognitoIdpEndpoint fallback

### DIFF
--- a/client/__tests__/oauth-endpoints.test.ts
+++ b/client/__tests__/oauth-endpoints.test.ts
@@ -1,0 +1,237 @@
+/**
+ * Copyright Amazon.com, Inc. and its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You
+ * may not use this file except in compliance with the License. A copy of
+ * the License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+import {
+  configure,
+  getAuthorizeEndpoint,
+  getTokenEndpoint,
+} from "../config.js";
+
+describe("OAuth2 endpoints (Hosted UI domain)", () => {
+  const redirectSignIn = "https://app.example.com/signin-redirect";
+
+  describe("configure", () => {
+    it("throws when hostedUi is configured without domain and cognitoIdpEndpoint is a region", () => {
+      expect(() =>
+        configure({
+          cognitoIdpEndpoint: "eu-west-1",
+          clientId: "test-client-id",
+          hostedUi: {
+            redirectSignIn,
+          },
+        })
+      ).toThrow("hostedUi.domain is required");
+    });
+
+    it("throws when hostedUi is configured without domain and cognitoIdpEndpoint is an https:// prefixed region", () => {
+      // https://eu-west-1 is not a usable OAuth2 origin: it is just the bare
+      // AWS region with a scheme glued on, not a real custom URL
+      const previous = configure({
+        cognitoIdpEndpoint: "eu-west-1",
+        clientId: "previous-client-id",
+      });
+      expect(() =>
+        configure({
+          cognitoIdpEndpoint: "https://eu-west-1",
+          clientId: "rejected-client-id",
+          hostedUi: {
+            redirectSignIn,
+          },
+        })
+      ).toThrow("hostedUi.domain is required");
+      // The failed configure() must not have touched the loaded configuration
+      const current = configure();
+      expect(current).toBe(previous);
+      expect(current.clientId).toBe("previous-client-id");
+    });
+
+    it("throws when hostedUi is configured without domain and cognitoIdpEndpoint is an https:// dotless host", () => {
+      expect(() =>
+        configure({
+          cognitoIdpEndpoint: "https://localhost",
+          clientId: "test-client-id",
+          hostedUi: {
+            redirectSignIn,
+          },
+        })
+      ).toThrow("hostedUi.domain is required");
+    });
+
+    it("throws when hostedUi is configured without domain and cognitoIdpEndpoint is derived from userPoolId", () => {
+      expect(() =>
+        configure({
+          userPoolId: "eu-west-1_abc123",
+          clientId: "test-client-id",
+          hostedUi: {
+            redirectSignIn,
+          },
+        })
+      ).toThrow("hostedUi.domain is required");
+    });
+
+    it("accepts hostedUi without domain when cognitoIdpEndpoint is a full custom URL", () => {
+      const config = configure({
+        cognitoIdpEndpoint: "https://cognito-proxy.example.com",
+        clientId: "test-client-id",
+        hostedUi: {
+          redirectSignIn,
+        },
+      });
+      expect(config.hostedUi?.domain).toBeUndefined();
+    });
+
+    it("throws when hostedUi is configured without domain and cognitoIdpEndpoint is a plaintext http:// URL", () => {
+      expect(() =>
+        configure({
+          cognitoIdpEndpoint: "http://cognito-proxy.example.com",
+          clientId: "test-client-id",
+          hostedUi: {
+            redirectSignIn,
+          },
+        })
+      ).toThrow("hostedUi.domain is required");
+    });
+
+    it("leaves the previous configuration intact when configure() throws", () => {
+      const previous = configure({
+        cognitoIdpEndpoint: "eu-west-1",
+        clientId: "previous-client-id",
+      });
+      expect(() =>
+        configure({
+          cognitoIdpEndpoint: "eu-west-1",
+          clientId: "rejected-client-id",
+          hostedUi: {
+            redirectSignIn,
+          },
+        })
+      ).toThrow("hostedUi.domain is required");
+      const current = configure();
+      expect(current).toBe(previous);
+      expect(current.clientId).toBe("previous-client-id");
+      expect(current.hostedUi).toBeUndefined();
+    });
+
+    it("accepts hostedUi with domain when cognitoIdpEndpoint is a region", () => {
+      const config = configure({
+        cognitoIdpEndpoint: "eu-west-1",
+        clientId: "test-client-id",
+        hostedUi: {
+          domain: "example.auth.eu-west-1.amazoncognito.com",
+          redirectSignIn,
+        },
+      });
+      expect(config.hostedUi?.domain).toBe(
+        "example.auth.eu-west-1.amazoncognito.com"
+      );
+    });
+  });
+
+  describe("getAuthorizeEndpoint / getTokenEndpoint", () => {
+    it("builds endpoints from hostedUi.domain", () => {
+      configure({
+        cognitoIdpEndpoint: "eu-west-1",
+        clientId: "test-client-id",
+        hostedUi: {
+          domain: "example.auth.eu-west-1.amazoncognito.com",
+          redirectSignIn,
+        },
+      });
+      expect(getAuthorizeEndpoint()).toBe(
+        "https://example.auth.eu-west-1.amazoncognito.com/oauth2/authorize"
+      );
+      expect(getTokenEndpoint()).toBe(
+        "https://example.auth.eu-west-1.amazoncognito.com/oauth2/token"
+      );
+    });
+
+    it("builds endpoints from a custom domain with protocol and trailing slash", () => {
+      configure({
+        cognitoIdpEndpoint: "eu-west-1",
+        clientId: "test-client-id",
+        hostedUi: {
+          domain: "https://auth.example.com/",
+          redirectSignIn,
+        },
+      });
+      expect(getAuthorizeEndpoint()).toBe(
+        "https://auth.example.com/oauth2/authorize"
+      );
+      expect(getTokenEndpoint()).toBe("https://auth.example.com/oauth2/token");
+    });
+
+    it("falls back to cognitoIdpEndpoint only when it is a full custom URL", () => {
+      configure({
+        cognitoIdpEndpoint: "https://cognito-proxy.example.com/",
+        clientId: "test-client-id",
+        hostedUi: {
+          redirectSignIn,
+        },
+      });
+      expect(getAuthorizeEndpoint()).toBe(
+        "https://cognito-proxy.example.com/oauth2/authorize"
+      );
+      expect(getTokenEndpoint()).toBe(
+        "https://cognito-proxy.example.com/oauth2/token"
+      );
+    });
+
+    it("refuses to build OAuth2 endpoints on a plaintext http:// cognitoIdpEndpoint", () => {
+      // Without hostedUi, configure() accepts a custom http:// IDP endpoint,
+      // but the OAuth2 endpoints must never be built on a non-TLS origin
+      // because authorization codes and tokens travel to it
+      configure({
+        cognitoIdpEndpoint: "http://cognito-proxy.example.com",
+        clientId: "test-client-id",
+      });
+      expect(() => getAuthorizeEndpoint()).toThrow(
+        "Cannot determine OAuth2 endpoint"
+      );
+      expect(() => getTokenEndpoint()).toThrow(
+        "Cannot determine OAuth2 endpoint"
+      );
+    });
+
+    it("never produces https://<region>/oauth2/... for a region-only cognitoIdpEndpoint", () => {
+      // hostedUi is not configured here, so configure() succeeds; the
+      // endpoint getters must still refuse to build a garbage URL
+      configure({
+        cognitoIdpEndpoint: "eu-west-1",
+        clientId: "test-client-id",
+      });
+      expect(() => getAuthorizeEndpoint()).toThrow(
+        "Cannot determine OAuth2 endpoint"
+      );
+      expect(() => getTokenEndpoint()).toThrow(
+        "Cannot determine OAuth2 endpoint"
+      );
+    });
+
+    it("never produces https://<region>/oauth2/... for an https:// prefixed region cognitoIdpEndpoint", () => {
+      // Same as above, but with the https:// scheme glued onto the bare
+      // region: still not a usable OAuth2 origin
+      configure({
+        cognitoIdpEndpoint: "https://eu-west-1",
+        clientId: "test-client-id",
+      });
+      expect(() => getAuthorizeEndpoint()).toThrow(
+        "Cannot determine OAuth2 endpoint"
+      );
+      expect(() => getTokenEndpoint()).toThrow(
+        "Cannot determine OAuth2 endpoint"
+      );
+    });
+  });
+});

--- a/client/config.ts
+++ b/client/config.ts
@@ -153,9 +153,16 @@ export interface Config {
    */
   hostedUi?: {
     /**
-     * (Optional) Custom domain for your Cognito Hosted UI. Example: auth.example.com
-     * If provided, all authorize / token endpoints are built from this domain.
-     * If omitted, we fall back to cognitoIdpEndpoint.
+     * The domain of your Cognito Hosted UI (the user pool domain), e.g.
+     * "example.auth.eu-west-1.amazoncognito.com" or a custom domain such as
+     * "auth.example.com". Amazon Cognito serves the OAuth2 endpoints
+     * (/oauth2/authorize, /oauth2/token) only on this domain — not on the
+     * cognito-idp API endpoint.
+     *
+     * Required, unless cognitoIdpEndpoint is a full https:// URL (e.g. a
+     * proxy you control that also serves the OAuth2 endpoints), in which case
+     * it may be omitted and cognitoIdpEndpoint is used as the OAuth2 base.
+     * Plaintext http:// URLs are not accepted as the OAuth2 base.
      */
     domain?: string;
     /** Redirect URI registered in the user-pool app client */
@@ -176,6 +183,34 @@ export type ConfigWithDefaults = Config &
 
 type ConfigInput = Omit<Config, "cognitoIdpEndpoint"> &
   Partial<Pick<Config, "cognitoIdpEndpoint">>;
+
+/** Matches a bare AWS region identifier, e.g. "eu-west-1" */
+const awsRegionRegex = /^[a-z]{2}-[a-z]+-\d$/;
+
+/**
+ * Determine if the configured cognitoIdpEndpoint is a genuine custom https://
+ * URL (e.g. a proxy you control) that can serve as the base for the OAuth2
+ * endpoints. A bare AWS region — with or without an https:// scheme, e.g.
+ * "eu-west-1" or "https://eu-west-1" — is just shorthand for the regional
+ * cognito-idp API endpoint, which does not serve the OAuth2 endpoints.
+ * Plaintext http:// is never accepted, because OAuth2 authorization codes
+ * and tokens travel to that origin
+ */
+function isCustomOAuthBase(endpoint: string): boolean {
+  if (!endpoint.startsWith("https://")) {
+    return false;
+  }
+  let hostname: string;
+  try {
+    hostname = new URL(endpoint).hostname;
+  } catch {
+    return false;
+  }
+  // A usable OAuth2 origin has a real hostname: a bare AWS region (e.g.
+  // "eu-west-1") or any other dotless host is not one
+  return hostname.includes(".") && !awsRegionRegex.test(hostname);
+}
+
 let config_: ConfigWithDefaults | undefined = undefined;
 export function configure(config?: ConfigInput) {
   if (config) {
@@ -188,12 +223,23 @@ export function configure(config?: ConfigInput) {
     }
 
     // If endpoint lacks protocol and is not an AWS region, prefix with https://
-    const regionRegex = /^[a-z]{2}-[a-z]+-\d$/;
     if (
       !cognitoIdpEndpoint.startsWith("http") &&
-      !regionRegex.test(cognitoIdpEndpoint)
+      !awsRegionRegex.test(cognitoIdpEndpoint)
     ) {
       cognitoIdpEndpoint = `https://${cognitoIdpEndpoint}`;
+    }
+
+    // Validate before assigning config_, so that a failed configure() is
+    // atomic and leaves any previously loaded configuration unchanged
+    if (
+      config.hostedUi &&
+      !config.hostedUi.domain &&
+      !isCustomOAuthBase(cognitoIdpEndpoint)
+    ) {
+      throw new Error(
+        "Invalid configuration: hostedUi.domain is required. Amazon Cognito serves the OAuth2 endpoints (/oauth2/authorize, /oauth2/token) only on your user pool domain, e.g. example.auth.eu-west-1.amazoncognito.com or a custom domain. It may only be omitted if cognitoIdpEndpoint is a full https:// URL (e.g. a proxy you control) that also serves the OAuth2 endpoints — an AWS region (e.g. eu-west-1) is not such a URL, and plaintext http:// is not allowed because OAuth2 authorization codes and tokens travel to that origin"
+      );
     }
 
     // Wrap the user-provided or default fetch in retry logic (pass debug callback)
@@ -235,7 +281,9 @@ export function configure(config?: ConfigInput) {
         ...(config.hostedUi.domain && { domain: config.hostedUi.domain }),
       };
       config_.debug?.(
-        "Cognito Hosted UI configured, will use cognitoIdpEndpoint for OAuth domain"
+        config.hostedUi.domain
+          ? "Cognito Hosted UI configured, will use hostedUi.domain for OAuth domain"
+          : "Cognito Hosted UI configured without domain, will use cognitoIdpEndpoint (custom URL) for OAuth domain"
       );
     }
     config_.debug?.("Configuration loaded:", config);
@@ -255,21 +303,38 @@ function normalizeEndpoint(endpoint: string): string {
   return withProtocol.replace(/\/+$/, ""); // trim trailing slashes
 }
 
-export function getAuthorizeEndpoint(): string {
+/**
+ * Get the base URL on which the OAuth2 endpoints are served: the Hosted UI
+ * (user pool) domain, or cognitoIdpEndpoint if that is a genuine custom
+ * https:// URL (e.g. a proxy you control). Throws if neither is usable,
+ * because Amazon Cognito does not serve the OAuth2 endpoints on the
+ * cognito-idp API endpoint — and a bare AWS region (even with an https://
+ * scheme) is just shorthand for that API endpoint. Plaintext http:// is
+ * never used as the OAuth2 base, because authorization codes and tokens
+ * travel to that origin
+ */
+function getOAuthBase(): string {
   const { cognitoIdpEndpoint, hostedUi } = configure();
-  const domainBase = hostedUi?.domain ?? cognitoIdpEndpoint;
-  const base = normalizeEndpoint(domainBase);
-  return `${base}/oauth2/authorize`;
+  if (hostedUi?.domain) {
+    return normalizeEndpoint(hostedUi.domain);
+  }
+  if (isCustomOAuthBase(cognitoIdpEndpoint)) {
+    return normalizeEndpoint(cognitoIdpEndpoint);
+  }
+  throw new Error(
+    "Cannot determine OAuth2 endpoint: configure hostedUi.domain with your user pool domain, e.g. example.auth.eu-west-1.amazoncognito.com or a custom domain. Amazon Cognito serves the OAuth2 endpoints only on that domain. A custom cognitoIdpEndpoint is only used as the OAuth2 base if it is a full https:// URL — an AWS region (e.g. eu-west-1) is not such a URL"
+  );
+}
+
+export function getAuthorizeEndpoint(): string {
+  return `${getOAuthBase()}/oauth2/authorize`;
 }
 
 /**
  * Get the full OAuth token endpoint URL with protocol
  */
 export function getTokenEndpoint(): string {
-  const { cognitoIdpEndpoint, hostedUi } = configure();
-  const domainBase = hostedUi?.domain ?? cognitoIdpEndpoint;
-  const base = normalizeEndpoint(domainBase);
-  return `${base}/oauth2/token`;
+  return `${getOAuthBase()}/oauth2/token`;
 }
 
 /**

--- a/test/refresh-comprehensive.test.ts
+++ b/test/refresh-comprehensive.test.ts
@@ -56,6 +56,10 @@ describe("Refresh System Comprehensive Tests", () => {
     configure({
       clientId: "testClient",
       cognitoIdpEndpoint: "us-west-2",
+      hostedUi: {
+        domain: "example.auth.us-west-2.amazoncognito.com",
+        redirectSignIn: "https://app.example.com/signin-redirect",
+      },
       fetch: fetchMock,
       storage: mockStorage,
       debug: (...args: unknown[]) => {

--- a/test/refresh-visibility-change.test.ts
+++ b/test/refresh-visibility-change.test.ts
@@ -66,6 +66,10 @@ describe("Visibility Change Handler Tests", () => {
     configureClient({
       clientId: "testClient",
       cognitoIdpEndpoint: "us-west-2",
+      hostedUi: {
+        domain: "example.auth.us-west-2.amazoncognito.com",
+        redirectSignIn: "https://app.example.com/signin-redirect",
+      },
       fetch: fetchMock,
       storage: mockStorage,
       debug: (...args: unknown[]) => {

--- a/test/refreshTokensLock.test.ts
+++ b/test/refreshTokensLock.test.ts
@@ -124,6 +124,10 @@ describe("RefreshTokens Lock", () => {
     configure({
       clientId: "testClient",
       cognitoIdpEndpoint: "us-west-2",
+      hostedUi: {
+        domain: "example.auth.us-west-2.amazoncognito.com",
+        redirectSignIn: "https://app.example.com/signin-redirect",
+      },
       fetch: dummyFetch,
       storage: mockStorage,
       debug: debugFn,


### PR DESCRIPTION
## Summary
`getAuthorizeEndpoint()` / `getTokenEndpoint()` fell back to `cognitoIdpEndpoint` when `hostedUi.domain` was omitted, producing URLs on a host that cannot serve Cognito's OAuth2 endpoints. `configure()` now requires `hostedUi.domain` (with an explicit escape hatch for full custom-URL proxies), and the endpoint getters refuse to build a garbage URL.

## Finding
- **Severity:** High
- **Confidence:** Validated by code reading and AWS documentation
- **Where:** `client/config.ts:258-273` (endpoint getters), `client/config.ts:230-240` (unvalidated `hostedUi` config), doc comment on `Config.hostedUi.domain`
- **Failure scenario:** With the documented region-only configuration (`cognitoIdpEndpoint: "eu-west-1"`), `client/cognito-api.ts` expands the region to `https://cognito-idp.eu-west-1.amazonaws.com/` for API calls, but the OAuth getters did no such expansion — `normalizeEndpoint()` produced `https://eu-west-1/oauth2/authorize`, so `signInWithRedirect()` navigated the browser to a nonexistent host, and OAuth-based token refresh (`client/refresh.ts:511`) POSTed to the same garbage URL. Even with a full `cognito-idp.*` URL the fallback is wrong: AWS serves `/oauth2/authorize` and `/oauth2/token` only on the user pool's hosted UI / managed-login domain (e.g. `<prefix>.auth.<region>.amazoncognito.com` or a custom domain). Because `configure()` accepted `hostedUi` without `domain`, the break only surfaced at sign-in time.

## Fix
- `configure()` throws a clear, actionable error when `hostedUi` is provided without `domain`, unless `cognitoIdpEndpoint` is a full custom URL (a developer-controlled proxy may legitimately serve the OAuth2 endpoints too) — that escape hatch is now documented explicitly on `Config.hostedUi.domain`.
- New `getOAuthBase()` helper backs `getAuthorizeEndpoint()` / `getTokenEndpoint()`: it uses `hostedUi.domain`, falls back to `cognitoIdpEndpoint` only when it is a full URL, and otherwise throws instead of producing `https://<region>/oauth2/...` (defense in depth).
- Fixed the misleading doc comment ("If omitted, we fall back to cognitoIdpEndpoint") and the misleading debug message.
- Updated three refresh tests that configured REDIRECT tokens with a region-only endpoint and no `hostedUi` — an impossible production state that only "worked" because fetch was mocked — to use a realistic hosted UI config.

## Test plan
- New `client/__tests__/oauth-endpoints.test.ts`: hostedUi without domain + region endpoint → configure throws; same via `userPoolId`-derived region → throws; with domain → exact `https://<domain>/oauth2/authorize` and `/oauth2/token` URLs (including domain given with protocol/trailing slash); full custom-URL `cognitoIdpEndpoint` without domain → allowed and used as OAuth base; region-only endpoint without hostedUi → getters throw instead of producing `https://<region>/oauth2/...`.
- Gates: `npx tsc --project client/tsconfig.json --noEmit` clean; `npx eslint` clean on all changed files; `npx jest client/__tests__/hosted-oauth.test.ts client/__tests__/oauth-endpoints.test.ts` 15/15 passed; full `npx jest` suite: 24 passed, 2 skipped (skipped on main as well), 190 tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes authentication configuration and OAuth URL resolution; apps that relied on the old region fallback will fail at configure or endpoint resolution until they set hostedUi.domain, but the fix prevents silent broken sign-in/refresh.
> 
> **Overview**
> **OAuth2 URL construction no longer falls back to `cognitoIdpEndpoint` when that value is only an AWS region**, which previously produced invalid hosts like `https://eu-west-1/oauth2/authorize` and broke redirect sign-in and OAuth token refresh.
> 
> `configure()` now **requires `hostedUi.domain`** whenever Hosted UI is enabled, unless `cognitoIdpEndpoint` is a real **https** custom proxy URL (`isCustomOAuthBase`); validation runs **before** mutating config so failed `configure()` calls leave prior settings intact. **`getOAuthBase()`** centralizes authorize/token URL building: prefer `hostedUi.domain`, else the custom https endpoint; **http** and region-style bases throw with actionable errors. Docs and debug messaging match this behavior.
> 
> Adds **`client/__tests__/oauth-endpoints.test.ts`** and updates refresh tests to include a realistic Hosted UI domain for OAuth-path scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e96670299046401699a506caf2db0b354854369. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->