### PR TITLE
Reset per-user state on sign-out in React hook

### DIFF
--- a/client/__tests__/react-signout-reset.test.tsx
+++ b/client/__tests__/react-signout-reset.test.tsx
@@ -243,4 +243,73 @@ describe("signOut resets per-user state", () => {
     });
     expect(result.current.mfaStatusReady).toBe(false);
   });
+
+  it("fetches the next user's MFA status immediately after sign-out, without waiting out the previous user's cooldown", async () => {
+    // Regression: sign-out cleared lastFetchedMfaTokenRef but left the
+    // 5s fetch cooldown running, so a different user signing in right
+    // after sign-out had their MFA fetch blocked by the previous user's
+    // cooldown window.
+    const tokensA: TokensFromSignIn = {
+      accessToken: "mock-access-token",
+      idToken: "mock-id-token",
+      refreshToken: "mock-refresh-token",
+      expireAt: new Date(Date.now() + 3600_000),
+      username: "user-a",
+      authMethod: "FIDO2",
+    };
+    const tokensB: TokensFromSignIn = {
+      ...tokensA,
+      accessToken: "mock-access-token-user-b",
+      username: "user-b",
+    };
+
+    let capturedTokensCb:
+      | ((tokens: TokensFromSignIn) => void | Promise<void>)
+      | undefined;
+    mockAuthenticateWithFido2.mockImplementation((props) => {
+      capturedTokensCb = props?.tokensCb;
+      return {
+        signedIn: Promise.resolve(tokensA),
+        abort: jest.fn(),
+      };
+    });
+
+    const wrapper = makeWrapper();
+    const { result } = renderHook(() => usePasswordless(), { wrapper });
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    // User A signs in; MFA status fetched
+    act(() => {
+      result.current.authenticateWithFido2({ username: "user-a" });
+    });
+    await act(async () => {
+      await capturedTokensCb!(tokensA);
+    });
+    await waitFor(() => {
+      expect(result.current.mfaStatusReady).toBe(true);
+    });
+    expect(mockGetUser).toHaveBeenCalledTimes(1);
+
+    // Sign out, then user B signs in well within the 5s cooldown
+    await act(async () => {
+      await result.current.signOut().signedOut;
+    });
+    act(() => {
+      result.current.authenticateWithFido2({ username: "user-b" });
+    });
+    await act(async () => {
+      await capturedTokensCb!(tokensB);
+    });
+
+    // User B's MFA fetch must run immediately (no 5s stall)
+    await waitFor(() => {
+      expect(mockGetUser).toHaveBeenCalledTimes(2);
+      expect(result.current.mfaStatusReady).toBe(true);
+    });
+    expect(mockGetUser.mock.calls[1][0]).toMatchObject({
+      accessToken: "mock-access-token-user-b",
+    });
+  });
 });

