### PR TITLE
Make setTimeoutWallClock resilient to device sleep for the whole delay

### DIFF
--- a/client/util.ts
+++ b/client/util.ts
@@ -78,64 +78,68 @@ export function computeClockDriftMs(accessToken?: string): number {
 }
 
 /**
+ * Maximum length of each setTimeout chunk used by setTimeoutWallClock.
+ * Browsers don't reliably credit setTimeout time spent in system sleep,
+ * so we never trust a single setTimeout for more than this long, and
+ * re-check the wall clock on every chunk boundary.
+ */
+const WALL_CLOCK_TIMEOUT_CHUNK_MS = 30 * 1000;
+
+/**
+ * Poll interval used once the remaining time until the deadline is at most
+ * WALL_CLOCK_TIMEOUT_CHUNK_MS. In this final stretch the wall clock is
+ * re-checked every second (mirroring the 1-second polling this util has
+ * always used near the deadline), so that sleeping through the deadline
+ * delays the callback by at most ~1 second after wake, instead of by the
+ * full remainder of one uncredited setTimeout
+ */
+const WALL_CLOCK_FINAL_POLL_MS = 1000;
+
+/**
  * Schedule a callback once, like setTimeout, but count
- * time spent sleeping also as time spent. This way, if the browser tab
- * where this is happening is activated again after sleeping,
- * the callback is run immediately (more precise: within 1 second)
+ * time spent sleeping also as time spent. This is done by tracking a
+ * wall-clock deadline and chaining short setTimeouts (at most 30 seconds
+ * each, at most 1 second each during the final 30 seconds) that re-check
+ * the wall clock upon every wake, and only run the callback when the
+ * wall-clock deadline has truly passed. This way, if the device sleeps past
+ * the deadline, the callback runs within one chunk (at most 30 seconds,
+ * typically much sooner) after waking, instead of waiting out the
+ * remainder of one long setTimeout
  */
 export function setTimeoutWallClock<T>(cb: () => T, ms: number) {
   const executeAt = Date.now() + ms;
-
-  // For short delays (< 30 seconds), use the original approach
-  if (ms < 30000) {
-    const i = setInterval(() => {
-      if (Date.now() >= executeAt) {
-        clearInterval(i);
-        cb();
-      }
-    }, 1000);
-
-    // unref the interval if we can, so that e.g. when running in Node.js
-    // this interval would not block program exit:
-    if (typeof i.unref === "function") i.unref();
-
-    return () => clearInterval(i);
-  }
-
-  // For long delays, use a hybrid approach:
-  // 1. Use setTimeout for most of the delay
-  // 2. Switch to interval checking only in the final 30 seconds
-  const initialDelay = ms - 30000; // All but the last 30 seconds
-  // eslint-disable-next-line prefer-const
-  let timeoutId: ReturnType<typeof setTimeout>;
-  let intervalId: ReturnType<typeof setInterval>;
+  let timer: ReturnType<typeof setTimeout>;
   let cancelled = false;
 
-  const cleanup = () => {
-    cancelled = true;
-    if (timeoutId) clearTimeout(timeoutId);
-    if (intervalId) clearInterval(intervalId);
-  };
-
-  // First phase: use setTimeout for the bulk of the delay
-  timeoutId = setTimeout(() => {
-    if (cancelled) return;
-
-    // Second phase: use interval for the final 30 seconds to handle sleep/wake
-    intervalId = setInterval(() => {
+  const scheduleNextCheck = () => {
+    const remaining = executeAt - Date.now();
+    // Cap every setTimeout: long remainders are chunked at 30 seconds, and
+    // the final stretch is polled at 1 second, so device sleep is always
+    // detected at the next chunk boundary. Delays shorter than the poll
+    // interval are scheduled as-is (e.g. 500 ms fires after 500 ms)
+    const delay =
+      remaining > WALL_CLOCK_TIMEOUT_CHUNK_MS
+        ? WALL_CLOCK_TIMEOUT_CHUNK_MS
+        : Math.min(Math.max(remaining, 0), WALL_CLOCK_FINAL_POLL_MS);
+    timer = setTimeout(() => {
       if (cancelled) return;
       if (Date.now() >= executeAt) {
-        clearInterval(intervalId);
         cb();
+      } else {
+        scheduleNextCheck();
       }
-    }, 1000);
+    }, delay);
 
-    if (typeof intervalId.unref === "function") intervalId.unref();
-  }, initialDelay);
+    // unref the timer if we can, so that e.g. when running in Node.js
+    // this timer would not block program exit:
+    if (typeof timer.unref === "function") timer.unref();
+  };
+  scheduleNextCheck();
 
-  if (typeof timeoutId.unref === "function") timeoutId.unref();
-
-  return cleanup;
+  return () => {
+    cancelled = true;
+    clearTimeout(timer);
+  };
 }
 
 export function currentBrowserLocationWithoutFragmentIdentifier() {

--- a/test/refresh-device-sleep.test.ts
+++ b/test/refresh-device-sleep.test.ts
@@ -1,3 +1,23 @@
+// Use the REAL setTimeoutWallClock implementation (client/__tests__/setup.ts
+// mocks it with a plain setTimeout, which would defeat the purpose of these
+// tests). Keep the atob-based parseJwtPayload mock from setup.ts, because the
+// real one relies on TextDecoder which is not available in jsdom.
+jest.mock("../client/util.js", () => {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  const actualUtil = jest.requireActual("../client/util.js");
+  return {
+    ...(actualUtil as object),
+    parseJwtPayload: (token: string) => {
+      const [, payload] = token.split(".");
+      if (!payload) {
+        throw new Error("Invalid token format");
+      }
+      const base64 = payload.replace(/-/g, "+").replace(/_/g, "/");
+      return JSON.parse(atob(base64)) as Record<string, unknown>;
+    },
+  };
+});
+
 import { configure } from "../client/config.js";
 import { scheduleRefresh, cleanupRefreshSystem } from "../client/refresh.js";
 import { storeTokens } from "../client/storage.js";
@@ -16,7 +36,10 @@ const createJWT = (claims: Record<string, unknown>) => {
   return `${header}.${payload}.signature`;
 };
 
-const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+// Capture the real setTimeout before MockTimerEnvironment replaces it, so
+// `sleep` waits real time (letting promises/microtasks settle)
+const realSetTimeout = setTimeout;
+const sleep = (ms: number) => new Promise((r) => realSetTimeout(r, ms));
 
 // Mock timer implementation that supports device sleep simulation
 class MockTimerEnvironment {
@@ -319,7 +342,7 @@ describe("Device Sleep/Wake Scenarios", () => {
   });
 
   describe("Timer Reliability", () => {
-    test.skip("should fire refresh timer after device wake if overdue", async () => {
+    test("should fire refresh timer after device wake if overdue", async () => {
       const now = timerEnv.getCurrentTime();
       const expiresIn10Min = new Date(now + 10 * 60 * 1000);
 
@@ -378,6 +401,16 @@ describe("Device Sleep/Wake Scenarios", () => {
       // Wake up - timer is now overdue
       timerEnv.simulateDeviceWake();
       await sleep(200);
+
+      // The refresh timer fires right after wake (this is what's under test),
+      // but the first attempt backs off via the cross-tab coordination check
+      // (the expired tokens are dropped by retrieveTokens) and schedules a
+      // forced retry in 30s. Advance mock time in steps, letting promises
+      // settle in between, so the internal waits and the retry can fire.
+      for (let i = 0; i < 8; i++) {
+        timerEnv.advanceTime(5 * 1000);
+        await sleep(50);
+      }
 
       // Timer should fire and trigger refresh
       expect(fetchMock).toHaveBeenCalled();

--- a/test/refresh-device-sleep.test.ts
+++ b/test/refresh-device-sleep.test.ts
@@ -185,6 +185,34 @@ describe("Device Sleep/Wake Scenarios", () => {
   };
   let timerEnv: MockTimerEnvironment;
 
+  // Await a promise while pumping the mocked timers. Production code awaits
+  // setTimeout-based sleeps internally (e.g. the lock's post-write
+  // verification jitter and shouldAttemptRefresh's scheduling jitter), but
+  // MockTimerEnvironment only fires mocked setTimeouts when mock time is
+  // advanced — so a plain `await` would deadlock. Advance mock time in 100ms
+  // steps, letting microtasks settle in between via short real-timer waits,
+  // until the promise settles.
+  const awaitPumpingTimers = async <T>(promise: Promise<T>): Promise<T> => {
+    let settled = false;
+    const guarded = promise.finally(() => {
+      settled = true;
+    });
+    // Prevent unhandled rejection warnings while we keep pumping
+    guarded.catch(() => undefined);
+    // Cap the pumping so a genuine deadlock fails fast instead of hanging
+    const maxSteps = 600; // 60s of mock time
+    for (let step = 0; !settled; step++) {
+      if (step >= maxSteps) {
+        throw new Error(
+          "awaitPumpingTimers: promise did not settle after pumping mock timers"
+        );
+      }
+      timerEnv.advanceTime(100);
+      await sleep(1);
+    }
+    return guarded;
+  };
+
   beforeEach(() => {
     // Create a mock storage
     const storageData = new Map<string, string>();
@@ -251,7 +279,7 @@ describe("Device Sleep/Wake Scenarios", () => {
       await storeTokens(tokens);
 
       // Schedule refresh (starts watchdog)
-      await scheduleRefresh();
+      await awaitPumpingTimers(scheduleRefresh());
 
       // Clear logs
       debugLogs = [];
@@ -317,7 +345,7 @@ describe("Device Sleep/Wake Scenarios", () => {
       } as MinimalResponse);
 
       // Schedule refresh
-      await scheduleRefresh();
+      await awaitPumpingTimers(scheduleRefresh());
 
       // Clear logs
       debugLogs = [];
@@ -378,7 +406,7 @@ describe("Device Sleep/Wake Scenarios", () => {
       } as MinimalResponse);
 
       // Schedule refresh (should be ~8 minutes from now)
-      await scheduleRefresh();
+      await awaitPumpingTimers(scheduleRefresh());
 
       const scheduleLog = debugLogs.find((log) =>
         log.includes("Scheduling token refresh in")
@@ -457,7 +485,7 @@ describe("Device Sleep/Wake Scenarios", () => {
       } as MinimalResponse);
 
       // Schedule refresh
-      await scheduleRefresh();
+      await awaitPumpingTimers(scheduleRefresh());
 
       // Advance time to when refresh should fire (~8 minutes)
       timerEnv.advanceTime(8 * 60 * 1000);
@@ -498,7 +526,7 @@ describe("Device Sleep/Wake Scenarios", () => {
       await storeTokens(tokens);
 
       // Schedule refresh
-      await scheduleRefresh();
+      await awaitPumpingTimers(scheduleRefresh());
 
       // Clear logs
       debugLogs = [];

--- a/test/set-timeout-wall-clock.test.ts
+++ b/test/set-timeout-wall-clock.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Unit tests for the setTimeoutWallClock timer primitive.
+ *
+ * Uses Jest's modern fake timers, where:
+ * - jest.advanceTimersByTime(ms) advances both timers and Date.now()
+ *   (normal passage of time)
+ * - jest.setSystemTime(t) jumps Date.now() while preserving the relative
+ *   remaining delay of pending timers — which models how browsers handle
+ *   system sleep: setTimeout time spent sleeping is not (reliably) credited
+ */
+
+// Use the real implementation (client/__tests__/setup.ts mocks it globally)
+jest.unmock("../client/util.js");
+
+import { setTimeoutWallClock } from "../client/util.js";
+
+const CHUNK_MS = 30 * 1000; // matches WALL_CLOCK_TIMEOUT_CHUNK_MS in client/util.ts
+const FINAL_POLL_MS = 1000; // matches WALL_CLOCK_FINAL_POLL_MS in client/util.ts
+
+describe("setTimeoutWallClock", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test("fires at the deadline under normal timer progression (long delay)", () => {
+    const cb = jest.fn();
+    setTimeoutWallClock(cb, 45 * 60 * 1000);
+
+    jest.advanceTimersByTime(45 * 60 * 1000 - 1);
+    expect(cb).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(1);
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  test("fires at the deadline under normal timer progression (short delay)", () => {
+    const cb = jest.fn();
+    setTimeoutWallClock(cb, 5000);
+
+    jest.advanceTimersByTime(4999);
+    expect(cb).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(1);
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  test("fires within one chunk after wake when the deadline passed during device sleep", () => {
+    const cb = jest.fn();
+    setTimeoutWallClock(cb, 45 * 60 * 1000);
+
+    // 10 minutes of normal operation
+    jest.advanceTimersByTime(10 * 60 * 1000);
+    expect(cb).not.toHaveBeenCalled();
+
+    // Device sleeps for 8 hours: wall clock jumps way past the deadline,
+    // but pending setTimeouts get no credit for the time spent sleeping
+    jest.setSystemTime(Date.now() + 8 * 60 * 60 * 1000);
+    expect(cb).not.toHaveBeenCalled();
+
+    // After wake, the currently pending chunk elapses (at most CHUNK_MS),
+    // the wall clock is re-checked, and the overdue callback fires
+    jest.advanceTimersByTime(CHUNK_MS);
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  test("fires within the poll interval after wake when the deadline passed during sleep on a short delay", () => {
+    const cb = jest.fn();
+    setTimeoutWallClock(cb, 10 * 1000);
+
+    // 2 seconds of normal operation
+    jest.advanceTimersByTime(2 * 1000);
+    expect(cb).not.toHaveBeenCalled();
+
+    // Device sleeps for an hour: wall clock jumps way past the deadline,
+    // but pending setTimeouts get no credit for the time spent sleeping
+    jest.setSystemTime(Date.now() + 60 * 60 * 1000);
+    expect(cb).not.toHaveBeenCalled();
+
+    // After wake, the overdue callback fires within one poll interval —
+    // NOT only after the full remaining 8 seconds of one uncredited timer
+    jest.advanceTimersByTime(FINAL_POLL_MS);
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  test("fires within the poll interval after wake when sleep hits the final stretch of a long delay", () => {
+    const cb = jest.fn();
+    setTimeoutWallClock(cb, 45 * 60 * 1000);
+
+    // Normal operation until 15 seconds before the deadline
+    jest.advanceTimersByTime(45 * 60 * 1000 - 15 * 1000);
+    expect(cb).not.toHaveBeenCalled();
+
+    // Device sleeps past the deadline during the final stretch
+    jest.setSystemTime(Date.now() + 60 * 60 * 1000);
+    expect(cb).not.toHaveBeenCalled();
+
+    // After wake, the overdue callback fires within one poll interval
+    jest.advanceTimersByTime(FINAL_POLL_MS);
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not fire early if the wall clock jumps but the deadline has not passed", () => {
+    const cb = jest.fn();
+    setTimeoutWallClock(cb, 45 * 60 * 1000);
+
+    // Device sleeps for 10 minutes: deadline (45 min) not reached yet
+    jest.setSystemTime(Date.now() + 10 * 60 * 1000);
+    jest.advanceTimersByTime(CHUNK_MS);
+    expect(cb).not.toHaveBeenCalled();
+
+    // Remaining wall-clock time elapses normally
+    jest.advanceTimersByTime(35 * 60 * 1000 - CHUNK_MS);
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  test("cancellation between chunks clears the pending chunk timer", () => {
+    const cb = jest.fn();
+    const cancel = setTimeoutWallClock(cb, 5 * 60 * 1000);
+
+    // Advance a few chunks in, then cancel
+    jest.advanceTimersByTime(2 * 60 * 1000);
+    cancel();
+
+    // The currently pending chunk timer must be cleared
+    expect(jest.getTimerCount()).toBe(0);
+
+    jest.advanceTimersByTime(10 * 60 * 1000);
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  test("cancellation also works after device sleep, before the chunk fires", () => {
+    const cb = jest.fn();
+    const cancel = setTimeoutWallClock(cb, 45 * 60 * 1000);
+
+    jest.advanceTimersByTime(10 * 60 * 1000);
+
+    // Sleep past the deadline, then cancel before the pending chunk fires
+    jest.setSystemTime(Date.now() + 8 * 60 * 60 * 1000);
+    cancel();
+
+    jest.advanceTimersByTime(60 * 60 * 1000);
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  test("fires on the next tick for a zero (or negative) delay", () => {
+    const cb = jest.fn();
+    setTimeoutWallClock(cb, 0);
+
+    // Not synchronously...
+    expect(cb).not.toHaveBeenCalled();
+
+    // ...but on the next timer tick
+    jest.advanceTimersByTime(0);
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
`setTimeoutWallClock` now tracks a wall-clock deadline and chains short setTimeouts (max 30s each, `WALL_CLOCK_TIMEOUT_CHUNK_MS`) that re-check `Date.now()` on every tick for the whole delay, instead of trusting one long `setTimeout` for all but the final 30 seconds.

## Finding
- **Severity:** HIGH (externally validated)
- **Confidence:** High — confirmed by reading the implementation and reproducing with tests
- **Where:** `client/util.ts:105-138` (pre-fix) — for delays >= 30s, phase 1 was a plain `setTimeout(ms - 30000)`, with 1-second wall-clock polling only for the final 30 seconds.
- **Why it's a bug:** Browsers do not reliably credit `setTimeout` time spent in system sleep (the WHATWG timers spec normatively permits an extra "implementation-defined length of time", and Chromium engineers confirm sleep behavior varies by platform — whatwg/html#6759). If the device sleeps during phase 1 — which covers almost the entire delay — the callback fires up to the full sleep duration late relative to wall clock, despite the doc comment promising prompt execution after wake.
- **Concrete failure scenario:** 60-min token, refresh scheduled at +45 min (`client/refresh.ts:383`), laptop sleeps at +10 min overnight. On wake, the remaining ~35 min of the phase-1 `setTimeout` must still elapse before the refresh runs — the token is expired that whole time.
- The regression test covering this was `test.skip`-ed at `test/refresh-device-sleep.test.ts:322` (and the global test setup mocked `setTimeoutWallClock` with a plain `setTimeout`, so the real implementation was never exercised).

## Fix
- `client/util.ts`: single unified implementation — compute `executeAt = Date.now() + ms`, then chain `setTimeout`s of `min(remaining, 30s)` (named constant `WALL_CLOCK_TIMEOUT_CHUNK_MS`), re-checking the wall clock on every chunk boundary and firing as soon as the deadline has passed (within one chunk of wake). Timers are still `unref`-ed in Node.js.
- Public signature and cancellation semantics are unchanged: still returns a cleanup function (as used by `client/refresh.ts`), and cancellation between chunks clears the currently pending chunk timer.

## Test plan
- New `test/set-timeout-wall-clock.test.ts`: focused unit tests for the primitive using Jest modern fake timers (mocked `Date.now`) — on-time firing for short/long delays, firing within one chunk after a simulated sleep (`jest.setSystemTime` jumps the wall clock without crediting pending timers), no early firing when the deadline hasn't passed, cancellation between chunks (asserts the pending chunk timer is cleared), cancellation after sleep, and zero-delay behavior.
- Un-skipped `should fire refresh timer after device wake if overdue` in `test/refresh-device-sleep.test.ts`, and made that file exercise the REAL `setTimeoutWallClock` (overriding the global test mock; `parseJwtPayload` stays mocked because jsdom lacks `TextDecoder`).
- Verified the new/un-skipped sleep tests FAIL against the old implementation and pass with the fix.
- Gates: `npx tsc --project client/tsconfig.json --noEmit` clean; `npx eslint` clean on changed files; `npx jest test/` — 15 passed, 1 skipped suites (64 passed, 18 skipped tests), no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core timer behavior used by token refresh scheduling; behavior is well-tested but affects timing-sensitive auth refresh paths.
> 
> **Overview**
> **`setTimeoutWallClock`** no longer relies on one long `setTimeout` for most of the delay. It keeps a wall-clock deadline and chains short timers (30s chunks, 1s polling in the last 30s), re-checking `Date.now()` on each wake so overdue callbacks run soon after device sleep instead of waiting out uncredited timer time.
> 
> Adds **`test/set-timeout-wall-clock.test.ts`** for normal firing, sleep/wake behavior, and cancellation. **`test/refresh-device-sleep.test.ts`** now exercises the real util (overriding the global mock), pumps mocked timers while awaiting `scheduleRefresh`, and **un-skips** the overdue-after-wake refresh timer test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4c4756d6f537fe48797582491305209badd93a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->