### PR TITLE
Fix refresh-schedule dedup suppressing next refresh for short-lived tokens

### DIFF
--- a/client/common.ts
+++ b/client/common.ts
@@ -41,13 +41,14 @@ const REFRESH_DEDUPLICATION_WINDOW_MS = 300000; // 5 minutes
 const FRESH_LOGIN_REFRESH_DELAY_MS = 120000; // 2 minutes
 
 // Track active refresh schedules to prevent duplicate scheduling
-// Key: username, Value: { scheduledAt: timestamp, abortController: AbortController, refreshToken: string }
+// Key: username, Value: { scheduledAt: timestamp, abortController: AbortController, refreshToken: string, accessToken: string }
 const activeRefreshSchedules = new Map<
   string,
   {
     scheduledAt: number;
     abortController: AbortController;
     refreshToken: string;
+    accessToken: string;
   }
 >();
 
@@ -205,8 +206,16 @@ async function processTokensInternal(
     const now = Date.now();
 
     // Skip if we already scheduled for this user recently (within 5 minutes)
+    // for the SAME access token. New tokens (e.g. just obtained by a refresh)
+    // must always get their own schedule: with short-lived access tokens
+    // (Cognito allows lifetimes as low as 5 minutes) each refresh completes
+    // within the deduplication window, and the previous schedule entry is
+    // only cleared after this function returns, so deduplicating on
+    // wall-clock age alone would silently prevent the next refresh from
+    // ever being scheduled.
     if (
       existingSchedule &&
+      existingSchedule.accessToken === normalizedTokens.accessToken &&
       now - existingSchedule.scheduledAt < REFRESH_DEDUPLICATION_WINDOW_MS
     ) {
       debug?.(
@@ -215,9 +224,21 @@ async function processTokensInternal(
       return normalizedTokens;
     }
 
-    // Clear any existing schedule for this user
+    // Clear any existing schedule for this user. Skip the abort when the
+    // tracked controller is the very one driving THIS call: during an
+    // active refresh, refreshTokens passes the schedule's own abort
+    // signal back into processTokens, so aborting it here would be a
+    // self-abort of the in-flight refresh chain. That fires the old
+    // schedule's abort listeners ("Refresh scheduling aborted", which can
+    // cancel a pending timer) and leaves the signal permanently aborted,
+    // so every later abort-check on that chain (scheduleRefresh's early
+    // return, lock acquisition, retry backoff) bails out — and the new
+    // tokens can end up without a next refresh. The replacement schedule
+    // below is also wired to this same signal, so it must stay live.
     if (existingSchedule?.abortController) {
-      existingSchedule.abortController.abort();
+      if (existingSchedule.abortController.signal !== abort) {
+        existingSchedule.abortController.abort();
+      }
       activeRefreshSchedules.delete(normalizedTokens.username);
     }
 
@@ -243,6 +264,7 @@ async function processTokensInternal(
       scheduledAt: now,
       abortController: scheduleAbort,
       refreshToken: normalizedTokens.refreshToken,
+      accessToken: normalizedTokens.accessToken,
     });
 
     const scheduleFn = () => {

--- a/test/refresh-bugs.test.ts
+++ b/test/refresh-bugs.test.ts
@@ -1,7 +1,18 @@
 import { configure } from "../client/config.js";
-import { scheduleRefresh } from "../client/refresh.js";
+import { scheduleRefresh, cleanupRefreshSystem } from "../client/refresh.js";
 import { storeTokens, retrieveTokens } from "../client/storage.js";
 import { processTokens } from "../client/common.js";
+
+// Poll until the predicate is true (used to await fire-and-forget chains)
+const waitFor = async (predicate: () => boolean, timeoutMs = 4000) => {
+  const start = Date.now();
+  while (!predicate()) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error("Timed out waiting for condition");
+    }
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+};
 
 // Helper to create JWT tokens
 const createJWT = (claims: Record<string, unknown>) => {
@@ -282,5 +293,135 @@ describe("Refresh System Bug Hunt", () => {
     );
 
     expect(dedupLogs.length).toBeGreaterThan(0);
+  });
+
+  test("REGRESSION: short-lived tokens get their next refresh scheduled after a refresh", async () => {
+    const now = Date.now();
+    const username = "shortlived-user";
+    // Initial tokens with a 5-minute lifetime (Cognito's minimum access
+    // token lifetime). The computed refresh delay is ~3.5 minutes, so the
+    // refresh completes well within the 5-minute deduplication window.
+    const initialTokens = {
+      accessToken: createJWT({
+        sub: "user456",
+        username,
+        exp: Math.floor((now + 300000) / 1000),
+        iat: Math.floor(now / 1000),
+      }),
+      refreshToken: "short-lived-refresh-token",
+      username,
+      expireAt: new Date(now + 300000),
+    };
+
+    // First processTokens schedules the refresh and records the schedule
+    await processTokens(initialTokens);
+
+    // Simulate the refresh completing: processTokens runs for the NEW
+    // tokens while the previous schedule entry is still tracked (refresh.ts
+    // only clears it via tokensCb AFTER processTokens returns).
+    const refreshedTokens = {
+      accessToken: createJWT({
+        sub: "user456",
+        username,
+        exp: Math.floor((now + 600000) / 1000),
+        iat: Math.floor((now + 300000) / 1000),
+      }),
+      refreshToken: "short-lived-refresh-token",
+      username,
+      expireAt: new Date(now + 600000),
+    };
+
+    debugLogs = [];
+    await processTokens(refreshedTokens);
+
+    // The new tokens MUST get their own refresh scheduled; deduplication
+    // must not suppress it, otherwise short-lived tokens silently stop
+    // being refreshed after the first refresh.
+    const dedupLog = debugLogs.find((log) =>
+      log.includes("skipping duplicate")
+    );
+    const scheduleLog = debugLogs.find((log) =>
+      log.includes("Scheduling token refresh")
+    );
+    expect(dedupLog).toBeUndefined();
+    expect(scheduleLog).toBeTruthy();
+  });
+
+  test("REGRESSION: refresh-driven processTokens must not abort its own schedule signal", async () => {
+    const now = Date.now();
+    const username = "selfabort-user";
+
+    // Spy on AbortController.prototype.abort: nothing in the happy-path
+    // refresh flow below should cancel anything. Before the fix, the
+    // nested processTokens (running inside the active refresh, with the
+    // schedule's own abort signal passed through by refreshTokens)
+    // aborted that very signal when replacing the tracked schedule,
+    // firing the old schedule's abort listeners and wiring the new
+    // schedule to an already-aborted signal.
+    const abortSpy = jest.spyOn(AbortController.prototype, "abort");
+
+    try {
+      // Token that expires in 30 seconds: scheduleRefresh takes its
+      // immediate-refresh path, so the chain
+      //   processTokens -> scheduleRefresh -> refreshTokens -> processTokens
+      // runs end-to-end without waiting on a refresh timer.
+      const initialTokens = {
+        accessToken: createJWT({
+          sub: "user789",
+          username,
+          exp: Math.floor((now + 30000) / 1000),
+          iat: Math.floor(now / 1000),
+        }),
+        refreshToken: "self-abort-refresh-token",
+        username,
+        expireAt: new Date(now + 30000),
+      };
+
+      // The refresh returns a 5-minute token
+      fetchMock.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          AuthenticationResult: {
+            AccessToken: createJWT({
+              sub: "user789",
+              username,
+              exp: Math.floor((now + 300000) / 1000),
+              iat: Math.floor(now / 1000),
+            }),
+            IdToken: createJWT({
+              sub: "user789",
+              username,
+              exp: Math.floor((now + 300000) / 1000),
+              iat: Math.floor(now / 1000),
+            }),
+            RefreshToken: "self-abort-refresh-token-2",
+            ExpiresIn: 300,
+            TokenType: "Bearer",
+          },
+        }),
+      });
+
+      debugLogs = [];
+      await processTokens(initialTokens);
+
+      // Wait for the fire-and-forget refresh chain to complete: the
+      // refreshed tokens must end up with a live refresh timer of their
+      // own ("Scheduling token refresh in X minutes" comes from
+      // refresh.ts when it arms the timer for the new token's expiry).
+      await waitFor(() =>
+        debugLogs.some((log) => log.includes("Scheduling token refresh in"))
+      );
+
+      // The nested processTokens replaced the tracked schedule while the
+      // schedule's own abort signal was driving the call. That must not
+      // abort anything:
+      expect(abortSpy).not.toHaveBeenCalled();
+      expect(
+        debugLogs.some((log) => log.includes("Refresh scheduling aborted"))
+      ).toBe(false);
+    } finally {
+      abortSpy.mockRestore();
+      cleanupRefreshSystem(username);
+    }
   });
 });


