### PR TITLE
Add discriminating error codes so the documented NotAllowedError fallback works

### DIFF
--- a/ERROR_HANDLING.md
+++ b/ERROR_HANDLING.md
@@ -232,6 +232,9 @@ All base properties plus:
 | ------------------------ | -------------------- | ------------------------------------------ | ----------------------------------- |
 | `WEBAUTHN_ABORTED`       | Fido2AbortError      | "Passkey verification was cancelled"       | User cancelled or operation aborted |
 | `CREDENTIAL_ERROR`       | Fido2CredentialError | "Unable to complete passkey operation"     | Credential operation failed         |
+| `CREDENTIAL_NOT_ALLOWED` | Fido2CredentialError | "Passkey access was denied. Please try again." | User cancelled, no gesture, permission denied, or no local credentials (mediation: "immediate"). Detect via `isFido2NotAllowedError()` |
+| `CREDENTIAL_INVALID_STATE` | Fido2CredentialError | "This passkey is already registered"     | Authenticator in invalid state or credential already registered |
+| `CREDENTIAL_REQUEST_PENDING` | Fido2CredentialError | "Another passkey request is in progress. Please try again." | Another WebAuthn request is already pending (Chrome throws OperationError) |
 | `CONFIG_ERROR`           | Fido2ConfigError     | "Passkeys are not properly configured"     | Missing or invalid configuration    |
 | `VALIDATION_ERROR`       | Fido2ValidationError | "Unable to verify passkey"                 | Data validation failed              |
 | `AUTH_ERROR`             | Fido2AuthError       | "Authentication with passkey failed"       | Authentication/authorization failed |
@@ -262,6 +265,7 @@ The library automatically converts WebAuthn DOMExceptions to appropriate Fido2Er
 | `AbortError`        | Fido2AbortError      | "Passkey verification was cancelled"           | Operation cancelled via AbortController or timeout             |
 | `NotAllowedError`   | Fido2CredentialError | "Passkey access was denied. Please try again." | User cancelled ceremony, no user gesture, or permission denied |
 | `InvalidStateError` | Fido2CredentialError | "This passkey is already registered"           | Authenticator is in invalid state                              |
+| `OperationError`    | Fido2CredentialError | "Another passkey request is in progress. Please try again." | Another WebAuthn request is already pending (Chrome-specific, not in spec) |
 | `SecurityError`     | Fido2ConfigError     | "Passkeys cannot be used on this website"      | Invalid domain or HTTPS required                               |
 | `UnknownError`      | Fido2Error           | "Something went wrong with your passkey"       | Client-specific error that doesn't fit other categories        |
 
