### PR TITLE
Add opt-in Hosted UI sign-out via signOutWithRedirect

### DIFF
--- a/client/__tests__/hosted-ui-logout.test.ts
+++ b/client/__tests__/hosted-ui-logout.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Copyright Amazon.com, Inc. and its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You
+ * may not use this file except in compliance with the License. A copy of
+ * the License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+import { signOutWithRedirect } from "../hosted-oauth.js";
+import { configure, getLogoutEndpoint } from "../config.js";
+import { signOut } from "../common.js";
+import type { Config } from "../config.js";
+
+// Mock the local sign-out (the real config module is used so we exercise
+// actual logout URL construction)
+jest.mock("../common");
+jest.mock("../storage");
+
+const mockSignOut = signOut as jest.MockedFunction<typeof signOut>;
+
+type MutableLocation = {
+  href: string;
+  hostname: string;
+};
+
+describe("Hosted UI logout (signOutWithRedirect)", () => {
+  let mockLocation: MutableLocation;
+  let mockStorage: {
+    getItem: jest.Mock;
+    setItem: jest.Mock;
+    removeItem: jest.Mock;
+  };
+
+  const baseConfig = (): Config => ({
+    cognitoIdpEndpoint: "eu-west-1",
+    clientId: "test-client-id",
+    hostedUi: {
+      domain: "auth.example.com",
+      redirectSignIn: "https://app.example.com/signin-redirect",
+      redirectSignOut: "https://app.example.com/signed-out",
+    },
+    location: mockLocation,
+    storage: mockStorage,
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockLocation = {
+      href: "https://app.example.com/some/page",
+      hostname: "app.example.com",
+    };
+
+    mockStorage = {
+      getItem: jest.fn(),
+      setItem: jest.fn(),
+      removeItem: jest.fn(),
+    };
+
+    mockSignOut.mockReturnValue({
+      signedOut: Promise.resolve(),
+      abort: jest.fn(),
+    } as unknown as ReturnType<typeof signOut>);
+  });
+
+  describe("getLogoutEndpoint", () => {
+    it("builds the logout endpoint from the hosted UI domain", () => {
+      configure(baseConfig());
+      expect(getLogoutEndpoint()).toBe("https://auth.example.com/logout");
+    });
+
+    it("falls back to cognitoIdpEndpoint when no hosted UI domain is set", () => {
+      const config = baseConfig();
+      config.cognitoIdpEndpoint = "https://cognito.example.com";
+      delete config.hostedUi!.domain;
+      configure(config);
+      expect(getLogoutEndpoint()).toBe("https://cognito.example.com/logout");
+    });
+  });
+
+  describe("signOutWithRedirect", () => {
+    it("navigates to the logout endpoint with client_id and encoded logout_uri", async () => {
+      configure(baseConfig());
+
+      await signOutWithRedirect();
+
+      expect(mockLocation.href).toBe(
+        "https://auth.example.com/logout?client_id=test-client-id&logout_uri=https%3A%2F%2Fapp.example.com%2Fsigned-out"
+      );
+    });
+
+    it("converts a relative redirectSignOut to an absolute logout_uri", async () => {
+      const config = baseConfig();
+      config.hostedUi!.redirectSignOut = "/signed-out";
+      configure(config);
+
+      await signOutWithRedirect();
+
+      expect(mockLocation.href).toBe(
+        "https://auth.example.com/logout?client_id=test-client-id&logout_uri=https%3A%2F%2Fapp.example.com%2Fsigned-out"
+      );
+    });
+
+    it("performs the local sign-out before navigating", async () => {
+      const events: string[] = [];
+
+      mockSignOut.mockReturnValue({
+        signedOut: new Promise<void>((resolve) => {
+          setTimeout(() => {
+            events.push("localSignOut");
+            resolve();
+          }, 10);
+        }),
+        abort: jest.fn(),
+      } as unknown as ReturnType<typeof signOut>);
+
+      let href = "https://app.example.com/some/page";
+      const trackedLocation: MutableLocation = {
+        hostname: "app.example.com",
+        get href() {
+          return href;
+        },
+        set href(value: string) {
+          events.push("navigate");
+          href = value;
+        },
+      };
+      const config = baseConfig();
+      config.location = trackedLocation;
+      configure(config);
+
+      await signOutWithRedirect();
+
+      expect(events).toEqual(["localSignOut", "navigate"]);
+    });
+
+    it("forwards sign-out props (e.g. skipTokenRevocation) to the local signOut", async () => {
+      configure(baseConfig());
+      const tokensRemovedLocallyCb = jest.fn();
+
+      await signOutWithRedirect({
+        skipTokenRevocation: true,
+        tokensRemovedLocallyCb,
+      });
+
+      expect(mockSignOut).toHaveBeenCalledWith({
+        skipTokenRevocation: true,
+        tokensRemovedLocallyCb,
+      });
+    });
+
+    it("throws and does not navigate when redirectSignOut is not configured", async () => {
+      const config = baseConfig();
+      delete config.hostedUi!.redirectSignOut;
+      configure(config);
+
+      await expect(signOutWithRedirect()).rejects.toThrow(
+        "hostedUi.redirectSignOut configuration missing"
+      );
+      expect(mockSignOut).not.toHaveBeenCalled();
+      expect(mockLocation.href).toBe("https://app.example.com/some/page");
+    });
+
+    it("throws and does not navigate when hostedUi is not configured", async () => {
+      const config = baseConfig();
+      delete config.hostedUi;
+      configure(config);
+
+      await expect(signOutWithRedirect()).rejects.toThrow(
+        "hostedUi configuration missing"
+      );
+      expect(mockSignOut).not.toHaveBeenCalled();
+      expect(mockLocation.href).toBe("https://app.example.com/some/page");
+    });
+
+    it("does not navigate when the local sign-out fails", async () => {
+      configure(baseConfig());
+
+      mockSignOut.mockReturnValue({
+        signedOut: Promise.reject(new Error("sign-out failed")),
+        abort: jest.fn(),
+      } as unknown as ReturnType<typeof signOut>);
+
+      await expect(signOutWithRedirect()).rejects.toThrow("sign-out failed");
+      expect(mockLocation.href).toBe("https://app.example.com/some/page");
+    });
+  });
+});