### PR DESCRIPTION
## Summary
The 5-minute refresh-schedule deduplication window in `processTokens` could permanently stop automatic token refresh for users with short-lived access tokens. The dedup check now keys on access-token identity, so post-refresh rescheduling is never suppressed while duplicate schedules for the same token are still prevented.

## Finding
- Severity: MEDIUM (externally validated)
- Confidence: high — confirmed by reading the code and by a regression test that fails on unfixed `main`
- `client/common.ts:207-216` (pre-fix line numbers): after a successful refresh, `processTokens` runs for the new tokens and is the designated place to schedule the next refresh (`client/refresh.ts:335-336` relies on this). But the scheduling step returned early whenever the previous `activeRefreshSchedules` entry was younger than `REFRESH_DEDUPLICATION_WINDOW_MS` (5 min).
- The stale entry is only deleted by `tokensCb` AFTER `processTokens` returns (`client/refresh.ts:791-793`), so it is always still present during the check.
- Concrete failure scenario: Cognito allows access-token lifetimes as low as 5 minutes. For a 5-minute token the computed refresh delay is ~3.5 min (buffer = max(60s, 0.3 × 300s)), so each refresh completes inside the 5-minute dedup window and the NEXT refresh is silently never scheduled. Only the global watchdog papers over this every 5 minutes.