@@ -275,10 +279,22 @@ try {
   await fido2getCredential({ challenge });
 } catch (error) {
   if (error instanceof Fido2CredentialError) {
-    console.log("Error code:", error.code); // "CREDENTIAL_ERROR"
+    console.log("Error code:", error.code); // "CREDENTIAL_NOT_ALLOWED"
     console.log("Technical:", error.message); // "Operation not allowed..."
     console.log("User-friendly:", error.userMessage); // "Passkey access was denied..."
     console.log("Original DOMException:", error.cause); // NotAllowedError
+  }
+}
+
+// Or use the helper predicate (e.g. to fall back to a password form
+// when mediation: "immediate" finds no local credentials):
+import { isFido2NotAllowedError } from "@joinmeow/cognito-passwordless-auth";
+
+try {
+  await authenticateWithFido2({ mediation: "immediate" }).signedIn;
+} catch (error) {
+  if (isFido2NotAllowedError(error)) {
+    showPasswordForm();
   }
 }
 ```

--- a/client/__tests__/errors.test.ts
+++ b/client/__tests__/errors.test.ts
@@ -23,6 +23,7 @@ import {
   Fido2NetworkError,
   isFido2Error,
   isFido2AbortError,
+  isFido2NotAllowedError,
   fromDOMException,
 } from "../errors.js";
 
@@ -80,6 +81,20 @@ describe("Fido2Error classes", () => {
       expect(error.code).toBe("CREDENTIAL_ERROR");
       expect(error.name).toBe("Fido2CredentialError");
       expect(error.cause).toBe(cause);
+    });
+
+    it("should accept a custom code while defaulting to CREDENTIAL_ERROR", () => {
+      const defaultError = new Fido2CredentialError("No credential found");
+      expect(defaultError.code).toBe("CREDENTIAL_ERROR");
+
+      const customError = new Fido2CredentialError(
+        "Not allowed",
+        undefined,
+        undefined,
+        "CREDENTIAL_NOT_ALLOWED"
+      );
+      expect(customError.code).toBe("CREDENTIAL_NOT_ALLOWED");
+      expect(customError.name).toBe("Fido2CredentialError");
     });
   });
 
@@ -175,6 +190,40 @@ describe("Type guards", () => {
       expect(isFido2AbortError(null)).toBe(false);
     });
   });
+
+  describe("isFido2NotAllowedError", () => {
+    it("should return true for errors mapped from DOMException NotAllowedError", () => {
+      const domError = new DOMException("Not allowed", "NotAllowedError");
+      expect(isFido2NotAllowedError(fromDOMException(domError))).toBe(true);
+    });
+
+    it("should return false for other credential error codes", () => {
+      const invalidState = fromDOMException(
+        new DOMException("Invalid state", "InvalidStateError")
+      );
+      const pending = fromDOMException(
+        new DOMException("A request is already pending", "OperationError")
+      );
+
+      expect(isFido2NotAllowedError(invalidState)).toBe(false);
+      expect(isFido2NotAllowedError(pending)).toBe(false);
+      expect(isFido2NotAllowedError(new Fido2CredentialError("test"))).toBe(
+        false
+      );
+    });
+
+    it("should return false for non-credential errors", () => {
+      expect(isFido2NotAllowedError(new Fido2AbortError())).toBe(false);
+      expect(isFido2NotAllowedError(new Error("test"))).toBe(false);
+      expect(
+        isFido2NotAllowedError(
+          new DOMException("Not allowed", "NotAllowedError")
+        )
+      ).toBe(false);
+      expect(isFido2NotAllowedError(null)).toBe(false);
+      expect(isFido2NotAllowedError(undefined)).toBe(false);
+    });
+  });
 });
 
 describe("fromDOMException", () => {
@@ -188,23 +237,53 @@ describe("fromDOMException", () => {
       expect(error.code).toBe("WEBAUTHN_ABORTED");
     });
 
-    it("should convert NotAllowedError to Fido2CredentialError", () => {
+    it("should convert NotAllowedError to Fido2CredentialError with CREDENTIAL_NOT_ALLOWED code", () => {
       const domError = new DOMException("Not allowed", "NotAllowedError");
       const error = fromDOMException(domError);
 
       expect(error).toBeInstanceOf(Fido2CredentialError);
       expect(error.message).toContain("not allowed");
-      expect(error.code).toBe("CREDENTIAL_ERROR");
+      expect(error.code).toBe("CREDENTIAL_NOT_ALLOWED");
       expect(error.cause).toBe(domError);
     });
 
-    it("should convert InvalidStateError to Fido2CredentialError", () => {
+    it("should convert InvalidStateError to Fido2CredentialError with CREDENTIAL_INVALID_STATE code", () => {
       const domError = new DOMException("Invalid state", "InvalidStateError");
       const error = fromDOMException(domError);
 
       expect(error).toBeInstanceOf(Fido2CredentialError);
       expect(error.message).toContain("invalid state");
-      expect(error.code).toBe("CREDENTIAL_ERROR");
+      expect(error.code).toBe("CREDENTIAL_INVALID_STATE");
+      expect(error.cause).toBe(domError);
+    });
+
+    it("should convert OperationError to Fido2CredentialError with CREDENTIAL_REQUEST_PENDING code", () => {
+      // Chrome throws OperationError when another WebAuthn request is pending
+      const domError = new DOMException(
+        "A request is already pending",
+        "OperationError"
+      );
+      const error = fromDOMException(domError);
+
+      expect(error).toBeInstanceOf(Fido2CredentialError);
+      expect(error.message).toContain("already pending");
+      expect(error.code).toBe("CREDENTIAL_REQUEST_PENDING");
+      expect(error.cause).toBe(domError);
+    });
+
+    it("should convert OperationError without a pending-request message to generic Fido2Error", () => {
+      // Browsers can also surface OperationError for transient/authenticator
+      // failures - those must not be reported as a pending request
+      const domError = new DOMException(
+        "The operation failed for an unknown transient reason.",
+        "OperationError"
+      );
+      const error = fromDOMException(domError);
+
+      expect(error).toBeInstanceOf(Fido2Error);
+      expect(error).not.toBeInstanceOf(Fido2CredentialError);
+      expect(error.message).toContain("WebAuthn operation failed");
+      expect(error.code).toBe("WEBAUTHN_ERROR");
       expect(error.cause).toBe(domError);
     });
 

--- a/client/__tests__/fido2-errors.test.ts
+++ b/client/__tests__/fido2-errors.test.ts
@@ -26,7 +26,9 @@ import {
   Fido2CredentialError,
   Fido2ConfigError,
   Fido2AuthError,
+  Fido2Error,
   Fido2ValidationError,
+  isFido2NotAllowedError,
 } from "../errors.js";
 import type { ConfigWithDefaults } from "../config.js";
 import { configure } from "../config.js";
@@ -546,6 +548,94 @@ describe("fido2.ts error handling", () => {
           relyingPartyId: "example.com",
         })
       ).rejects.toThrow(Fido2CredentialError);
+    });
+
+    it("should convert NotAllowedError from get() to an error detectable via isFido2NotAllowedError", async () => {
+      const mockGet = jest
+        .fn()
+        .mockRejectedValue(new DOMException("Not allowed", "NotAllowedError"));
+      Object.defineProperty(global.navigator, "credentials", {
+        value: { get: mockGet },
+        configurable: true,
+      });
+
+      const thrown = await fido2getCredential({
+        challenge: "test-challenge",
+        relyingPartyId: "example.com",
+      }).then(
+        () => undefined,
+        (err: unknown) => err
+      );
+
+      expect(thrown).toBeInstanceOf(Fido2CredentialError);
+      expect((thrown as Fido2CredentialError).code).toBe(
+        "CREDENTIAL_NOT_ALLOWED"
+      );
+      expect(isFido2NotAllowedError(thrown)).toBe(true);
+      // The documented legacy pattern `error.name === 'NotAllowedError'`
+      // does not match library errors - only the cause keeps the DOM name
+      expect((thrown as Fido2CredentialError).name).toBe(
+        "Fido2CredentialError"
+      );
+      expect(((thrown as Fido2CredentialError).cause as DOMException).name).toBe(
+        "NotAllowedError"
+      );
+    });
+
+    it("should convert OperationError (pending request) to Fido2CredentialError with CREDENTIAL_REQUEST_PENDING", async () => {
+      // Chrome throws OperationError when another WebAuthn request is pending
+      const mockGet = jest
+        .fn()
+        .mockRejectedValue(
+          new DOMException("A request is already pending", "OperationError")
+        );
+      Object.defineProperty(global.navigator, "credentials", {
+        value: { get: mockGet },
+        configurable: true,
+      });
+
+      const thrown = await fido2getCredential({
+        challenge: "test-challenge",
+        relyingPartyId: "example.com",
+      }).then(
+        () => undefined,
+        (err: unknown) => err
+      );
+
+      expect(thrown).toBeInstanceOf(Fido2CredentialError);
+      expect((thrown as Fido2CredentialError).code).toBe(
+        "CREDENTIAL_REQUEST_PENDING"
+      );
+      expect(isFido2NotAllowedError(thrown)).toBe(false);
+    });
+
+    it("should convert OperationError without a pending message to generic Fido2Error", async () => {
+      // Browsers can surface OperationError for transient/authenticator
+      // failures too - those must keep the generic fallback mapping
+      const mockGet = jest
+        .fn()
+        .mockRejectedValue(
+          new DOMException(
+            "The operation failed for an unknown transient reason.",
+            "OperationError"
+          )
+        );
+      Object.defineProperty(global.navigator, "credentials", {
+        value: { get: mockGet },
+        configurable: true,
+      });
+
+      const thrown = await fido2getCredential({
+        challenge: "test-challenge",
+        relyingPartyId: "example.com",
+      }).then(
+        () => undefined,
+        (err: unknown) => err
+      );
+
+      expect(thrown).toBeInstanceOf(Fido2Error);
+      expect(thrown).not.toBeInstanceOf(Fido2CredentialError);
+      expect((thrown as Fido2Error).code).toBe("WEBAUTHN_ERROR");
     });
 
     it("should convert NotSupportedError to Fido2ConfigError for create", async () => {

--- a/client/errors.ts
+++ b/client/errors.ts
@@ -62,12 +62,29 @@ export class Fido2AbortError extends Fido2Error {
  * - No credential returned from browser
  * - Invalid credential format
  * - Credential not found
+ *
+ * The `code` property discriminates the failure mode:
+ * - "CREDENTIAL_NOT_ALLOWED": user cancelled, no local credentials
+ *   (mediation: "immediate"), no user gesture, or permission denied
+ *   (DOMException NotAllowedError)
+ * - "CREDENTIAL_INVALID_STATE": authenticator in invalid state or credential
+ *   already registered (DOMException InvalidStateError)
+ * - "CREDENTIAL_REQUEST_PENDING": another WebAuthn request is already pending
+ *   (DOMException OperationError whose message indicates a pending request,
+ *   e.g. Chrome's "A request is already pending"; other OperationErrors map
+ *   to the generic fallback)
+ * - "CREDENTIAL_ERROR": other credential failures (default)
  */
 export class Fido2CredentialError extends Fido2Error {
-  constructor(message: string, cause?: unknown, userMessage?: string) {
+  constructor(
+    message: string,
+    cause?: unknown,
+    userMessage?: string,
+    code = "CREDENTIAL_ERROR"
+  ) {
     super(
       message,
-      "CREDENTIAL_ERROR",
+      code,
       userMessage ?? "Unable to complete passkey operation",
       cause
     );
@@ -176,6 +193,37 @@ export function isFido2AbortError(error: unknown): error is Fido2AbortError {
 }
 
 /**
+ * Type guard to check if error means the WebAuthn ceremony was not allowed:
+ * the user cancelled the passkey dialog, no user gesture was present,
+ * permission was denied, or (with mediation: "immediate") no local
+ * credentials were available.
+ *
+ * Note: errors thrown by this library are Fido2Error instances, so checking
+ * `error.name === "NotAllowedError"` does NOT work — the original
+ * DOMException is only preserved in `error.cause`. Use this helper instead,
+ * e.g. to fall back to a password form:
+ *
+ * @example
+ * ```typescript
+ * try {
+ *   await authenticateWithFido2({ mediation: "immediate" }).signedIn;
+ * } catch (error) {
+ *   if (isFido2NotAllowedError(error)) {
+ *     showPasswordForm();
+ *   }
+ * }
+ * ```
+ */
+export function isFido2NotAllowedError(
+  error: unknown
+): error is Fido2CredentialError {
+  return (
+    error instanceof Fido2CredentialError &&
+    error.code === "CREDENTIAL_NOT_ALLOWED"
+  );
+}
+
+/**
  * Helper to convert DOMException (from WebAuthn API) to appropriate Fido2Error
  *
  * Based on WebAuthn Level 2 specification:
@@ -194,12 +242,15 @@ export function fromDOMException(error: DOMException): Fido2Error {
       );
 
     case "NotAllowedError":
-      // User cancelled the ceremony, or no user gesture, or permission denied
+      // User cancelled the ceremony, or no user gesture, or permission denied,
+      // or no local credentials with mediation: "immediate"
       // This is a catch-all covering many scenarios
+      // Detect via isFido2NotAllowedError() or code === "CREDENTIAL_NOT_ALLOWED"
       return new Fido2CredentialError(
         "Operation not allowed (user cancelled, no gesture, or permission denied)",
         error,
-        "Passkey access was denied. Please try again."
+        "Passkey access was denied. Please try again.",
+        "CREDENTIAL_NOT_ALLOWED"
       );
 
     case "InvalidStateError":
@@ -208,8 +259,26 @@ export function fromDOMException(error: DOMException): Fido2Error {
       return new Fido2CredentialError(
         "Authenticator is in invalid state or credential already registered",
         error,
-        "This passkey is already registered"
+        "This passkey is already registered",
+        "CREDENTIAL_INVALID_STATE"
       );
+
+    case "OperationError":
+      // Not in the WebAuthn spec list, but thrown by Chrome when another
+      // WebAuthn request is already pending ("A request is already pending").
+      // Browsers also surface OperationError for generic transient or
+      // authenticator failures, so only map to CREDENTIAL_REQUEST_PENDING
+      // when the message actually indicates a pending/concurrent request;
+      // other OperationErrors fall through to the generic fallback below
+      if (/pending/i.test(error.message)) {
+        return new Fido2CredentialError(
+          "Another WebAuthn request is already pending",
+          error,
+          "Another passkey request is in progress. Please try again.",
+          "CREDENTIAL_REQUEST_PENDING"
+        );
+      }
+      break;
 
     case "NotSupportedError":
       // No pubKeyCredParams had type="public-key", or authenticator doesn't support algorithms
@@ -242,13 +311,14 @@ export function fromDOMException(error: DOMException): Fido2Error {
         error
       );
 
-    default:
-      // Catch any other DOMExceptions not in spec
-      return new Fido2Error(
-        `WebAuthn operation failed: ${error.message}`,
-        "WEBAUTHN_ERROR",
-        "Unable to use passkey. Please try again.",
-        error
-      );
   }
+
+  // Catch any other DOMExceptions not in spec
+  // (incl. OperationError without a pending-request message)
+  return new Fido2Error(
+    `WebAuthn operation failed: ${error.message}`,
+    "WEBAUTHN_ERROR",
+    "Unable to use passkey. Please try again.",
+    error
+  );
 }

--- a/client/fido2.ts
+++ b/client/fido2.ts
@@ -141,9 +141,11 @@ export async function getClientCapabilities(): Promise<WebAuthnClientCapabilitie
  * } else if (capabilities.immediate) {
  *   // Use immediate mediation for smart sign-in button
  *   try {
- *     await authenticateWithFido2({ mediation: 'immediate' });
+ *     await authenticateWithFido2({ mediation: 'immediate' }).signedIn;
  *   } catch (error) {
- *     if (error.name === 'NotAllowedError') {
+ *     // Library errors wrap the DOMException (error.name is never
+ *     // 'NotAllowedError'); use the helper to detect this case
+ *     if (isFido2NotAllowedError(error)) {
  *       showPasswordForm();
  *     }
  *   }
@@ -1101,6 +1103,7 @@ export function authenticateWithFido2({
    * Usage patterns:
    * ```typescript
    * import { detectMediationCapabilities, getClientCapabilities } from './fido2';
