### PR TITLE
Fix unreachable conditional-mediation guard in fido2getCredential

### DIFF
--- a/client/__tests__/__utils__/webauthn-mocks.ts
+++ b/client/__tests__/__utils__/webauthn-mocks.ts
@@ -35,8 +35,10 @@ import {
 export interface WebAuthnMockConfig {
   /** Whether PublicKeyCredential API is available */
   available?: boolean;
-  /** Whether conditional UI is supported */
+  /** Whether isConditionalMediationAvailable() exists on PublicKeyCredential */
   conditionalMediationSupported?: boolean;
+  /** Value resolved by isConditionalMediationAvailable() */
+  conditionalMediationAvailable?: boolean;
   /** Mock credential to return from get() */
   credential?: PublicKeyCredential | null;
   /** Mock credential to return from create() */
@@ -128,6 +130,7 @@ export function setupWebAuthnMock(config: WebAuthnMockConfig = {}): () => void {
   const {
     available = true,
     conditionalMediationSupported = true,
+    conditionalMediationAvailable = true,
     credential = MOCK_ASSERTION_CREDENTIAL,
     createCredential = MOCK_ATTESTATION_CREDENTIAL,
     getError = null,
@@ -164,7 +167,7 @@ export function setupWebAuthnMock(config: WebAuthnMockConfig = {}): () => void {
       .mockResolvedValue(true),
 
     isConditionalMediationAvailable: conditionalMediationSupported
-      ? jest.fn().mockResolvedValue(true)
+      ? jest.fn().mockResolvedValue(conditionalMediationAvailable)
       : undefined,
 
     getClientCapabilities: jest.fn().mockResolvedValue(capabilities),
@@ -257,6 +260,19 @@ export function setupAbortedWebAuthnMock(): () => void {
 export function setupNoConditionalMediationMock(): () => void {
   return setupWebAuthnMock({
     conditionalMediationSupported: false,
+    capabilities: {
+      ...TEST_CAPABILITIES,
+      conditionalGet: false,
+    },
+  });
+}
+
+/**
+ * Setup WebAuthn mock where isConditionalMediationAvailable() resolves false
+ */
+export function setupConditionalMediationUnavailableMock(): () => void {
+  return setupWebAuthnMock({
+    conditionalMediationAvailable: false,
     capabilities: {
       ...TEST_CAPABILITIES,
       conditionalGet: false,

--- a/client/__tests__/mediation-integration.test.ts
+++ b/client/__tests__/mediation-integration.test.ts
@@ -24,6 +24,7 @@ import {
 import {
   setupWebAuthnMock,
   setupNoConditionalMediationMock,
+  setupConditionalMediationUnavailableMock,
   setupNoBrowserSupportMock,
   createMockAbortController,
 } from "./__utils__/webauthn-mocks.js";
@@ -77,6 +78,67 @@ describe("Mediation Integration Tests", () => {
 
       expect(debugSpy).toHaveBeenCalledWith(
         expect.stringContaining("Cannot verify conditional mediation support")
+      );
+    });
+
+    it("throws Fido2ConfigError when conditional mediation is reported as unsupported", async () => {
+      cleanup = setupConditionalMediationUnavailableMock();
+
+      await expect(
+        fido2getCredential({
+          challenge: TEST_CHALLENGES.basic,
+          mediation: "conditional",
+        })
+      ).rejects.toThrow(Fido2ConfigError);
+
+      // The credential request must not be attempted on unsupported browsers
+      expect(
+        (global as any).navigator.credentials.get as jest.Mock
+      ).not.toHaveBeenCalled();
+    });
+
+    it("proceeds when conditional mediation support check itself throws", async () => {
+      const debugSpy = jest.fn();
+      mockConfigure.mockReturnValue({
+        debug: debugSpy,
+        fido2: {
+          rp: { id: TEST_RP.id, name: TEST_RP.name },
+        },
+      } as any);
+
+      const getSpy = jest.fn().mockResolvedValue(MOCK_ASSERTION_CREDENTIAL);
+
+      (global as any).PublicKeyCredential = {
+        isConditionalMediationAvailable: jest
+          .fn()
+          .mockRejectedValue(new Error("capability check failed")),
+      };
+
+      // Use Object.defineProperty for jsdom compatibility
+      Object.defineProperty((global as any).navigator, "credentials", {
+        value: {
+          get: getSpy,
+        },
+        configurable: true,
+        writable: true,
+      });
+
+      const result = await fido2getCredential({
+        challenge: TEST_CHALLENGES.basic,
+        mediation: "conditional",
+      });
+
+      expect(result).toBeDefined();
+      expect(getSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          mediation: "conditional",
+        })
+      );
+      expect(debugSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "Cannot verify conditional mediation support - proceeding with conditional mediation anyway"
+        ),
+        expect.any(Error)
       );
     });
 

--- a/client/fido2.ts
+++ b/client/fido2.ts
@@ -663,18 +663,19 @@ export async function fido2getCredential({
     if (
       typeof PublicKeyCredential.isConditionalMediationAvailable === "function"
     ) {
+      let isAvailable: boolean | undefined;
       try {
-        const isAvailable =
+        isAvailable =
           await PublicKeyCredential.isConditionalMediationAvailable();
-        if (!isAvailable) {
-          throw new Fido2ConfigError(
-            "Conditional mediation requested but not supported by this browser."
-          );
-        }
       } catch (error) {
         debug?.(
-          "⚠️ Cannot verify conditional mediation support - treating as unsupported",
+          "⚠️ Cannot verify conditional mediation support - proceeding with conditional mediation anyway",
           error
+        );
+      }
+      if (isAvailable === false) {
+        throw new Fido2ConfigError(
+          "Conditional mediation requested but not supported by this browser."
         );
       }
     } else {


### PR DESCRIPTION
## Summary
Fixes a swallowed-error bug in `fido2getCredential`: the guard that should reject conditional mediation on browsers that explicitly report it unsupported was unreachable because its own catch block swallowed the thrown error.

## Finding
- Severity: MEDIUM, confidence: certain
- Location: `client/fido2.ts:663-684` (on main), inside `fido2getCredential`
- When `PublicKeyCredential.isConditionalMediationAvailable()` resolved `false`, the code threw `Fido2ConfigError("Conditional mediation requested but not supported by this browser.")` — but that throw was inside the same `try` whose `catch` only debug-logged and continued. Concrete failure scenario: on a browser that explicitly reports conditional mediation unsupported, the error is silently swallowed and the code proceeds to call `navigator.credentials.get({ mediation: "conditional" })` anyway, typically producing an unexpected modal credential dialog at page load instead of the designed `Fido2ConfigError`. The debug message ("treating as unsupported") was also untruthful — the code proceeded as if supported.

## Fix
- `client/fido2.ts`: capture the result of `isConditionalMediationAvailable()` inside the `try`, and move the `Fido2ConfigError` throw outside it. Explicit `false` now propagates as `Fido2ConfigError`; if the capability check itself throws, the existing lenient behavior is kept and the debug message now truthfully says it proceeds with conditional mediation anyway.

## Test plan
- New regression tests in `client/__tests__/mediation-integration.test.ts`:
  - `isConditionalMediationAvailable()` resolves `false` → `Fido2ConfigError` is thrown and `navigator.credentials.get` is never called.
  - capability check rejects → request proceeds with conditional mediation and the lenient-path debug message is logged.
- `client/__tests__/__utils__/webauthn-mocks.ts`: new `conditionalMediationAvailable` config option and `setupConditionalMediationUnavailableMock()` helper covering the explicit-false case (previously only the function-missing case was mockable).
- Gates: `npx tsc --project client/tsconfig.json --noEmit` clean, `npx eslint` clean on changed files, `npx jest client/__tests__/` 128/128 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches WebAuthn sign-in client behavior for conditional mediation; wrong handling could change whether credential prompts run on unsupported browsers.
> 
> **Overview**
> Fixes a control-flow bug in **`fido2getCredential`** when `mediation` is **`conditional`**: if `PublicKeyCredential.isConditionalMediationAvailable()` returned **`false`**, the code threw **`Fido2ConfigError`** inside the same **`try`** whose **`catch`** only logged and continued, so the rejection never surfaced and **`navigator.credentials.get`** could still run.
> 
> The guard now stores the boolean in **`try`**, throws only when **`isAvailable === false`** after **`catch`**, and keeps the lenient path when the capability check itself fails (debug text updated to say it proceeds anyway).
> 
> Test support adds **`conditionalMediationAvailable`** on WebAuthn mocks, **`setupConditionalMediationUnavailableMock()`**, and integration cases for explicit unsupported vs. check rejection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06cdd28020ff68c5b758b34bb985e91c0658fb45. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->