### PR TITLE
Fix OAuth in-progress flag being clobbered by non-callback invocations

### DIFF
--- a/client/__tests__/hosted-oauth.test.ts
+++ b/client/__tests__/hosted-oauth.test.ts
@@ -266,6 +266,97 @@ describe("OAuth Integration with processTokens", () => {
       expect(mockProcessTokens).not.toHaveBeenCalled();
     });
 
+    it("should not touch the in-progress flag when invoked on a non-callback URL", async () => {
+      // Flow in flight, but current URL is NOT the configured redirect URL
+      // (e.g. another tab loads a page with an unrelated ?code=... param)
+      mockLocation.href = "https://app.example.com/some-other-page?code=COUPON";
+      mockLocation.pathname = "/some-other-page";
+      mockLocation.search = "?code=COUPON";
+
+      mockStorage.getItem.mockImplementation((key: string) => {
+        if (key === "cognito_oauth_in_progress") return Promise.resolve("true");
+        if (key === "cognito_oauth_state") return Promise.resolve("test-state");
+        if (key === "cognito_oauth_pkce")
+          return Promise.resolve("test-verifier");
+        return Promise.resolve(null);
+      });
+
+      const result = await handleCognitoOAuthCallback();
+
+      expect(result).toBeNull();
+      expect(mockProcessTokens).not.toHaveBeenCalled();
+      // The in-flight flag must NOT be overwritten ("processing") or cleared,
+      // otherwise the real callback would be silently ignored later
+      expect(mockStorage.setItem).not.toHaveBeenCalledWith(
+        "cognito_oauth_in_progress",
+        expect.anything()
+      );
+      expect(mockStorage.removeItem).not.toHaveBeenCalledWith(
+        "cognito_oauth_in_progress"
+      );
+    });
+
+    it("should process the real callback after a non-callback invocation", async () => {
+      const storedItems: Record<string, string> = {
+        cognito_oauth_in_progress: "true",
+        cognito_oauth_state: "test-state",
+        cognito_oauth_pkce: "test-verifier",
+      };
+      mockStorage.getItem.mockImplementation((key: string) =>
+        Promise.resolve(storedItems[key] ?? null)
+      );
+      mockStorage.setItem.mockImplementation((key: string, value: string) => {
+        storedItems[key] = value;
+        return Promise.resolve();
+      });
+      mockStorage.removeItem.mockImplementation((key: string) => {
+        delete storedItems[key];
+        return Promise.resolve();
+      });
+
+      // First invocation: non-callback URL while flow is in flight
+      mockLocation.href = "https://app.example.com/some-other-page?code=COUPON";
+      mockLocation.pathname = "/some-other-page";
+      mockLocation.search = "?code=COUPON";
+
+      expect(await handleCognitoOAuthCallback()).toBeNull();
+      expect(storedItems["cognito_oauth_in_progress"]).toBe("true");
+
+      // Second invocation: the real Cognito redirect arrives
+      mockLocation.href =
+        "https://app.example.com/signin-redirect?code=test-code&state=test-state";
+      mockLocation.pathname = "/signin-redirect";
+      mockLocation.search = "?code=test-code&state=test-state";
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          access_token: "mock-access-token",
+          id_token: "mock-id-token",
+          refresh_token: "mock-refresh-token",
+          expires_in: 3600,
+          token_type: "Bearer",
+        }),
+      });
+
+      const processedTokens = {
+        accessToken: "mock-access-token",
+        idToken: "mock-id-token",
+        refreshToken: "mock-refresh-token",
+        expireAt: new Date(Date.now() + 3600000),
+        username: "test-user",
+        authMethod: "REDIRECT" as const,
+      };
+      mockProcessTokens.mockResolvedValue(processedTokens);
+
+      const result = await handleCognitoOAuthCallback();
+
+      expect(result).toEqual(processedTokens);
+      expect(mockProcessTokens).toHaveBeenCalledTimes(1);
+      // OAuth state is cleaned up after successful processing
+      expect(storedItems["cognito_oauth_in_progress"]).toBeUndefined();
+    });
+
     it("should throw error on OAuth state mismatch", async () => {
       mockStorage.getItem.mockImplementation((key: string) => {
         if (key === "cognito_oauth_in_progress") return Promise.resolve("true");

--- a/client/hosted-oauth.ts
+++ b/client/hosted-oauth.ts
@@ -158,9 +158,6 @@ export async function handleCognitoOAuthCallback(): Promise<TokensFromSignIn | n
     return null; // not our redirect
   }
 
-  // Mark as processing to prevent duplicate handling in concurrent invocations
-  await cfg.storage.setItem(OAUTH_IN_PROGRESS_KEY, "processing");
-
   const url = new URL(cfg.location.href);
   debug?.(`Current URL: ${url.toString()}`);
   debug?.(
@@ -189,6 +186,12 @@ export async function handleCognitoOAuthCallback(): Promise<TokensFromSignIn | n
   }
 
   debug?.("URL matches expected redirect URL, continuing OAuth flow");
+
+  // Mark as processing to prevent duplicate handling in concurrent invocations.
+  // This must happen only AFTER the redirect-URL check above: invocations on
+  // other URLs must leave the in-progress flag untouched, so the real callback
+  // can still be processed when it arrives.
+  await cfg.storage.setItem(OAUTH_IN_PROGRESS_KEY, "processing");
 
   const error = url.searchParams.get("error");
   if (error) {


### PR DESCRIPTION
## Summary
`handleCognitoOAuthCallback()` set the shared OAuth in-progress flag to `"processing"` before checking whether the current URL is the configured redirect URL, and the mismatch branch returned `null` without restoring it. Any invocation on a non-callback URL while a flow was in flight permanently bricked that sign-in. This PR moves the redirect-URL check ahead of the flag transition.

## Finding
- Severity: MEDIUM, Confidence: high
- `client/hosted-oauth.ts:156-189` (pre-fix): the handler checked `OAUTH_IN_PROGRESS === "true"`, immediately overwrote it with `"processing"`, and only then compared the current URL with the configured redirect URL. The URL-mismatch branch returned `null` without restoring the flag.
- Concrete failure scenario: user starts hosted-UI sign-in in tab A; tab B loads any app page whose URL contains `?code=...` (the React hook at `client/react/hooks.tsx:746` fires `handleCognitoOAuthCallback` on ANY `code` query param — e.g. a coupon/invite code). Tab B's invocation flips the shared localStorage flag to `"processing"` and bails on the URL mismatch. When the real Cognito redirect arrives in tab A, `inFlight !== "true"` and the callback is silently ignored — the auth code, state, and PKCE verifier rot in storage and the sign-in never completes.

## Fix
Move the redirect-URL comparison before the `"processing"` flag write in `client/hosted-oauth.ts`, so invocations on non-callback URLs leave the in-flight flag untouched. All remaining paths after the flag write either complete the flow or clear OAuth state and throw, so no other early exit can strand the flag.

## Test plan
- Added regression tests in `client/__tests__/hosted-oauth.test.ts`:
  - flow in flight + handler invoked on a non-callback URL returns `null` and the in-progress flag is neither overwritten nor removed
  - a subsequent invocation on the real callback URL processes the code normally (mocked token exchange) and cleans up OAuth state
- Verified both new tests fail against the pre-fix code and pass with the fix
- `npx tsc --project client/tsconfig.json --noEmit` passes
- `npx eslint client/hosted-oauth.ts client/__tests__/hosted-oauth.test.ts` passes
- `npx jest client/__tests__/hosted-oauth.test.ts`: 9 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication callback ordering and shared storage state; behavior change is narrow but sign-in completion is security-sensitive.
> 
> **Overview**
> Fixes hosted Cognito OAuth sign-in getting **stuck** when `handleCognitoOAuthCallback()` runs on a page that is not the configured redirect URL while a flow is already in progress (e.g. another tab with an unrelated `?code=` query param).
> 
> **`hosted-oauth.ts`:** The write that sets `cognito_oauth_in_progress` to `"processing"` now happens **after** the normalized redirect-URL check. Early returns on URL mismatch no longer flip that flag, so the real callback can still run when it lands on the correct redirect path.
> 
> **Tests:** Two regressions cover non-callback invocations leaving the in-progress flag unchanged (no `setItem`/`removeItem` on that key) and a later real redirect still completing token exchange and cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c98a8a375e0aa32557e3a9d455865772fe01f4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->