+   * import { isFido2NotAllowedError } from './errors';
    *
    * // Option 1: Simple detection helper
    * const { conditional, immediate } = await detectMediationCapabilities();
@@ -1116,9 +1119,11 @@ export function authenticateWithFido2({
    * const capabilities = await getClientCapabilities();
    * if (capabilities?.immediateGet) {
    *   try {
-   *     await authenticateWithFido2({ mediation: 'immediate' });
+   *     await authenticateWithFido2({ mediation: 'immediate' }).signedIn;
    *   } catch (error) {
-   *     if (error.name === 'NotAllowedError') {
+   *     // Library errors wrap the DOMException (error.name is never
+   *     // 'NotAllowedError'); use the helper to detect this case
+   *     if (isFido2NotAllowedError(error)) {
    *       // No local credentials - show password form
    *       showPasswordForm();
    *     }

--- a/client/react/README.md
+++ b/client/react/README.md
@@ -126,7 +126,10 @@ sequenceDiagram
 
 ```tsx
 import { useEffect } from "react";
-import { detectMediationCapabilities } from "@joinmeow/cognito-passwordless-auth";
+import {
+  detectMediationCapabilities,
+  isFido2NotAllowedError,
+} from "@joinmeow/cognito-passwordless-auth";
 import { usePasswordless } from "@joinmeow/cognito-passwordless-auth/react";
 
 function AutofillSignInButton() {
@@ -144,7 +147,9 @@ function AutofillSignInButton() {
         // User selected a passkey – finish sign-in using the prepared assertion.
         authenticateWithFido2({ prepared });
       } catch (error) {
-        if (error instanceof DOMException && error.name === "NotAllowedError") {
+        // The library wraps DOMExceptions (error.name is never
+        // "NotAllowedError"); use the helper to detect this case.
+        if (isFido2NotAllowedError(error)) {
           // User ignored the autofill UI – fall back gracefully.
           return;
         }


### PR DESCRIPTION
## Summary
The library's own docs told integrators to detect user-cancelled / no-local-credential passkey failures via `error.name === 'NotAllowedError'`, but that condition can never match an error thrown by this library. This PR adds discriminating error codes, a helper predicate, and maps Chrome's `OperationError` (pending request), then fixes the docs to a pattern that actually works.

## Finding
- Severity: MEDIUM, confidence: certain
- `client/errors.ts:196-203` (pre-fix): `fromDOMException` converts a DOMException `NotAllowedError` into a `Fido2CredentialError` whose `.name` is `"Fido2CredentialError"` — the original DOMException survives only in `.cause`.
- Yet the JSDoc at `client/fido2.ts:146` (`detectMediationCapabilities`) and `client/fido2.ts:1121` (`authenticateWithFido2`'s `mediation` param), plus `client/react/README.md:147`, instructed integrators to write `if (error.name === 'NotAllowedError') { showPasswordForm(); }`.
- Concrete failure scenario: an app uses `mediation: 'immediate'` for a frictionless sign-in button and follows the documented pattern to fall back to a password form when no local credentials exist. The browser rejects with `NotAllowedError`, the library rewraps it, the documented check never fires, and the user is silently stuck with no fallback UI.
- Compounding: `Fido2CredentialError` used the single code `CREDENTIAL_ERROR` for both `NotAllowedError` and `InvalidStateError`, so there was no programmatic discriminator short of inspecting `.cause`.
- Addendum: for a concurrent pending request, Chrome throws `OperationError` ("A request is already pending"), which fell through to the generic `WEBAUTHN_ERROR` catch-all.

## Fix
- `Fido2CredentialError` gains an optional trailing `code` parameter (default `CREDENTIAL_ERROR`, class and name unchanged, so `instanceof` checks and direct construction keep working).
- `fromDOMException` now maps `NotAllowedError` → `CREDENTIAL_NOT_ALLOWED`, `InvalidStateError` → `CREDENTIAL_INVALID_STATE`, and adds an `OperationError` case → `CREDENTIAL_REQUEST_PENDING`, following the existing code-naming scheme.
- New exported type guard `isFido2NotAllowedError()` (same pattern as `isFido2AbortError`) for the password-form fallback; exported via the existing `export * from "./errors.js"` in `client/index.ts`.
- Rewrote the JSDoc examples in `client/fido2.ts` and the docs in `ERROR_HANDLING.md` and `client/react/README.md` to use the helper (and `.signedIn`, matching the real return shape of `authenticateWithFido2`).

## Test plan
- `npx tsc --project client/tsconfig.json --noEmit` — clean
- `npx eslint client/errors.ts client/fido2.ts client/__tests__/errors.test.ts client/__tests__/fido2-errors.test.ts` — clean
- `npx jest client/__tests__/` — 10 suites, 133 tests, all passing
- New/updated tests: `fromDOMException` code assertions for `NotAllowedError`, `InvalidStateError`, and `OperationError`; `isFido2NotAllowedError` predicate (positive/negative cases incl. raw DOMException); `Fido2CredentialError` default-code backward compatibility; end-to-end `fido2getCredential` rejection tests proving the legacy `error.name` pattern doesn't match while the helper does, and the `OperationError` pending-request mapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-side error mapping and API surface only; default `CREDENTIAL_ERROR` is preserved for direct construction, with expanded tests and no auth protocol changes.
> 
> **Overview**
> Fixes a **documentation vs. behavior mismatch**: integrators were told to use `error.name === 'NotAllowedError'`, but thrown errors are `Fido2CredentialError` with the DOMException only on `error.cause`.
> 
> **`Fido2CredentialError`** now accepts an optional **`code`** (default `CREDENTIAL_ERROR`). **`fromDOMException`** maps WebAuthn DOMExceptions to **`CREDENTIAL_NOT_ALLOWED`**, **`CREDENTIAL_INVALID_STATE`**, and **`CREDENTIAL_REQUEST_PENDING`** (Chrome `OperationError` when the message matches `/pending/i`; other `OperationError`s stay **`WEBAUTHN_ERROR`**).
> 
> Adds exported **`isFido2NotAllowedError()`** for password-form / immediate-mediation fallback. Updates **`ERROR_HANDLING.md`**, **`fido2.ts`** JSDoc (including **`.signedIn`**), and **`client/react/README.md`** to use the helper instead of `error.name`.
> 
> Tests cover the new codes, the predicate, backward-compatible default codes, and end-to-end `fido2getCredential` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53533f2a0211154c9a375066cf43ec35d3ed8a4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->