### PR TITLE
Fix signOut permanently tearing down global refresh watchdog and visibility listener

### DIFF
--- a/client/common.ts
+++ b/client/common.ts
@@ -27,7 +27,7 @@ import {
   IdleState,
   busyState,
 } from "./model.js";
-import { scheduleRefresh, cleanupRefreshSystem } from "./refresh.js";
+import { scheduleRefresh, cleanupUserRefreshState } from "./refresh.js";
 import { computeClockDriftMs } from "./util.js";
 import { handleDeviceConfirmation } from "./device.js";
 import { withStorageLock, LockTimeoutError } from "./lock.js";
@@ -386,8 +386,11 @@ export const signOut = (props?: {
             activeRefreshSchedules.delete(userIdentifier);
           }
 
-          // Clean up all refresh system resources (timers, listeners)
-          cleanupRefreshSystem(userIdentifier);
+          // Clean up this user's refresh state (timers, in-memory state).
+          // Deliberately NOT cleanupRefreshSystem: that would tear down the
+          // global visibilitychange/watchdog listeners for the rest of the
+          // page lifetime, breaking refresh for the next user that signs in.
+          cleanupUserRefreshState(userIdentifier);
         }
 
         const tokens = await retrieveTokens();

--- a/client/refresh.ts
+++ b/client/refresh.ts
@@ -1016,8 +1016,41 @@ if (isBrowserEnvironment()) {
 }
 
 /**
+ * Clean up refresh state for a specific user (timers and in-memory state).
+ * Call this on sign-out: it does NOT remove the global visibilitychange,
+ * watchdog and unload listeners, so token refresh keeps working when
+ * another user signs in afterwards.
+ * @param username - Optional username to clean up specific user state
+ */
+export function cleanupUserRefreshState(username?: string): void {
+  logDebug("Cleaning up user refresh state");
+
+  // Get the appropriate refresh state
+  const state = getRefreshState(username);
+
+  // Clean up any active refresh timer
+  if (state.refreshTimer) {
+    state.refreshTimer();
+    state.refreshTimer = undefined;
+    state.nextRefreshTime = undefined;
+  }
+
+  // Reset refresh state
+  state.isRefreshing = false;
+  state.lastRefreshTime = undefined;
+
+  // Clear user-specific state from the map
+  if (username) {
+    clearRefreshState(username);
+  }
+}
+
+/**
  * Clean up all refresh-related timers and event listeners.
- * Call this when unmounting the application or switching users.
+ * Call this when unmounting the application (e.g. on page unload).
+ * Note: this removes the GLOBAL visibilitychange, watchdog and unload
+ * listeners for the rest of the page lifetime — for user sign-out use
+ * cleanupUserRefreshState instead.
  * @param username - Optional username to clean up specific user state
  */
 export function cleanupRefreshSystem(username?: string): void {
@@ -1043,22 +1076,6 @@ export function cleanupRefreshSystem(username?: string): void {
     autoCleanupHandler = undefined;
   }
 
-  // Get the appropriate refresh state
-  const state = getRefreshState(username);
-
-  // Clean up any active refresh timer
-  if (state.refreshTimer) {
-    state.refreshTimer();
-    state.refreshTimer = undefined;
-    state.nextRefreshTime = undefined;
-  }
-
-  // Reset refresh state
-  state.isRefreshing = false;
-  state.lastRefreshTime = undefined;
-
-  // Clear user-specific state from the map
-  if (username) {
-    clearRefreshState(username);
-  }
+  // Clean up per-user refresh state
+  cleanupUserRefreshState(username);
 }