--- a/client/__tests__/hosted-ui-logout.test.ts
+++ b/client/__tests__/hosted-ui-logout.test.ts
@@ -153,6 +153,10 @@ describe("Hosted UI logout (signOutWithRedirect)", () => {
       expect(mockSignOut).toHaveBeenCalledWith({
         skipTokenRevocation: true,
         tokensRemovedLocallyCb,
+        // Always set for the redirect flow: revocation must complete while
+        // the page is still alive, and local removal must happen right
+        // before the navigation
+        revokeTokensBeforeLocalRemoval: true,
       });
     });
 

--- a/client/__tests__/react-hooks-coverage.test.tsx
+++ b/client/__tests__/react-hooks-coverage.test.tsx
@@ -348,6 +348,15 @@ describe("React hooks coverage for hooks.tsx branches", () => {
 
     expect(result.current.authMethod).toBeUndefined();
     expect(result.current.tokens).toBeUndefined();
+    // Hosted-UI sign-out performs the same full per-user reset (SIGN_OUT)
+    // as the regular signOut path, so nothing leaks to the next user
+    expect(result.current.deviceKey).toBeNull();
+    expect(result.current.mfaStatusReady).toBe(false);
+    expect(result.current.totpMfaStatus).toEqual({
+      enabled: false,
+      preferred: false,
+      availableMfaTypes: [],
+    });
   });
 
   it("forwards prepared bundle to authenticateWithFido2", async () => {

--- a/client/__tests__/react-hooks-coverage.test.tsx
+++ b/client/__tests__/react-hooks-coverage.test.tsx
@@ -22,7 +22,11 @@ import {
 } from "../react/hooks.js";
 import { configure } from "../config.js";
 import { retrieveTokens } from "../storage.js";
-import { handleCognitoOAuthCallback } from "../hosted-oauth.js";
+import {
+  handleCognitoOAuthCallback,
+  signInWithRedirect as signInWithRedirectCore,
+  signOutWithRedirect as signOutWithRedirectCore,
+} from "../hosted-oauth.js";
 import {
   prepareFido2SignIn as prepareFido2SignInCore,
   authenticateWithFido2 as authenticateWithFido2Core,
@@ -58,6 +62,12 @@ const mockRetrieveTokens = retrieveTokens as jest.MockedFunction<
 >;
 const mockHandleOAuth = handleCognitoOAuthCallback as jest.MockedFunction<
   typeof handleCognitoOAuthCallback
+>;
+const mockSignInWithRedirect = signInWithRedirectCore as jest.MockedFunction<
+  typeof signInWithRedirectCore
+>;
+const mockSignOutWithRedirect = signOutWithRedirectCore as jest.MockedFunction<
+  typeof signOutWithRedirectCore
 >;
 const mockPrepareFido2SignIn = prepareFido2SignInCore as jest.MockedFunction<
   typeof prepareFido2SignInCore
@@ -245,6 +255,92 @@ describe("React hooks coverage for hooks.tsx branches", () => {
       mediation: undefined,
       signal: undefined,
     });
+  });
+
+  it("keeps authMethod and tokens when signOutWithRedirect fails before local sign-out", async () => {
+    const future = new Date(Date.now() + 60_000);
+    mockRetrieveTokens.mockResolvedValue({
+      accessToken: "mock-access-token",
+      idToken: undefined,
+      refreshToken: "mock-refresh-token",
+      expireAt: future,
+      username: "test-user",
+      authMethod: "REDIRECT",
+    });
+    mockSignInWithRedirect.mockResolvedValue(undefined);
+    // Reject before the local sign-out runs (e.g. missing hostedUi /
+    // redirectSignOut configuration), so tokensRemovedLocallyCb never fires
+    mockSignOutWithRedirect.mockRejectedValue(
+      new Error("hostedUi configuration missing")
+    );
+
+    const wrapper = makeWrapper();
+    const { result } = renderHook(() => usePasswordless(), { wrapper });
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0));
+    });
+    expect(result.current.tokens?.accessToken).toBe("mock-access-token");
+
+    // Establish authMethod in React state (as a redirect sign-in would)
+    act(() => {
+      result.current.signInWithRedirect();
+    });
+    expect(result.current.authMethod).toBe("REDIRECT");
+
+    await act(async () => {
+      result.current.signOutWithRedirect();
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    expect(mockSignOutWithRedirect).toHaveBeenCalled();
+    // Tokens were never removed from storage, so React state must still
+    // reflect the signed-in user: authMethod and tokens stay intact
+    expect(result.current.authMethod).toBe("REDIRECT");
+    expect(result.current.tokens?.accessToken).toBe("mock-access-token");
+    expect(result.current.lastError?.message).toBe(
+      "hostedUi configuration missing"
+    );
+  });
+
+  it("clears authMethod once tokens are removed locally during signOutWithRedirect", async () => {
+    const future = new Date(Date.now() + 60_000);
+    mockRetrieveTokens.mockResolvedValue({
+      accessToken: "mock-access-token",
+      idToken: undefined,
+      refreshToken: "mock-refresh-token",
+      expireAt: future,
+      username: "test-user",
+      authMethod: "REDIRECT",
+    });
+    mockSignInWithRedirect.mockResolvedValue(undefined);
+    // Simulate a successful local sign-out: the helper invokes
+    // tokensRemovedLocallyCb after removing tokens from storage
+    mockSignOutWithRedirect.mockImplementation(async (props) => {
+      props?.tokensRemovedLocallyCb?.();
+    });
+
+    const wrapper = makeWrapper();
+    const { result } = renderHook(() => usePasswordless(), { wrapper });
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0));
+    });
+    expect(result.current.tokens?.accessToken).toBe("mock-access-token");
+
+    // Establish authMethod in React state (as a redirect sign-in would)
+    act(() => {
+      result.current.signInWithRedirect();
+    });
+    expect(result.current.authMethod).toBe("REDIRECT");
+
+    await act(async () => {
+      result.current.signOutWithRedirect();
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    expect(result.current.authMethod).toBeUndefined();
+    expect(result.current.tokens).toBeUndefined();
   });
 
   it("forwards prepared bundle to authenticateWithFido2", async () => {

--- a/client/common.ts
+++ b/client/common.ts
@@ -374,6 +374,17 @@ export const signOut = (props?: {
   tokensRemovedLocallyCb?: () => void;
   statusCb?: (status: BusyState | IdleState) => void;
   skipTokenRevocation?: boolean;
+  /**
+   * Revoke the refresh token BEFORE removing tokens locally (default: after).
+   * Use when sign-out is immediately followed by a navigation (e.g. the
+   * hosted UI /logout redirect): revoking first means the network call
+   * completes while the page is still alive, and the local sign-out happens
+   * right before the navigation — minimizing the window in which the app
+   * looks signed out while the Cognito hosted-UI session cookie is still
+   * valid (an auto-redirecting app could otherwise silently re-auth as the
+   * previous user).
+   */
+  revokeTokensBeforeLocalRemoval?: boolean;
 }) => {
   const { clientId, debug, storage } = configure();
   const { currentStatus, statusCb, skipTokenRevocation } = props ?? {};
@@ -454,6 +465,31 @@ export const signOut = (props?: {
           return;
         }
         const { username, refreshToken } = session;
+        const revokeRefreshTokenOnce = async () => {
+          if (
+            refreshToken &&
+            !tokenRevocationTracker.has(refreshToken) &&
+            !skipTokenRevocation
+          ) {
+            try {
+              tokenRevocationTracker.add(refreshToken);
+              await revokeToken({
+                abort: undefined,
+                refreshToken: refreshToken,
+              });
+              debug?.("Successfully revoked refresh token");
+            } catch (revokeError) {
+              debug?.(
+                "Error revoking token, but continuing sign-out process:",
+                revokeError
+              );
+            }
+          }
+        };
+
+        if (props?.revokeTokensBeforeLocalRemoval) {
+          await revokeRefreshTokenOnce();
+        }
         await Promise.all([
           storage.removeItem(`${amplifyKeyPrefix}.${username}.idToken`),
           storage.removeItem(`${amplifyKeyPrefix}.${username}.accessToken`),
@@ -479,25 +515,7 @@ export const signOut = (props?: {
         ]);
         props?.tokensRemovedLocallyCb?.();
 
-        if (
-          refreshToken &&
-          !tokenRevocationTracker.has(refreshToken) &&
-          !skipTokenRevocation
-        ) {
-          try {
-            tokenRevocationTracker.add(refreshToken);
-            await revokeToken({
-              abort: undefined,
-              refreshToken: refreshToken,
-            });
-            debug?.("Successfully revoked refresh token");
-          } catch (revokeError) {
-            debug?.(
-              "Error revoking token, but continuing sign-out process:",
-              revokeError
-            );
-          }
-        }
+        await revokeRefreshTokenOnce();
 
         statusCb?.("SIGNED_OUT");
       } catch (error) {

--- a/client/config.ts
+++ b/client/config.ts
@@ -160,6 +160,12 @@ export interface Config {
     domain?: string;
     /** Redirect URI registered in the user-pool app client */
     redirectSignIn: string;
+    /**
+     * (Optional) Redirect URI to return to after signing out via the Hosted UI
+     * /logout endpoint (see signOutWithRedirect). Must be registered as an
+     * allowed sign-out URL in the user-pool app client.
+     */
+    redirectSignOut?: string;
     /** OAuth2 scopes requested. Defaults to ['openid','email','profile'] */
     scopes?: string[];
     /** Use authorization-code or implicit flow. Defaults to 'code'. */
@@ -233,6 +239,9 @@ export function configure(config?: ConfigInput) {
         scopes: config.hostedUi.scopes ?? ["openid", "email", "profile"],
         responseType: config.hostedUi.responseType ?? "code",
         ...(config.hostedUi.domain && { domain: config.hostedUi.domain }),
+        ...(config.hostedUi.redirectSignOut && {
+          redirectSignOut: config.hostedUi.redirectSignOut,
+        }),
       };
       config_.debug?.(
         "Cognito Hosted UI configured, will use cognitoIdpEndpoint for OAuth domain"
@@ -260,6 +269,16 @@ export function getAuthorizeEndpoint(): string {
   const domainBase = hostedUi?.domain ?? cognitoIdpEndpoint;
   const base = normalizeEndpoint(domainBase);
   return `${base}/oauth2/authorize`;
+}
+
+/**
+ * Get the full Hosted UI logout endpoint URL with protocol
+ */
+export function getLogoutEndpoint(): string {
+  const { cognitoIdpEndpoint, hostedUi } = configure();
+  const domainBase = hostedUi?.domain ?? cognitoIdpEndpoint;
+  const base = normalizeEndpoint(domainBase);
+  return `${base}/logout`;
 }
 
 /**

--- a/client/hosted-oauth.ts
+++ b/client/hosted-oauth.ts
@@ -189,10 +189,15 @@ export async function signOutWithRedirect(props?: {
   const logoutEndpoint = getLogoutEndpoint();
   debug?.(`Using Hosted UI logout endpoint: ${logoutEndpoint}`);
 
-  // Perform the local sign-out first (clear tokens, revoke refresh token),
-  // so local state is cleaned up before we navigate away
+  // Perform the local sign-out first, with the refresh token revoked BEFORE
+  // tokens are removed locally: the revocation network call then completes
+  // while the page is still alive, and the local sign-out happens right
+  // before the navigation below — minimizing the window in which the app
+  // already looks signed out while the Cognito hosted-UI session cookie is
+  // still valid (an auto-redirecting app could otherwise call
+  // signInWithRedirect in that window and silently re-auth as this user)
   debug?.("Performing local sign-out before Hosted UI logout redirect");
-  await signOut(props).signedOut;
+  await signOut({ ...props, revokeTokensBeforeLocalRemoval: true }).signedOut;
 
   const qs = new URLSearchParams({
     client_id: cfg.clientId,

--- a/client/hosted-oauth.ts
+++ b/client/hosted-oauth.ts
@@ -12,13 +12,18 @@
  * ANY KIND, either express or implied. See the License for the specific
  * language governing permissions and limitations under the License.
  */
-import { configure, getAuthorizeEndpoint, getTokenEndpoint } from "./config.js";
+import {
+  configure,
+  getAuthorizeEndpoint,
+  getLogoutEndpoint,
+  getTokenEndpoint,
+} from "./config.js";
 import { generateRandomString, generatePkcePair } from "./oauthUtil.js";
 import { parseJwtPayload } from "./util.js";
 import { CognitoAccessTokenPayload } from "./jwt-model.js";
 import { withStorageLock, LockTimeoutError } from "./lock.js";
-import { processTokens } from "./common.js";
-import { TokensFromSignIn } from "./model.js";
+import { processTokens, signOut } from "./common.js";
+import { BusyState, IdleState, TokensFromSignIn } from "./model.js";
 
 const STATE_KEY = "cognito_oauth_state";
 const PKCE_KEY = "cognito_oauth_pkce";
@@ -115,6 +120,72 @@ export async function signInWithRedirect({
   const oauthUrl = `${authorizeEndpoint}?${qs}`;
   debug?.(`Redirecting to: ${oauthUrl}`);
   cfg.location.href = oauthUrl;
+}
+
+/**
+ * Sign the user out locally (clear tokens from storage, revoke the refresh
+ * token) and then redirect to the Cognito Hosted UI /logout endpoint to
+ * terminate the Hosted UI (managed login) session as well. Without this
+ * redirect, the Cognito session cookie survives a local signOut and the next
+ * signInWithRedirect may silently sign in as the previous user.
+ *
+ * Requires hostedUi.redirectSignOut to be configured, and that URL must be
+ * registered as an allowed sign-out URL in the Cognito user-pool app client.
+ */
+export async function signOutWithRedirect(props?: {
+  currentStatus?: BusyState | IdleState;
+  tokensRemovedLocallyCb?: () => void;
+  statusCb?: (status: BusyState | IdleState) => void;
+  skipTokenRevocation?: boolean;
+}) {
+  const cfg = configure();
+  const { debug } = cfg;
+
+  if (!cfg.hostedUi) {
+    throw new Error("hostedUi configuration missing");
+  }
+
+  const { redirectSignOut } = cfg.hostedUi;
+  if (!redirectSignOut) {
+    throw new Error("hostedUi.redirectSignOut configuration missing");
+  }
+
+  // Construct full URL from relative URL if needed
+  let fullRedirectUrl = redirectSignOut;
+
+  // Check if the redirectSignOut is relative (doesn't start with http:// or https://)
+  if (!redirectSignOut.match(/^https?:\/\//)) {
+    debug?.(
+      `Converting relative redirectSignOut "${redirectSignOut}" to absolute URL`
+    );
+
+    // Create a URL object using the current location as base
+    const currentUrl = new URL(cfg.location.href);
+
+    // Create a new URL with the current as base and the redirect path as the path
+    const absoluteUrl = new URL(redirectSignOut, currentUrl.origin);
+    fullRedirectUrl = absoluteUrl.href;
+
+    debug?.(`Converted to absolute URL: ${fullRedirectUrl}`);
+  }
+
+  // Get the Hosted UI logout endpoint
+  const logoutEndpoint = getLogoutEndpoint();
+  debug?.(`Using Hosted UI logout endpoint: ${logoutEndpoint}`);
+
+  // Perform the local sign-out first (clear tokens, revoke refresh token),
+  // so local state is cleaned up before we navigate away
+  debug?.("Performing local sign-out before Hosted UI logout redirect");
+  await signOut(props).signedOut;
+
+  const qs = new URLSearchParams({
+    client_id: cfg.clientId,
+    logout_uri: fullRedirectUrl,
+  }).toString();
+
+  const logoutUrl = `${logoutEndpoint}?${qs}`;
+  debug?.(`Redirecting to: ${logoutUrl}`);
+  cfg.location.href = logoutUrl;
 }
 
 export async function handleCognitoOAuthCallback(): Promise<TokensFromSignIn | null> {

--- a/client/react/hooks.tsx
+++ b/client/react/hooks.tsx
@@ -70,6 +70,7 @@ import React, {
 } from "react";
 import {
   signInWithRedirect as hostedSignInWithRedirect,
+  signOutWithRedirect as hostedSignOutWithRedirect,
   handleCognitoOAuthCallback,
 } from "../hosted-oauth.js";
 
@@ -1844,6 +1845,33 @@ function _usePasswordless() {
           });
         }
       );
+    },
+    /** Sign out locally and from the Cognito Hosted UI (redirect to the /logout endpoint) */
+    signOutWithRedirect: (options?: { skipTokenRevocation?: boolean }) => {
+      const { debug } = configure();
+      debug?.("Starting sign-out via Hosted UI redirect");
+      dispatch({ type: "SET_ERROR", payload: undefined });
+      hostedSignOutWithRedirect({
+        statusCb: setSigninInStatus,
+        tokensRemovedLocallyCb: () => {
+          _setTokens(undefined);
+          parseAndSetTokens(undefined);
+          // Clear authMethod only once tokens are actually removed from
+          // storage, so React state stays consistent with storage if
+          // hostedSignOutWithRedirect rejects earlier (e.g. on missing
+          // hostedUi / redirectSignOut configuration)
+          dispatch({ type: "SET_AUTH_METHOD", payload: undefined });
+          dispatch({ type: "SET_FIDO2_CREDENTIALS", payload: undefined });
+        },
+        currentStatus: signingInStatus,
+        skipTokenRevocation: options?.skipTokenRevocation,
+      }).catch((err: unknown) => {
+        debug?.("Failed to initiate redirect sign-out:", err);
+        dispatch({
+          type: "SET_ERROR",
+          payload: err instanceof Error ? err : new Error(String(err)),
+        });
+      });
     },
     /** The current authentication method used for these tokens */
     authMethod,

--- a/client/react/hooks.tsx
+++ b/client/react/hooks.tsx
@@ -1970,15 +1970,23 @@ function _usePasswordless() {
       dispatch({ type: "SET_ERROR", payload: undefined });
       hostedSignOutWithRedirect({
         statusCb: setSigninInStatus,
+        // Runs only once tokens are actually removed from storage, so React
+        // state stays consistent with storage if hostedSignOutWithRedirect
+        // rejects earlier (e.g. on missing hostedUi / redirectSignOut
+        // configuration). Mirrors the regular signOut callback: a full
+        // per-user reset (SIGN_OUT also clears authMethod, deviceKey, TOTP
+        // MFA status, ...) so nothing leaks into the next user's session
         tokensRemovedLocallyCb: () => {
           _setTokens(undefined);
           parseAndSetTokens(undefined);
-          // Clear authMethod only once tokens are actually removed from
-          // storage, so React state stays consistent with storage if
-          // hostedSignOutWithRedirect rejects earlier (e.g. on missing
-          // hostedUi / redirectSignOut configuration)
-          dispatch({ type: "SET_AUTH_METHOD", payload: undefined });
           dispatch({ type: "SET_FIDO2_CREDENTIALS", payload: undefined });
+          lastActivityAtRef.current = Date.now();
+          // Invalidate any in-flight getUser fetch and reset its cooldown,
+          // so a stale response can't restore the previous user's MFA
+          // status and the next user's fetch runs immediately
+          lastFetchedMfaTokenRef.current = undefined;
+          lastMfaFetchTimeRef.current = 0;
+          dispatch({ type: "SIGN_OUT" });
         },
         currentStatus: signingInStatus,
         skipTokenRevocation: options?.skipTokenRevocation,

--- a/test/signOut.test.ts
+++ b/test/signOut.test.ts
@@ -285,3 +285,93 @@ describe("SignOut with expired access token", () => {
     }
   );
 });
+
+describe("SignOut revocation ordering", () => {
+  const username = "testuser";
+  const refreshToken = "ordering-refresh-token";
+  const amplifyKeyPrefix = `CognitoIdentityServiceProvider.testClient`;
+
+  // Returns a fetch mock that, when the RevokeToken request arrives,
+  // snapshots whether the refresh token is still in storage at that moment
+  const revokeSnapshottingFetch = (
+    snapshot: { refreshTokenInStorageAtRevoke?: string | null } = {}
+  ) => {
+    const fetchMock = jest.fn(
+      async (url: unknown, init?: { headers?: Record<string, string> }) => {
+        if (init?.headers?.["x-amz-target"]?.endsWith("RevokeToken")) {
+          const { storage } = configure();
+          snapshot.refreshTokenInStorageAtRevoke = await storage.getItem(
+            `${amplifyKeyPrefix}.${username}.refreshToken`
+          );
+        }
+        return { ok: true, status: 200, json: async () => ({}) };
+      }
+    );
+    return { fetchMock, snapshot };
+  };
+
+  const seedSession = async () => {
+    const now = Date.now();
+    await storeTokens({
+      accessToken: createJWT({
+        sub: "user123",
+        username,
+        scope: "openid",
+        exp: Math.floor((now + 3600_000) / 1000),
+        iat: Math.floor(now / 1000),
+      }),
+      idToken: createJWT({
+        sub: "user123",
+        "cognito:username": username,
+        exp: Math.floor((now + 3600_000) / 1000),
+        iat: Math.floor(now / 1000),
+      }),
+      refreshToken,
+      authMethod: "SRP",
+      expireAt: new Date(now + 3600_000),
+    });
+  };
+
+  test("by default revokes AFTER removing local tokens", async () => {
+    const { fetchMock, snapshot } = revokeSnapshottingFetch();
+    configure({
+      clientId: "testClient",
+      cognitoIdpEndpoint: "us-west-2",
+      fetch: fetchMock,
+    });
+    await seedSession();
+
+    await signOut().signedOut;
+
+    expect(snapshot.refreshTokenInStorageAtRevoke).toBeNull();
+  });
+
+  test("revokes BEFORE removing local tokens with revokeTokensBeforeLocalRemoval", async () => {
+    // Used by the hosted-UI logout redirect: revocation completes while the
+    // page is still alive, and local removal happens right before the
+    // navigation - minimizing the signed-out-locally-but-cookie-alive window
+    const { fetchMock, snapshot } = revokeSnapshottingFetch();
+    configure({
+      clientId: "testClient",
+      cognitoIdpEndpoint: "us-west-2",
+      fetch: fetchMock,
+    });
+    await seedSession();
+
+    await signOut({ revokeTokensBeforeLocalRemoval: true }).signedOut;
+
+    // At revoke time the session was still in storage ...
+    expect(snapshot.refreshTokenInStorageAtRevoke).toBe(refreshToken);
+    // ... and it is fully removed afterwards, with exactly one revocation
+    const { storage } = configure();
+    expect(
+      await storage.getItem(`${amplifyKeyPrefix}.${username}.refreshToken`)
+    ).toBeNull();
+    const revokeCalls = fetchMock.mock.calls.filter(([, init]) =>
+      (init as { headers?: Record<string, string> })?.headers?.[
+        "x-amz-target"
+      ]?.endsWith("RevokeToken")
+    );
+    expect(revokeCalls).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary
Adds an opt-in Hosted UI (managed login) sign-out: a new `hostedUi.redirectSignOut` config field and a `signOutWithRedirect()` function that performs the local sign-out and then redirects to the Cognito `/logout` endpoint, terminating the Cognito SSO session cookie. Also exposed as `signOutWithRedirect` on the React `usePasswordless()` hook. Plain `signOut` behavior is unchanged (non-breaking).

## Finding
- **Severity:** Medium (externally validated)
- **Confidence:** High
- **Refs:** `client/hosted-oauth.ts` (only implemented `signInWithRedirect`, no logout counterpart), `client/common.ts:349` (`signOut` only clears storage and revokes the refresh token)

No hosted-UI logout existed anywhere in `client/` — no `/logout` URL construction and no `redirectSignOut`/`logoutUri` config. Per AWS docs, the Cognito managed-login session cookie lasts one hour and `prompt=none` (or simply revisiting `/oauth2/authorize`) silently re-authenticates. Concrete failure: on a shared device, user A signs out via `signOut()` (local cleanup only); user B clicks "sign in with Google/Hosted UI" within the hour and is silently signed in **as user A** with no credential prompt. User A's hosted-UI session was un-terminable from this library.

## Fix
- `client/config.ts`: new optional `hostedUi.redirectSignOut` field (documented: must be registered as an allowed sign-out URL in the Cognito app client) and a `getLogoutEndpoint()` helper that mirrors `getAuthorizeEndpoint()` (hosted UI `domain` with `cognitoIdpEndpoint` fallback).
- `client/hosted-oauth.ts`: new exported `signOutWithRedirect(props?)` that awaits the local `signOut()` cleanup (forwarding `statusCb`, `tokensRemovedLocallyCb`, `skipTokenRevocation`, etc.), then navigates via `cfg.location.href` (same mechanism as `signInWithRedirect`) to `https://<domain>/logout?client_id=<clientId>&logout_uri=<encoded redirectSignOut>`. Relative `redirectSignOut` values are converted to absolute URLs, matching `redirectSignIn` handling. Automatically re-exported from `client/index.ts` via the existing `export * from "./hosted-oauth.js"`.
- `client/react/hooks.tsx`: new `signOutWithRedirect` hook method alongside `signInWithRedirect`, wiring the same React state cleanup callbacks as the existing `signOut` hook method.

## Test plan
- New `client/__tests__/hosted-ui-logout.test.ts` (9 tests, real config module):
  - `getLogoutEndpoint()` from hosted UI domain and from `cognitoIdpEndpoint` fallback
  - logout URL contains correct domain, `client_id`, and percent-encoded `logout_uri`
  - relative `redirectSignOut` converted to absolute
  - local sign-out completes **before** navigation (event-order assertion)
  - props forwarded to local `signOut`
  - throws without navigating when `hostedUi`/`redirectSignOut` missing or local sign-out fails
- Gates: `npx tsc --project client/tsconfig.json --noEmit` clean; `npx eslint` on changed files clean; `npx jest client/__tests__/` — 11 suites, 135 tests, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches sign-out and token revocation ordering and full-page redirects in auth flows; default `signOut` stays backward compatible but Hosted UI logout misconfiguration or partial failure affects session state and UX.
> 
> **Overview**
> Adds **opt-in Cognito Hosted UI sign-out** so local token cleanup is not the only step: apps can end the managed-login session cookie that otherwise lets the next `signInWithRedirect` silently reuse the previous user.
> 
> **Configuration and core API:** Optional `hostedUi.redirectSignOut` (allowed sign-out URL in the app client) and `getLogoutEndpoint()` build `https://<domain>/logout`. New `signOutWithRedirect()` validates hosted UI config, resolves relative `redirectSignOut` to an absolute `logout_uri`, awaits local `signOut()` (with **`revokeTokensBeforeLocalRemoval: true`** so revocation finishes before navigation), then sets `location.href` to the logout URL. Missing `hostedUi` / `redirectSignOut` or a failed local sign-out throws and does not navigate.
> 
> **`signOut` behavior:** Default path is unchanged; an optional flag reorders work so refresh-token revocation can run **before** storage is cleared (used only by the redirect logout flow).
> 
> **React:** `usePasswordless().signOutWithRedirect` wires status callbacks and clears React state only in `tokensRemovedLocallyCb` (after storage removal), matching regular `signOut` and avoiding stale signed-in UI when redirect setup fails early.
> 
> **Tests** cover logout URL construction, redirect ordering, hook state on success vs pre-sign-out failure, and revocation ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c10701b034f900bde27b9e4adc61730393423eb4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->