--- a/client/__tests__/react-signout-reset.test.tsx
+++ b/client/__tests__/react-signout-reset.test.tsx
@@ -1,0 +1,171 @@
+/**
+ * Copyright Amazon.com, Inc. and its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You
+ * may not use this file except in compliance with the License. A copy of
+ * the License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+import React from "react";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import {
+  PasswordlessContextProvider,
+  usePasswordless,
+} from "../react/hooks.js";
+import { configure } from "../config.js";
+import { retrieveTokens } from "../storage.js";
+import { signOut as signOutCore } from "../common.js";
+import { getUser } from "../cognito-api.js";
+import { authenticateWithFido2 as authenticateWithFido2Core } from "../fido2.js";
+import type { TokensFromSignIn } from "../model.js";
+
+// Mocks
+jest.mock("../config");
+jest.mock("../storage");
+jest.mock("../common");
+jest.mock("../cognito-api");
+jest.mock("../hosted-oauth");
+jest.mock("../fido2", () => {
+  const actual = jest.requireActual("../fido2");
+  return {
+    ...actual,
+    authenticateWithFido2: jest.fn(),
+  };
+});
+
+const mockConfigure = configure as jest.MockedFunction<typeof configure>;
+const mockRetrieveTokens = retrieveTokens as jest.MockedFunction<
+  typeof retrieveTokens
+>;
+const mockSignOutCore = signOutCore as jest.MockedFunction<typeof signOutCore>;
+const mockGetUser = getUser as jest.MockedFunction<typeof getUser>;
+const mockAuthenticateWithFido2 =
+  authenticateWithFido2Core as jest.MockedFunction<
+    typeof authenticateWithFido2Core
+  >;
+
+// Helper wrapper to mount the hook with the provider
+const makeWrapper = () =>
+  function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <PasswordlessContextProvider>{children}</PasswordlessContextProvider>
+    );
+  };
+
+describe("signOut resets per-user state", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // Minimal default config for tests
+    mockConfigure.mockReturnValue({
+      clientId: "test-client-id",
+      debug: jest.fn(),
+      storage: {
+        getItem: jest.fn(),
+        setItem: jest.fn(),
+        removeItem: jest.fn(),
+      },
+    } as unknown as ReturnType<typeof configure>);
+
+    // No cached tokens at mount
+    mockRetrieveTokens.mockResolvedValue(undefined);
+
+    // getUser reports user A has TOTP MFA enabled and preferred
+    mockGetUser.mockResolvedValue({
+      Username: "user-a",
+      UserAttributes: [],
+      MFAOptions: [],
+      UserMFASettingList: ["SOFTWARE_TOKEN_MFA"],
+      PreferredMfaSetting: "SOFTWARE_TOKEN_MFA",
+    });
+
+    // Core signOut invokes the local-removal callback like the real one does
+    mockSignOutCore.mockImplementation((props) => {
+      props?.statusCb?.("SIGNING_OUT");
+      props?.tokensRemovedLocallyCb?.();
+      props?.statusCb?.("SIGNED_OUT");
+      return {
+        signedOut: Promise.resolve(),
+        abort: jest.fn(),
+      } as unknown as ReturnType<typeof signOutCore>;
+    });
+  });
+
+  it("clears deviceKey, totpMfaStatus and mfaStatusReady on signOut", async () => {
+    const signInTokens: TokensFromSignIn = {
+      accessToken: "mock-access-token", // parseable via parseJwtPayload mock in setup.ts
+      idToken: "mock-id-token",
+      refreshToken: "mock-refresh-token",
+      expireAt: new Date(Date.now() + 3600_000),
+      username: "user-a",
+      authMethod: "FIDO2",
+      deviceKey: "us-west-2_device-key-user-a",
+    };
+
+    // Capture the hook's tokensCb so we can drive a sign-in with a deviceKey
+    let capturedTokensCb:
+      | ((tokens: TokensFromSignIn) => void | Promise<void>)
+      | undefined;
+    mockAuthenticateWithFido2.mockImplementation((props) => {
+      capturedTokensCb = props?.tokensCb;
+      return {
+        signedIn: Promise.resolve(signInTokens),
+        abort: jest.fn(),
+      };
+    });
+
+    const wrapper = makeWrapper();
+    const { result } = renderHook(() => usePasswordless(), { wrapper });
+
+    // Wait for initial token retrieval to settle
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    // Sign user A in (the mocked core flow hands tokens to the hook)
+    act(() => {
+      result.current.authenticateWithFido2({ username: "user-a" });
+    });
+    expect(capturedTokensCb).toBeDefined();
+    await act(async () => {
+      await capturedTokensCb!(signInTokens);
+    });
+
+    // Per-user state is populated for user A
+    await waitFor(() => {
+      expect(result.current.signInStatus).toBe("SIGNED_IN");
+      expect(result.current.deviceKey).toBe("us-west-2_device-key-user-a");
+      expect(result.current.totpMfaStatus).toEqual({
+        enabled: true,
+        preferred: true,
+        availableMfaTypes: ["SOFTWARE_TOKEN_MFA"],
+      });
+      expect(result.current.mfaStatusReady).toBe(true);
+    });
+
+    // Sign out
+    await act(async () => {
+      await result.current.signOut().signedOut;
+    });
+
+    // All per-user state must be reset so it cannot leak to the next user
+    expect(result.current.tokens).toBeUndefined();
+    expect(result.current.tokensParsed).toBeUndefined();
+    expect(result.current.fido2Credentials).toBeUndefined();
+    expect(result.current.deviceKey).toBeNull();
+    expect(result.current.totpMfaStatus).toEqual({
+      enabled: false,
+      preferred: false,
+      availableMfaTypes: [],
+    });
+    expect(result.current.mfaStatusReady).toBe(false);
+    expect(result.current.signInStatus).toBe("NOT_SIGNED_IN");
+  });
+});

--- a/client/__tests__/react-signout-reset.test.tsx
+++ b/client/__tests__/react-signout-reset.test.tsx
@@ -168,4 +168,79 @@ describe("signOut resets per-user state", () => {
     expect(result.current.mfaStatusReady).toBe(false);
     expect(result.current.signInStatus).toBe("NOT_SIGNED_IN");
   });
+
+  it("discards an in-flight getUser response that lands after signOut", async () => {
+    // Regression: a getUser response resolving in the microtask gap between
+    // the SIGN_OUT dispatch and React's effect cleanup (which aborts the
+    // fetch) used to re-dispatch the previous user's MFA status while
+    // signed out.
+    type GetUserResult = Awaited<ReturnType<typeof getUser>>;
+    let resolveGetUser: ((user: GetUserResult) => void) | undefined;
+    mockGetUser.mockImplementation(
+      () =>
+        new Promise<GetUserResult>((resolve) => {
+          resolveGetUser = resolve;
+        })
+    );
+
+    const signInTokens: TokensFromSignIn = {
+      accessToken: "mock-access-token",
+      idToken: "mock-id-token",
+      refreshToken: "mock-refresh-token",
+      expireAt: new Date(Date.now() + 3600_000),
+      username: "user-a",
+      authMethod: "FIDO2",
+    };
+    let capturedTokensCb:
+      | ((tokens: TokensFromSignIn) => void | Promise<void>)
+      | undefined;
+    mockAuthenticateWithFido2.mockImplementation((props) => {
+      capturedTokensCb = props?.tokensCb;
+      return {
+        signedIn: Promise.resolve(signInTokens),
+        abort: jest.fn(),
+      };
+    });
+
+    const wrapper = makeWrapper();
+    const { result } = renderHook(() => usePasswordless(), { wrapper });
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    // Sign in; the MFA fetch starts and stays pending
+    act(() => {
+      result.current.authenticateWithFido2({ username: "user-a" });
+    });
+    await act(async () => {
+      await capturedTokensCb!(signInTokens);
+    });
+    await waitFor(() => {
+      expect(result.current.signInStatus).toBe("SIGNED_IN");
+    });
+    expect(resolveGetUser).toBeDefined();
+    expect(result.current.mfaStatusReady).toBe(false);
+
+    // Sign out, and let the stale getUser response land in the microtask
+    // gap after the SIGN_OUT dispatch but before the effect cleanup aborts
+    await act(async () => {
+      const signingOut = result.current.signOut();
+      resolveGetUser!({
+        Username: "user-a",
+        UserAttributes: [],
+        MFAOptions: [],
+        UserMFASettingList: ["SOFTWARE_TOKEN_MFA"],
+        PreferredMfaSetting: "SOFTWARE_TOKEN_MFA",
+      });
+      await signingOut.signedOut;
+    });
+
+    // The stale response must not restore the previous user's MFA status
+    expect(result.current.totpMfaStatus).toEqual({
+      enabled: false,
+      preferred: false,
+      availableMfaTypes: [],
+    });
+    expect(result.current.mfaStatusReady).toBe(false);
+  });
 });

--- a/client/react/hooks.tsx
+++ b/client/react/hooks.tsx
@@ -389,12 +389,19 @@ function passwordlessReducer(
       return { ...state, nowTick: action.payload };
 
     case "SIGN_OUT":
+      // Reset all per-user state (tokens, deviceKey, TOTP MFA status, etc.)
+      // so nothing leaks into the next user's session. Keep the signing
+      // status (it is driven by the sign-out flow's status callback) and
+      // device capabilities, and use fresh activity timestamps (the ones in
+      // initialPasswordlessState were captured at module load)
       return {
         ...initialPasswordlessState,
-        signingInStatus: "SIGNED_OUT",
+        signingInStatus: state.signingInStatus,
         initiallyRetrievingTokensFromStorage: false,
         userVerifyingPlatformAuthenticatorAvailable:
           state.userVerifyingPlatformAuthenticatorAvailable,
+        lastActivityAt: Date.now(),
+        nowTick: Date.now(),
       };
 
     default:
@@ -1422,6 +1429,10 @@ function _usePasswordless() {
           _setTokens(undefined);
           parseAndSetTokens(undefined);
           dispatch({ type: "SET_FIDO2_CREDENTIALS", payload: undefined });
+          // Reset remaining per-user state (deviceKey, TOTP MFA status,
+          // mfaStatusReady, activity timestamps) so it cannot leak into
+          // the next user's session
+          dispatch({ type: "SIGN_OUT" });
         },
         currentStatus: signingInStatus,
         skipTokenRevocation: options?.skipTokenRevocation,

--- a/client/react/hooks.tsx
+++ b/client/react/hooks.tsx
@@ -1050,11 +1050,20 @@ function _usePasswordless() {
     lastMfaFetchTimeRef.current = now;
 
     const abortController = new AbortController();
+    // Capture the token this fetch is for: if it is no longer the one we
+    // last fetched for by the time the response lands (sign-out cleared it,
+    // or a newer token's fetch started), the result must be discarded —
+    // the abort check alone can't cover the microtask gap between a
+    // SIGN_OUT dispatch and this effect's cleanup
+    const fetchedForToken = tokens.accessToken;
+    const isStale = () =>
+      abortController.signal.aborted ||
+      lastFetchedMfaTokenRef.current !== fetchedForToken;
 
     // Get MFA settings for the signed-in user
     getUser({ accessToken: tokens.accessToken, abort: abortController.signal })
       .then((user) => {
-        if (abortController.signal.aborted) return;
+        if (isStale()) return;
 
         // If we have a valid user object with MFA settings, use them
         if (user && typeof user === "object" && !("__type" in user)) {
@@ -1095,7 +1104,7 @@ function _usePasswordless() {
         }
       })
       .catch(() => {
-        if (abortController.signal.aborted) return;
+        if (isStale()) return;
 
         // On error we keep the previously known MFA status to avoid
         // falsely disabling security-gated UI. Log for debugging.
@@ -1448,6 +1457,10 @@ function _usePasswordless() {
           // mfaStatusReady, activity timestamps) so it cannot leak into
           // the next user's session
           lastActivityAtRef.current = Date.now();
+          // Invalidate any in-flight getUser fetch so a response landing
+          // after sign-out cannot restore the previous user's MFA status
+          // (and a same-token re-sign-in refetches afresh)
+          lastFetchedMfaTokenRef.current = undefined;
           dispatch({ type: "SIGN_OUT" });
         },
         currentStatus: signingInStatus,

--- a/client/react/hooks.tsx
+++ b/client/react/hooks.tsx
@@ -1038,12 +1038,30 @@ function _usePasswordless() {
     // Skip if we fetched recently (within cooldown period)
     if (timeSinceLastFetch < MFA_FETCH_COOLDOWN) {
       const { debug } = configure();
+      const remainingCooldown = MFA_FETCH_COOLDOWN - timeSinceLastFetch;
       debug?.(
         `Skipping getUser call - cooldown active (${Math.round(
-          (MFA_FETCH_COOLDOWN - timeSinceLastFetch) / 1000
+          remainingCooldown / 1000
         )}s remaining)`
       );
-      return;
+      // Schedule a re-run of this effect once the cooldown elapses,
+      // otherwise mfaStatusReady could stay false forever (the access
+      // token changed, so updateTokens reset it, but no dependency of
+      // this effect would change again on its own)
+      if (mfaRetryTimeoutRef.current) {
+        clearTimeout(mfaRetryTimeoutRef.current);
+      }
+      mfaRetryTimeoutRef.current = setTimeout(() => {
+        mfaRetryTimeoutRef.current = undefined;
+        // Nudge a re-run
+        dispatch({ type: "INCREMENT_RECHECK_STATUS" });
+      }, remainingCooldown);
+      return () => {
+        if (mfaRetryTimeoutRef.current) {
+          clearTimeout(mfaRetryTimeoutRef.current);
+          mfaRetryTimeoutRef.current = undefined;
+        }
+      };
     }
 
     lastFetchedMfaTokenRef.current = tokens.accessToken;
@@ -1461,6 +1479,11 @@ function _usePasswordless() {
           // after sign-out cannot restore the previous user's MFA status
           // (and a same-token re-sign-in refetches afresh)
           lastFetchedMfaTokenRef.current = undefined;
+          // Also reset the fetch cooldown: it rate-limits fetches within a
+          // session, and sign-out is a session boundary — the next user's
+          // MFA status fetch must run immediately, not wait out a cooldown
+          // started by the previous user
+          lastMfaFetchTimeRef.current = 0;
           dispatch({ type: "SIGN_OUT" });
         },
         currentStatus: signingInStatus,

--- a/client/react/hooks.tsx
+++ b/client/react/hooks.tsx
@@ -398,16 +398,14 @@ function passwordlessReducer(
       // Reset all per-user state (tokens, deviceKey, TOTP MFA status, etc.)
       // so nothing leaks into the next user's session. Keep the signing
       // status (it is driven by the sign-out flow's status callback) and
-      // device capabilities, and use fresh activity timestamps (the ones in
-      // initialPasswordlessState were captured at module load)
+      // device capabilities. Activity tracking lives in a ref
+      // (lastActivityAtRef) and is reset by the signOut flow itself
       return {
         ...initialPasswordlessState,
         signingInStatus: state.signingInStatus,
         initiallyRetrievingTokensFromStorage: false,
         userVerifyingPlatformAuthenticatorAvailable:
           state.userVerifyingPlatformAuthenticatorAvailable,
-        lastActivityAt: Date.now(),
-        nowTick: Date.now(),
       };
 
     default:
@@ -1449,6 +1447,7 @@ function _usePasswordless() {
           // Reset remaining per-user state (deviceKey, TOTP MFA status,
           // mfaStatusReady, activity timestamps) so it cannot leak into
           // the next user's session
+          lastActivityAtRef.current = Date.now();
           dispatch({ type: "SIGN_OUT" });
         },
         currentStatus: signingInStatus,


### PR DESCRIPTION
## Summary
The React `signOut` method never reset per-user state — the `SIGN_OUT` reducer action was dead code. Device key, TOTP MFA status, MFA readiness flag and activity timestamps survived sign-out and leaked into the next user's session. This PR dispatches `SIGN_OUT` from the sign-out flow and makes the reducer case complete.

## Finding
- **Severity:** Medium
- **Confidence:** High (verified by grep and a failing regression test against `main`)
- `client/react/hooks.tsx:391` defined a `SIGN_OUT` reducer case that was never dispatched anywhere.
- The `signOut` method (`client/react/hooks.tsx:1416-1433` on `main`) cleared only `lastError`, `authMethod`, tokens/parsed tokens and `fido2Credentials`. It never reset `deviceKey`, `totpMfaStatus`, `mfaStatusReady`, or `lastActivityAt`.
- Concrete failure scenarios:
  - User A signs out, user B signs in without a device key in the auth response: `deviceKey` still holds A's key, so `confirmDevice()` (`client/react/hooks.tsx:1266-1318` on `main`) would confirm/register A's device key against B's access token.
  - `totpMfaStatus` keeps showing user A's MFA configuration for user B until the `getUser` fetch completes — and the fetch's catch handler (`client/react/hooks.tsx:1075-1083` on `main`) deliberately retains the previous TOTP MFA status and sets `mfaStatusReady: true`, so on a transient `getUser` failure user B's security UI is confidently rendered from user A's MFA settings.

## Fix
- Dispatch `SIGN_OUT` from the `signOut` method's `tokensRemovedLocallyCb`, alongside the existing token/credential clears.
- Make the `SIGN_OUT` reducer case complete and safe:
  - Resets all per-user state via `initialPasswordlessState` (tokens, parsed tokens, FIDO2 credentials, `deviceKey`, `totpMfaStatus`, `mfaStatusReady`, error, auth method, refresh/recheck state).
  - Preserves `signingInStatus` — the sign-out status machine stays owned by the flow's `statusCb` (which fires `SIGNING_OUT` / `SIGNED_OUT` around token revocation).
  - Preserves `userVerifyingPlatformAuthenticatorAvailable` (a device capability, not per-user).
  - Uses fresh `lastActivityAt` / `nowTick` timestamps instead of the stale module-load-time values captured in `initialPasswordlessState`.
- Device remembering is unaffected: the persisted per-username device key in storage is intentionally kept (see `client/common.ts` sign-out), and the in-memory `deviceKey` is rehydrated from `getRememberedDevice(username)` on the next sign-in.

## Test plan
- New regression test `client/__tests__/react-signout-reset.test.tsx`: signs a user in via the FIDO2 flow with a device key, waits for `getUser` to report TOTP MFA enabled, calls `signOut()`, and asserts `deviceKey`, `totpMfaStatus`, `mfaStatusReady`, tokens and `signInStatus` are all reset. Verified this test fails on unfixed `main` (deviceKey leaked) and passes with the fix.
- `npx tsc --project client/tsconfig.json --noEmit` — clean.
- `npx eslint client/react/hooks.tsx client/__tests__/react-signout-reset.test.tsx` — clean.
- `npx jest client/__tests__/` — 11 suites, 127 tests, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auth session boundaries (device key, MFA UI, Cognito getUser timing); behavior change is intentional to fix cross-user leakage, with regression tests added.
> 
> **Overview**
> Fixes **cross-user session leakage** in the React `usePasswordless` hook by actually running sign-out cleanup that was defined but never triggered.
> 
> **Sign-out now resets per-user state:** `signOut` dispatches `SIGN_OUT` from `tokensRemovedLocallyCb`, clearing `deviceKey`, TOTP MFA status, `mfaStatusReady`, and related reducer state while keeping sign-out status callbacks and device capability flags. The `SIGN_OUT` reducer no longer forces `signingInStatus` to `SIGNED_OUT` so the existing sign-out flow still owns that lifecycle.
> 
> **MFA fetch hardening:** On sign-out, refs for the last MFA token and the 5s fetch cooldown are cleared so the next user is not blocked or polluted by the previous session. In-flight `getUser` responses are ignored via an `isStale()` check when the token ref no longer matches, covering the gap before effect cleanup aborts the request.
> 
> **Tests:** New `react-signout-reset.test.tsx` covers full state reset after sign-out, stale `getUser` after sign-out, and immediate MFA fetch for a user who signs in right after another user signs out.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f6c311da6845f9226b31006c6d845fbf12dbc33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->