### PR TITLE
Fix mfaStatusReady deadlock when access token rotates within MFA fetch cooldown

### DIFF
--- a/client/__tests__/react-mfa-status-cooldown.test.tsx
+++ b/client/__tests__/react-mfa-status-cooldown.test.tsx
@@ -1,0 +1,161 @@
+/**
+ * Copyright Amazon.com, Inc. and its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You
+ * may not use this file except in compliance with the License. A copy of
+ * the License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+import React from "react";
+import { renderHook, act } from "@testing-library/react";
+import {
+  PasswordlessContextProvider,
+  usePasswordless,
+} from "../react/hooks.js";
+import { configure } from "../config.js";
+import { retrieveTokens, TokensFromStorage } from "../storage.js";
+import { getUser } from "../cognito-api.js";
+import { refreshTokens } from "../refresh.js";
+import { TokensFromRefresh } from "../model.js";
+
+// Mocks
+jest.mock("../config");
+jest.mock("../storage");
+jest.mock("../hosted-oauth");
+jest.mock("../cognito-api");
+jest.mock("../refresh");
+jest.mock("../fido2", () => {
+  const actual = jest.requireActual("../fido2");
+  return {
+    ...actual,
+    fido2ListCredentials: jest.fn(() =>
+      Promise.resolve({ authenticators: [] })
+    ),
+  };
+});
+
+const mockConfigure = configure as jest.MockedFunction<typeof configure>;
+const mockRetrieveTokens = retrieveTokens as jest.MockedFunction<
+  typeof retrieveTokens
+>;
+const mockGetUser = getUser as jest.MockedFunction<typeof getUser>;
+const mockRefreshTokens = refreshTokens as jest.MockedFunction<
+  typeof refreshTokens
+>;
+
+// Build a token that the parseJwtPayload mock in setup.ts can decode
+const makeJwt = (payload: Record<string, unknown>) =>
+  `eyJhbGciOiJub25lIn0.${btoa(JSON.stringify(payload))}.signature`;
+
+const makeTokens = (suffix: string): TokensFromStorage => {
+  const expireAt = new Date(Date.now() + 3600_000);
+  return {
+    accessToken: makeJwt({
+      sub: "test-sub",
+      username: "test-user",
+      exp: Math.floor(expireAt.valueOf() / 1000),
+      iat: Math.floor(Date.now() / 1000),
+      jti: suffix,
+    }),
+    idToken: undefined,
+    refreshToken: `refresh-token-${suffix}`,
+    expireAt,
+    username: "test-user",
+    authMethod: "REDIRECT",
+  };
+};
+
+// Helper wrapper to mount the hook with the provider
+const makeWrapper = () =>
+  function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <PasswordlessContextProvider>{children}</PasswordlessContextProvider>
+    );
+  };
+
+describe("MFA status fetch cooldown", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+
+    mockConfigure.mockReturnValue({
+      clientId: "test-client-id",
+      debug: jest.fn(),
+      storage: {
+        getItem: jest.fn(),
+        setItem: jest.fn(),
+        removeItem: jest.fn(),
+      },
+    } as unknown as ReturnType<typeof configure>);
+
+    mockGetUser.mockResolvedValue({
+      Username: "test-user",
+      UserAttributes: [],
+      UserMFASettingList: [],
+    } as unknown as Awaited<ReturnType<typeof getUser>>);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("recovers mfaStatusReady when the access token rotates within the cooldown window", async () => {
+    const initialTokens = makeTokens("initial");
+    mockRetrieveTokens.mockResolvedValue(initialTokens);
+
+    // Simulate a token refresh that rotates the access token
+    const rotatedTokens = makeTokens("rotated") as TokensFromRefresh;
+    mockRefreshTokens.mockImplementation(async (args) => {
+      await args?.tokensCb?.(rotatedTokens);
+      return rotatedTokens;
+    });
+
+    const wrapper = makeWrapper();
+    const { result } = renderHook(() => usePasswordless(), { wrapper });
+
+    // Let the initial effects run: tokens load, getUser fetches MFA status
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(0);
+    });
+    expect(mockGetUser).toHaveBeenCalledTimes(1);
+    expect(result.current.mfaStatusReady).toBe(true);
+
+    // 2 seconds later (within the 5s cooldown) the access token rotates,
+    // e.g. an OAuth code exchange or forceRefreshTokens completes
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(2_000);
+    });
+    await act(async () => {
+      await result.current.refreshTokens();
+    });
+
+    // The token change resets mfaStatusReady, and the cooldown blocks an
+    // immediate re-fetch
+    expect(result.current.mfaStatusReady).toBe(false);
+    expect(mockGetUser).toHaveBeenCalledTimes(1);
+
+    // Once the cooldown elapses, the fetch must run again on its own
+    // (without the fix, no dependency changes and this deadlocks at false)
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(3_100);
+    });
+    expect(mockGetUser).toHaveBeenCalledTimes(2);
+    expect(mockGetUser).toHaveBeenLastCalledWith(
+      expect.objectContaining({ accessToken: rotatedTokens.accessToken })
+    );
+    expect(result.current.mfaStatusReady).toBe(true);
+
+    // No fetch storm: nothing further is scheduled once status is known
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(30_000);
+    });
+    expect(mockGetUser).toHaveBeenCalledTimes(2);
+  });
+});

--- a/client/react/hooks.tsx
+++ b/client/react/hooks.tsx
@@ -1016,12 +1016,30 @@ function _usePasswordless() {
     // Skip if we fetched recently (within cooldown period)
     if (timeSinceLastFetch < MFA_FETCH_COOLDOWN) {
       const { debug } = configure();
+      const remainingCooldown = MFA_FETCH_COOLDOWN - timeSinceLastFetch;
       debug?.(
         `Skipping getUser call - cooldown active (${Math.round(
-          (MFA_FETCH_COOLDOWN - timeSinceLastFetch) / 1000
+          remainingCooldown / 1000
         )}s remaining)`
       );
-      return;
+      // Schedule a re-run of this effect once the cooldown elapses,
+      // otherwise mfaStatusReady could stay false forever (the access
+      // token changed, so updateTokens reset it, but no dependency of
+      // this effect would change again on its own)
+      if (mfaRetryTimeoutRef.current) {
+        clearTimeout(mfaRetryTimeoutRef.current);
+      }
+      mfaRetryTimeoutRef.current = setTimeout(() => {
+        mfaRetryTimeoutRef.current = undefined;
+        // Nudge a re-run
+        dispatch({ type: "INCREMENT_RECHECK_STATUS" });
+      }, remainingCooldown);
+      return () => {
+        if (mfaRetryTimeoutRef.current) {
+          clearTimeout(mfaRetryTimeoutRef.current);
+          mfaRetryTimeoutRef.current = undefined;
+        }
+      };
     }
 
     lastFetchedMfaTokenRef.current = tokens.accessToken;


### PR DESCRIPTION
## Summary
`mfaStatusReady` could get stuck at `false` forever when the access token changed within 5 seconds of the previous MFA status fetch. Any UI gated on `mfaStatusReady` ("True once we have a reliable MFA status") would show a loader until page reload.

## Finding
- Severity: MEDIUM, Confidence: high (reproduced via regression test on unfixed code)
- `client/react/hooks.tsx`: `updateTokens` dispatches `SET_MFA_STATUS_READY: false` whenever the access token changes (hooks.tsx:1146-1148 and 1162-1164). The getUser fetch effect (hooks.tsx:1006-1123) is responsible for setting it back to `true`, but it early-returned when `timeSinceLastFetch < MFA_FETCH_COOLDOWN` (5s) without updating any refs and without scheduling a retry. The effect's deps (`isSignedIn`, `tokens?.accessToken`, `recheckSignInStatus`) never change again on their own, so the effect never re-ran.
- Concrete failure scenario (routine): a returning user with stored tokens hits the OAuth redirect callback page. `loadTokens()` installs stored tokens and the effect fetches `getUser` at t=0. The code exchange completes 1-3s later, `updateTokens` installs the new access token and flips `mfaStatusReady` to `false`. The effect re-runs, hits the cooldown, returns — `mfaStatusReady` stays `false` until reload. Same for sign-in followed within 5s by `forceRefreshTokens()`.

## Fix
When the cooldown blocks the fetch, schedule a `setTimeout` for the remaining cooldown that dispatches `INCREMENT_RECHECK_STATUS` (the same nudge mechanism the effect's error-retry path already uses), so the effect re-runs once the cooldown elapses and fetches MFA status for the new token. The cooldown branch now returns a cleanup that clears the timer on dep change/unmount, so a third token rotation within the window just replaces the timer — no fetch storm.

## Test plan
- New regression test `client/__tests__/react-mfa-status-cooldown.test.tsx` (jest/jsdom, fake timers): loads stored tokens, lets the initial `getUser` complete, rotates the access token 2s later via `refreshTokens`, asserts `mfaStatusReady` drops to `false` and the fetch is cooldown-blocked, then advances past the cooldown and asserts `getUser` runs again with the new token and `mfaStatusReady` becomes `true`, and that no further fetches occur afterwards.
- Verified the test fails on unfixed code (getUser never re-called, `mfaStatusReady` stuck at `false`) and passes with the fix.
- Gates: `npx tsc --project client/tsconfig.json --noEmit` clean; `npx eslint` clean on changed files; `npx jest client/__tests__/` — 11 suites, 127 tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches sign-in/MFA readiness in the React passwordless hook; behavior change is narrow (cooldown skip path) but affects UI gated on `mfaStatusReady`.
> 
> **Overview**
> Fixes a **deadlock** where `mfaStatusReady` could stay `false` until reload when the access token changed within the 5s `getUser` cooldown (e.g. OAuth callback or refresh right after an initial MFA fetch). `updateTokens` clears readiness on token rotation, but the MFA effect used to return early on cooldown with no follow-up, so effect deps never changed again.
> 
> When cooldown blocks the fetch, the hook now **schedules a timer** for the remaining cooldown that dispatches `INCREMENT_RECHECK_STATUS` (same nudge as the existing error-retry path), with cleanup so repeated rotations replace the timer instead of storming `getUser`.
> 
> Adds **`react-mfa-status-cooldown.test.tsx`**: fake timers, token rotation via `refreshTokens`, asserts recovery after cooldown and no extra fetches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ef49a88a559d7cd81f2e92b1871e92f483c2d9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->