--- a/client/refresh.ts
+++ b/client/refresh.ts
@@ -444,7 +444,12 @@ export async function scheduleRefresh(
   args: Parameters<typeof scheduleRefreshUnlocked>[0] = {}
 ): Promise<void> {
   const { clientId, debug } = configure();
-  const tokens0 = await retrieveTokens();
+  // Use retrieveTokensForRefresh first: the access token may already be
+  // expired while a refresh token still exists, and the per-user lock must
+  // still be honored then — e.g. signOut holds it during teardown, and the
+  // global watchdog/visibilitychange handlers must not schedule a refresh
+  // for a session that is being torn down
+  const tokens0 = (await retrieveTokensForRefresh()) ?? (await retrieveTokens());
   const userIdentifier = tokens0?.username;
   if (!userIdentifier) {
     debug?.("scheduleRefresh: no user, running unlocked");

--- a/test/scheduleRefresh.test.ts
+++ b/test/scheduleRefresh.test.ts
@@ -1,8 +1,8 @@
 import { configure } from "../client/config.js";
 import { scheduleRefresh } from "../client/refresh.js";
 
-// Helper to create a valid JWT for testing
-const createValidJWT = () => {
+// Helper to create a JWT for testing; expiry offset in seconds from now
+const createJWT = (expOffsetSeconds = 3600) => {
   const header = btoa(JSON.stringify({ alg: "HS256", typ: "JWT" }))
     .replace(/\+/g, "-")
     .replace(/\//g, "_")
@@ -11,7 +11,7 @@ const createValidJWT = () => {
     JSON.stringify({
       sub: "test-sub",
       username: "testuser",
-      exp: Math.floor(Date.now() / 1000) + 3600, // 1 hour from now
+      exp: Math.floor(Date.now() / 1000) + expOffsetSeconds,
       iat: Math.floor(Date.now() / 1000),
     })
   )
@@ -20,6 +20,7 @@ const createValidJWT = () => {
     .replace(/=+$/, "");
   return `${header}.${payload}.signature`;
 };
+const createValidJWT = () => createJWT(3600);
 
 describe("ScheduleRefresh Lock", () => {
   beforeEach(() => {
@@ -73,4 +74,35 @@ describe("ScheduleRefresh Lock", () => {
     expect(duration).toBeGreaterThan(14000);
     expect(duration).toBeLessThan(16000);
   }, 20000); // Increase timeout to handle lock wait
+
+  test("should honor the per-user lock when the access token is expired", async () => {
+    // Regression: scheduleRefresh used to derive the lock user via
+    // retrieveTokens(), which returns undefined for an expired access token,
+    // so the global watchdog/visibilitychange handlers would take the
+    // unlocked path and race a concurrent signOut holding the lock.
+    const debug = jest.fn();
+    configure({
+      clientId: "testClient",
+      cognitoIdpEndpoint: "us-west-2",
+      debug,
+    });
+    const { storage } = configure();
+    const amplifyKeyPrefix = `CognitoIdentityServiceProvider.testClient`;
+
+    await storage.setItem(`${amplifyKeyPrefix}.LastAuthUser`, "testuser");
+    await storage.setItem(
+      `${amplifyKeyPrefix}.testuser.accessToken`,
+      createJWT(-3600) // expired 1 hour ago
+    );
+    await storage.setItem(
+      `${amplifyKeyPrefix}.testuser.refreshToken`,
+      "test-refresh-token"
+    );
+
+    await scheduleRefresh();
+
+    const messages = debug.mock.calls.map((args) => String(args[0]));
+    expect(messages).not.toContain("scheduleRefresh: no user, running unlocked");
+    expect(messages).toContain("scheduleRefresh: waiting for lock");
+  });
 });

--- a/test/signout-keeps-global-listeners.test.ts
+++ b/test/signout-keeps-global-listeners.test.ts
@@ -1,0 +1,101 @@
+import { configure } from "../client/config.js";
+import { signOut } from "../client/common.js";
+import { storeTokens } from "../client/storage.js";
+
+// Helper to create JWT tokens
+const createJWT = (claims: Record<string, unknown>) => {
+  const header = btoa(JSON.stringify({ alg: "HS256", typ: "JWT" }))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+  const payload = btoa(JSON.stringify(claims))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+  return `${header}.${payload}.signature`;
+};
+
+const createTokens = (username: string, expiresInMs: number) => {
+  const now = Date.now();
+  return {
+    accessToken: createJWT({
+      sub: username,
+      username,
+      exp: Math.floor((now + expiresInMs) / 1000),
+      iat: Math.floor(now / 1000),
+    }),
+    refreshToken: `${username}-refresh-token`,
+    username,
+    expireAt: new Date(now + expiresInMs),
+  };
+};
+
+describe("Sign-out keeps global refresh listeners", () => {
+  let debugLogs: string[] = [];
+
+  beforeEach(() => {
+    debugLogs = [];
+    configure({
+      clientId: "testClient",
+      cognitoIdpEndpoint: "us-west-2",
+      debug: (...args: unknown[]) => {
+        debugLogs.push(args.map(String).join(" "));
+      },
+    });
+  });
+
+  test("signOut cleans up the user's refresh state without removing global listeners", async () => {
+    await storeTokens(createTokens("userA", 3600000));
+
+    const docRemoveSpy = jest.spyOn(document, "removeEventListener");
+    const globalRemoveSpy = jest.spyOn(globalThis, "removeEventListener");
+
+    const { signedOut } = signOut({ skipTokenRevocation: true });
+    await signedOut;
+
+    // Per-user cleanup ran ...
+    expect(
+      debugLogs.some((log) => log.includes("Cleaning up user refresh state"))
+    ).toBe(true);
+    // ... but the global teardown did NOT run
+    expect(
+      debugLogs.some((log) => log.includes("Cleaning up refresh system"))
+    ).toBe(false);
+
+    // The global visibilitychange listener must still be registered
+    const removedDocEvents = docRemoveSpy.mock.calls.map((call) => call[0]);
+    expect(removedDocEvents).not.toContain("visibilitychange");
+
+    // The watchdog's unload auto-cleanup listeners must still be registered
+    const removedGlobalEvents = globalRemoveSpy.mock.calls.map(
+      (call) => call[0]
+    );
+    expect(removedGlobalEvents).not.toContain("beforeunload");
+    expect(removedGlobalEvents).not.toContain("pagehide");
+    expect(removedGlobalEvents).not.toContain("unload");
+
+    docRemoveSpy.mockRestore();
+    globalRemoveSpy.mockRestore();
+  });
+
+  test("visibilitychange recovery still works for user B after user A signs out", async () => {
+    // User A signs out
+    await storeTokens(createTokens("userA", 3600000));
+    const { signedOut } = signOut({ skipTokenRevocation: true });
+    await signedOut;
+
+    // User B signs in
+    await storeTokens(createTokens("userB", 3600000));
+
+    // Simulate wake-from-sleep / tab becoming visible again
+    debugLogs = [];
+    document.dispatchEvent(new Event("visibilitychange"));
+    // The handler is async, give it a moment to run
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    // The global visibilitychange handler must still fire for user B
+    expect(
+      debugLogs.some((log) => log.includes("visibilitychange event:"))
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
Sign-out no longer destroys the module-global refresh safety nets (visibilitychange listener, watchdog loop, unload auto-cleanup handlers). It now only clears the signing-out user's refresh state, so token refresh keeps working for the next user who signs in within the same page lifetime.

## Finding
- Severity: MEDIUM, confidence: high
- `client/refresh.ts:953-1016` registers the visibilitychange listener, watchdog loop, and beforeunload/pagehide/unload handlers exactly once, at module import.
- `signOut` (`client/common.ts:390`) called `cleanupRefreshSystem(userIdentifier)` (`client/refresh.ts:1023`), which removes all three GLOBAL resources in addition to the per-user timer/state — and nothing ever re-registers them, since sign-in does not re-run module init.
- Concrete failure scenario in any SPA: user A signs out, user B signs in. B's session has no watchdog tick and no wake-from-sleep visibilitychange recovery, so a missed or late scheduled refresh has no safety net and B's tokens can silently expire.

## Fix
- New export `cleanupUserRefreshState(username?)` in `client/refresh.ts`: clears only the user's refresh timer and in-memory refresh state. It does not touch the global listeners.
- `cleanupRefreshSystem(username?)` keeps its full-teardown semantics (used by the page-unload auto-cleanup handler and for explicit app unmount) and now delegates the per-user portion to `cleanupUserRefreshState`. Its doc comment now warns it is page-lifetime teardown, not sign-out cleanup.
- `signOut` in `client/common.ts` now calls `cleanupUserRefreshState(userIdentifier)` instead of `cleanupRefreshSystem(userIdentifier)`.

## Test plan
- New regression suite `test/signout-keeps-global-listeners.test.ts`:
  - asserts signOut runs per-user cleanup but never calls `removeEventListener` for visibilitychange/beforeunload/pagehide/unload (jest spies);
  - asserts the visibilitychange handler still fires for user B after user A signs out.
- Verified both tests fail against the previous code and pass with the fix.
- `npx tsc --project client/tsconfig.json --noEmit` clean; `npx eslint` clean on changed files; full `npx jest test/` green: 16 suites (14 passed, 2 skipped), 60 tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches sign-out and token refresh coordination (locks, global listeners); behavior change is intentional but affects session lifecycle in SPAs with user switching.
> 
> **Overview**
> Fixes a SPA bug where **sign-out** called full **`cleanupRefreshSystem`**, removing module-global **visibilitychange**, **watchdog**, and **unload** listeners that are only registered once at import—so the next user on the same page lost refresh safety nets.
> 
> **Sign-out** now calls **`cleanupUserRefreshState`** to clear only that user’s timers and in-memory refresh state; **`cleanupRefreshSystem`** remains for page unload / app unmount and delegates per-user work to the new helper.
> 
> **`scheduleRefresh`** resolves the lock user via **`retrieveTokensForRefresh()`** (then **`retrieveTokens()`**) so an expired access token with a refresh token still takes the per-user lock path—avoiding races with **sign-out** from watchdog/visibility handlers.
> 
> Regression tests cover global listeners after sign-out, visibility recovery for a second user, and lock behavior with an expired access token.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9817a1d03ec9a69d297ef7c28544030253acfa5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->