### PR TITLE
Respect requested userVerification for conditional mediation

### DIFF
--- a/client/__tests__/mediation-integration.test.ts
+++ b/client/__tests__/mediation-integration.test.ts
@@ -101,7 +101,7 @@ describe("Mediation Integration Tests", () => {
       const result = await fido2getCredential({
         challenge: TEST_CHALLENGES.basic,
         mediation: "conditional",
-        userVerification: "required", // Should be overridden
+        userVerification: "required", // Should be passed through unchanged
         timeout: knownTimeout, // Should be removed
       });
 
@@ -109,8 +109,39 @@ describe("Mediation Integration Tests", () => {
       expect(getSpy).toHaveBeenCalledWith(
         expect.objectContaining({
           publicKey: expect.objectContaining({
-            userVerification: "preferred", // Overridden per spec
+            userVerification: "required", // Requested value respected
             timeout: undefined, // Removed per spec
+          }),
+          mediation: "conditional",
+        })
+      );
+    });
+
+    it("defaults userVerification to preferred for conditional mediation when not specified", async () => {
+      const getSpy = jest.fn().mockResolvedValue(MOCK_ASSERTION_CREDENTIAL);
+
+      (global as any).PublicKeyCredential = {
+        isConditionalMediationAvailable: jest.fn().mockResolvedValue(true),
+      };
+
+      // Use Object.defineProperty for jsdom compatibility
+      Object.defineProperty((global as any).navigator, "credentials", {
+        value: {
+          get: getSpy,
+        },
+        configurable: true,
+        writable: true,
+      });
+
+      await fido2getCredential({
+        challenge: TEST_CHALLENGES.basic,
+        mediation: "conditional",
+      });
+
+      expect(getSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          publicKey: expect.objectContaining({
+            userVerification: "preferred", // Default when nothing requested
           }),
           mediation: "conditional",
         })
@@ -151,12 +182,15 @@ describe("Mediation Integration Tests", () => {
       });
 
       expect(debugSpy).toHaveBeenCalledWith(
-        expect.stringContaining(
-          'WebAuthn spec requires userVerification="preferred"'
-        )
-      );
-      expect(debugSpy).toHaveBeenCalledWith(
         expect.stringContaining("WebAuthn spec recommends removing timeout")
+      );
+      // Requested userVerification must NOT be overridden
+      expect(getSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          publicKey: expect.objectContaining({
+            userVerification: "required",
+          }),
+        })
       );
     });
   });

--- a/client/fido2.ts
+++ b/client/fido2.ts
@@ -701,16 +701,18 @@ export async function fido2getCredential({
   let effectiveTimeout = timeout;
 
   if (mediation === "conditional") {
-    // Conditional mediation requires "preferred" userVerification and no timeout
-    effectiveUserVerification = "preferred";
-    effectiveTimeout = undefined;
-
-    if (userVerification && userVerification !== "preferred") {
+    // Conditional mediation: default userVerification to "preferred" (per passkeys.dev
+    // UX guidance) only when nothing was requested. A requested value (e.g. "required"
+    // from the server's fido2options) is passed through unchanged, so the authenticator
+    // performs user verification when the backend will verify the UV flag.
+    if (!userVerification) {
+      effectiveUserVerification = "preferred";
       debug?.(
-        `⚠️ WebAuthn spec requires userVerification="preferred" for conditional mediation. ` +
-          `Overriding "${userVerification}" → "preferred"`
+        `userVerification not specified - defaulting to "preferred" for conditional mediation`
       );
     }
+    effectiveTimeout = undefined;
+
     if (timeout) {
       debug?.(
         `⚠️ WebAuthn spec recommends removing timeout for conditional mediation. ` +
@@ -1087,7 +1089,7 @@ export function authenticateWithFido2({
    * **'conditional'** - Autofill UI (Password Manager Integration):
    * - Passkeys appear in browser autofill suggestions
    * - "Set and forget" - only resolves if user selects from autofill
-   * - userVerification automatically set to "preferred"
+   * - userVerification defaults to "preferred" when not specified
    * - timeout removed (per WebAuthn spec)
    * - Requires: HTML input with autocomplete="username webauthn"
    *


### PR DESCRIPTION
## Summary
`fido2getCredential` silently downgraded a server-requested `userVerification: "required"` to `"preferred"` whenever conditional mediation (passkey autofill) was used. The requested value is now passed through unchanged; `"preferred"` is applied only as a default when nothing was requested.

## Finding
- **Severity:** Medium (security-relevant)
- **Confidence:** High (externally validated against the W3C WebAuthn Level 3 spec)
- **Location:** `client/fido2.ts:703-713` (on `main`)

For `mediation: "conditional"`, the code unconditionally overrode `userVerification` to `"preferred"`, even when the Cognito challenge's `fido2options` (or the app's `authenticatorSelection` config) requested `"required"`. The debug message claimed the WebAuthn spec *requires* `"preferred"` for conditional mediation — this is false. The spec has no normative requirement tying conditional mediation to `"preferred"` for `get()`; that is only passkeys.dev UX guidance. The spec instead expects RPs that send `"required"` to verify the UV flag ("User verification SHOULD be required if, and only if, pkOptions.userVerification is set to required").

**Concrete failure scenario:** backend requests `userVerification: "required"`; the client downgrades it to `"preferred"`; the authenticator skips user verification and returns an assertion with UV=0. Either the backend rejects the assertion post-ceremony (broken sign-in UX), or — worse — accepts a possession-only assertion where two-factor verification was demanded.

## Fix
- `client/fido2.ts`: for conditional mediation, only default `userVerification` to `"preferred"` when no value was requested; a requested value (e.g. from the server's `fido2options` / configured `authenticatorSelection`) passes through unchanged. Removed the false spec claim from the debug message and corrected the related doc comment. The timeout removal for conditional mediation is unchanged.

## Test plan
- Updated `client/__tests__/mediation-integration.test.ts`:
  - conditional mediation with requested `"required"` now asserts `"required"` is passed through to `navigator.credentials.get` (previously asserted the downgrade)
  - new test: conditional mediation with no `userVerification` defaults to `"preferred"`
  - override-warning test now asserts only the timeout warning and that the requested userVerification is not overridden
- Gates: `npx tsc --project client/tsconfig.json --noEmit` clean; `npx eslint client/fido2.ts client/__tests__/mediation-integration.test.ts` clean; `npx jest client/__tests__` — 127 tests passed, 10 suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches WebAuthn sign-in ceremony parameters; the change aligns client behavior with backend UV expectations but affects all conditional-mediation flows.
> 
> **Overview**
> **Fixes conditional passkey autofill ignoring server-requested user verification.** `fido2getCredential` no longer forces `userVerification: "preferred"` for `mediation: "conditional"` when the caller (e.g. Cognito `fido2options` or app config) sends `"required"` or another explicit value.
> 
> For conditional mediation, `"preferred"` is applied **only** when `userVerification` is omitted (passkeys.dev-style default). **Timeout** is still cleared for conditional mediation; debug text no longer claims the spec *requires* `"preferred"`.
> 
> Integration tests were updated to expect pass-through of `"required"`, a new case for the default, and assertions that timeout warnings still fire without a userVerification override.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b454964ced4e2f28ad738035a30f6edb328d9fab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->