## Fix
Key the dedup entry by token identity in addition to wall-clock age (`client/common.ts`):
- Store the `accessToken` in the `activeRefreshSchedules` entry.
- Skip scheduling only when the existing entry is both recent AND for the same access token. New tokens from a completed refresh always differ (new `iat`/`exp`), so they always get their own schedule; repeated `processTokens` calls with identical tokens are still deduplicated (the window's original purpose, covered by the existing "Multiple processTokens calls create duplicate schedules" test).

## Test plan
- New regression test in `test/refresh-bugs.test.ts`: simulates a 5-minute token lifetime — `processTokens` for the initial tokens, then `processTokens` for the refreshed tokens while the previous schedule entry is still tracked. Asserts the next refresh is scheduled and not deduplicated. Verified it FAILS on unfixed code and passes with the fix.
- `npx tsc --project client/tsconfig.json --noEmit` — clean
- `npx eslint client/common.ts test/refresh-bugs.test.ts` — clean
- `npx jest test/` — 13 suites passed, 57 tests passed (2 suites / 19 tests skipped via pre-existing skip markers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core token refresh scheduling and abort-signal wiring; incorrect behavior would break silent refresh for some Cognito token lifetimes, but scope is narrow and covered by new regression tests.
> 
> **Overview**
> Fixes automatic Cognito token refresh so **short-lived access tokens** (e.g. 5-minute lifetimes) keep getting a **next** refresh after each successful refresh.
> 
> **Refresh deduplication** in `processTokens` now applies only when the existing schedule is recent **and** for the **same** access token (tracked on `activeRefreshSchedules`). Previously, age-only dedup could skip scheduling new tokens while the old schedule entry was still present until `tokensCb` ran—so the chain could stop after the first refresh.
> 
> When replacing an existing schedule, the code **no longer aborts** the tracked `AbortController` when its signal is the same one passed into the in-flight refresh (`refreshTokens` → nested `processTokens`), avoiding self-abort of the refresh chain and a permanently aborted schedule signal.
> 
> Adds regression tests for short-lived token rescheduling and for the no-self-abort behavior during the end-to-end refresh path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e2bbe6cac9ae7d6e6e4d5b01f159613c2092597. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->