### PR TITLE
Key plaintext-flow device records by canonical user id

### DIFF
--- a/client/__tests__/plaintext-device-key.test.ts
+++ b/client/__tests__/plaintext-device-key.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Copyright Amazon.com, Inc. and its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You
+ * may not use this file except in compliance with the License. A copy of
+ * the License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+import { authenticateWithPlaintextPassword } from "../plaintext.js";
+import { configure } from "../config.js";
+import { setRememberedDevice } from "../storage.js";
+import { initiateAuth, handleAuthResponse } from "../cognito-api.js";
+import { processTokens } from "../common.js";
+
+jest.mock("../cognito-api.js", () => {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  const actual = jest.requireActual("../cognito-api.js");
+  return {
+    ...(actual as object),
+    initiateAuth: jest.fn(),
+    handleAuthResponse: jest.fn(),
+  };
+});
+
+jest.mock("../common.js", () => ({
+  processTokens: jest.fn(),
+}));
+
+const mockInitiateAuth = initiateAuth as jest.MockedFunction<
+  typeof initiateAuth
+>;
+const mockHandleAuthResponse = handleAuthResponse as jest.MockedFunction<
+  typeof handleAuthResponse
+>;
+const mockProcessTokens = processTokens as jest.MockedFunction<
+  typeof processTokens
+>;
+
+const CANONICAL_USER_ID = "canonical-user-sub";
+const ALIAS_USERNAME = "alias@example.com";
+
+function createMemoryStorage() {
+  const store = new Map<string, string>();
+  return {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      store.set(key, value);
+    },
+    removeItem: (key: string) => {
+      store.delete(key);
+    },
+  };
+}
+
+function mockChallengeResponse(
+  challengeParameters: Record<string, string> = {
+    USER_ID_FOR_SRP: CANONICAL_USER_ID,
+  }
+) {
+  mockInitiateAuth.mockResolvedValue({
+    ChallengeName: "SMS_MFA",
+    ChallengeParameters: challengeParameters,
+    Session: "test-session",
+  } as unknown as Awaited<ReturnType<typeof initiateAuth>>);
+}
+
+function mockAuthenticatedResponse() {
+  // Access token whose payload carries the canonical username claim
+  const accessToken = `${btoa(JSON.stringify({ alg: "none" }))}.${btoa(
+    JSON.stringify({
+      username: CANONICAL_USER_ID,
+      exp: Math.floor(Date.now() / 1000) + 3600,
+    })
+  )}.signature`;
+  mockInitiateAuth.mockResolvedValue({
+    AuthenticationResult: {
+      AccessToken: accessToken,
+      IdToken: "test-id-token",
+      RefreshToken: "test-refresh-token",
+      ExpiresIn: 3600,
+      TokenType: "Bearer",
+    },
+    ChallengeParameters: {},
+  } as unknown as Awaited<ReturnType<typeof initiateAuth>>);
+}
+
+describe("plaintext flow device record lookup", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    configure({
+      clientId: "test-client",
+      userPoolId: "us-east-1_testpool",
+      storage: createMemoryStorage(),
+    });
+    mockHandleAuthResponse.mockImplementation(({ username }) =>
+      Promise.resolve({
+        accessToken: "mock-access-token",
+        idToken: "mock-id-token",
+        refreshToken: "mock-refresh-token",
+        expireAt: new Date(Date.now() + 3600 * 1000),
+        username,
+        deviceKey: undefined,
+        newDeviceMetadata: undefined,
+      })
+    );
+    mockProcessTokens.mockImplementation((tokens) => Promise.resolve(tokens));
+  });
+
+  it("finds a device record stored under the canonical user id when signing in with an alias", async () => {
+    // Device confirmed during an SRP sign-in is stored under the canonical user id
+    await setRememberedDevice(CANONICAL_USER_ID, {
+      deviceKey: "us-east-1_device-1",
+      groupKey: "group-key-1",
+      password: "device-password-1",
+      remembered: true,
+    });
+    mockChallengeResponse();
+
+    const { signedIn } = authenticateWithPlaintextPassword({
+      username: ALIAS_USERNAME,
+      password: "secret",
+      smsMfaCode: () => Promise.resolve("123456"),
+    });
+    await signedIn;
+
+    expect(mockHandleAuthResponse).toHaveBeenCalledTimes(1);
+    const callArgs = mockHandleAuthResponse.mock.calls[0][0];
+    expect(callArgs.username).toBe(CANONICAL_USER_ID);
+    expect(callArgs.deviceHandler?.deviceKey).toBe("us-east-1_device-1");
+  });
+
+  it("falls back to a legacy device record stored under the username as entered", async () => {
+    // Device record stored by previous versions, keyed by the alias
+    await setRememberedDevice(ALIAS_USERNAME, {
+      deviceKey: "us-east-1_device-2",
+      groupKey: "group-key-2",
+      password: "device-password-2",
+      remembered: true,
+    });
+    mockChallengeResponse();
+
+    const { signedIn } = authenticateWithPlaintextPassword({
+      username: ALIAS_USERNAME,
+      password: "secret",
+      smsMfaCode: () => Promise.resolve("123456"),
+    });
+    await signedIn;
+
+    expect(mockHandleAuthResponse).toHaveBeenCalledTimes(1);
+    const callArgs = mockHandleAuthResponse.mock.calls[0][0];
+    // Challenges still use the canonical user id ...
+    expect(callArgs.username).toBe(CANONICAL_USER_ID);
+    // ... while the legacy device record is found via the fallback lookup
+    expect(callArgs.deviceHandler?.deviceKey).toBe("us-east-1_device-2");
+  });
+
+  it("resolves the canonical user id from the access token for authenticated responses", async () => {
+    await setRememberedDevice(CANONICAL_USER_ID, {
+      deviceKey: "us-east-1_device-3",
+      groupKey: "group-key-3",
+      password: "device-password-3",
+      remembered: true,
+    });
+    mockAuthenticatedResponse();
+
+    const { signedIn } = authenticateWithPlaintextPassword({
+      username: ALIAS_USERNAME,
+      password: "secret",
+    });
+    await signedIn;
+
+    expect(mockHandleAuthResponse).toHaveBeenCalledTimes(1);
+    const callArgs = mockHandleAuthResponse.mock.calls[0][0];
+    expect(callArgs.username).toBe(CANONICAL_USER_ID);
+    expect(callArgs.deviceHandler?.deviceKey).toBe("us-east-1_device-3");
+  });
+
+  it("uses the username as entered when no canonical user id is available", async () => {
+    mockChallengeResponse({});
+
+    const { signedIn } = authenticateWithPlaintextPassword({
+      username: ALIAS_USERNAME,
+      password: "secret",
+      smsMfaCode: () => Promise.resolve("123456"),
+    });
+    await signedIn;
+
+    expect(mockHandleAuthResponse).toHaveBeenCalledTimes(1);
+    const callArgs = mockHandleAuthResponse.mock.calls[0][0];
+    expect(callArgs.username).toBe(ALIAS_USERNAME);
+    expect(callArgs.deviceHandler).toBeUndefined();
+  });
+});

--- a/client/plaintext.ts
+++ b/client/plaintext.ts
@@ -22,6 +22,8 @@ import {
 import { processTokens } from "./common.js";
 import { retrieveDeviceKey } from "./storage.js";
 import { createDeviceSrpAuthHandler } from "./device.js";
+import { parseJwtPayload } from "./util.js";
+import { CognitoAccessTokenPayload } from "./jwt-model.js";
 
 export function authenticateWithPlaintextPassword({
   username,
@@ -77,19 +79,46 @@ export function authenticateWithPlaintextPassword({
       });
       debug?.(`Response from initiateAuth:`, authResponse);
 
-      // Now that we have initiated authentication, we can look up device key
-      // using the confirmed username for this session
-      const actualDeviceKey =
-        deviceKey ?? (username ? await retrieveDeviceKey(username) : undefined);
+      // Resolve the canonical user id, so device records are keyed
+      // consistently with the SRP flow (the username as entered may be an
+      // alias, e.g. e-mail or phone number)
+      let canonicalUserId: string | undefined;
+      if (isAuthenticatedResponse(authResponse)) {
+        try {
+          canonicalUserId = parseJwtPayload<CognitoAccessTokenPayload>(
+            authResponse.AuthenticationResult.AccessToken
+          ).username;
+        } catch (err) {
+          debug?.(`Failed to determine username from access token:`, err);
+        }
+      } else {
+        canonicalUserId = authResponse.ChallengeParameters?.USER_ID_FOR_SRP;
+      }
 
-      // Pre-create device SRP handler if we have a device key
-      const deviceHandler = actualDeviceKey
-        ? await createDeviceSrpAuthHandler(username, actualDeviceKey)
-        : undefined;
+      // Look up the device key under the canonical user id first, falling
+      // back to the username as entered (legacy behavior) so device records
+      // stored by previous versions keep working
+      const usernamesToTry = [...new Set([canonicalUserId, username])].filter(
+        (u): u is string => !!u
+      );
+      let deviceHandler:
+        | Awaited<ReturnType<typeof createDeviceSrpAuthHandler>>
+        | undefined;
+      for (const usernameToTry of usernamesToTry) {
+        const actualDeviceKey =
+          deviceKey ?? (await retrieveDeviceKey(usernameToTry));
+        if (!actualDeviceKey) continue;
+        // Pre-create device SRP handler if we have a device key
+        deviceHandler = await createDeviceSrpAuthHandler(
+          usernameToTry,
+          actualDeviceKey
+        );
+        if (deviceHandler) break;
+      }
 
       const tokens = await handleAuthResponse({
         authResponse,
-        username,
+        username: canonicalUserId ?? username,
         smsMfaCode,
         otpMfaCode,
         newPassword,


### PR DESCRIPTION
## Summary
Device-key / remembered-device records were keyed inconsistently across auth flows: the SRP flow keys them by the canonical user id (`USER_ID_FOR_SRP`), while the plaintext (`USER_PASSWORD_AUTH`) flow used the username as entered, which may be an alias (e-mail / phone). This PR makes the plaintext flow resolve the canonical user id from the auth response and use it consistently, with a backward-compat fallback lookup under the as-entered username.

## Finding
- **Severity:** MEDIUM
- **Confidence:** High (confirmed in code)
- `client/srp.ts:369-374` stores/retrieves device material under `USER_ID_FOR_SRP` (canonical), and `handleDeviceConfirmation` (`client/device.ts:367-375`) stores under `tokens.username`, which the SRP flow sets to `userIdForSrp`.
- `client/plaintext.ts:82-87` (before this PR) called `retrieveDeviceKey(username)` / `createDeviceSrpAuthHandler(username, ...)` with the as-entered username, and passed that username into `handleAuthResponse`, so device lookups at `client/cognito-api.ts:1089` and `:1116` also used the alias.
- **Concrete failure scenario:** a user signs in via SRP with their canonical username — the confirmed device is stored under the canonical id. Later they sign in with their e-mail alias through the plaintext flow: the device record is never found, so device remembering is silently lost; and if Cognito issues a `DEVICE_SRP_AUTH` challenge, `handleAuthResponse` (`client/cognito-api.ts:1088-1096`) throws `"Failed to create device SRP handler"`, failing the entire sign-in. The reverse direction (device confirmed via plaintext flow under an alias, later SRP sign-in) failed the same way.

## Fix
In `client/plaintext.ts`:
- After `initiateAuth`, resolve the canonical user id: `ChallengeParameters.USER_ID_FOR_SRP` for challenge responses, or the access token's `username` claim for directly authenticated responses.
- Look up the device key / build the device SRP handler under the canonical id first, falling back to the as-entered username so device records stored by previous versions keep working.
- Pass the canonical id as `username` to `handleAuthResponse`, matching the SRP flow. This makes in-challenge device-handler creation (`cognito-api.ts:1089/1116`), challenge `USERNAME`/`SECRET_HASH` values, and device-record storage in `handleDeviceConfirmation` all use the canonical id.

## Test plan
- New `client/__tests__/plaintext-device-key.test.ts` (jest, mocked Cognito responses):
  - device record stored under canonical id is found when signing in via an alias (challenge response path)
  - legacy alias-keyed record is still found via the fallback lookup
  - canonical id is resolved from the access token for directly authenticated responses
  - as-entered username is used when no canonical id is available
- Gates: `npx tsc --project client/tsconfig.json --noEmit` clean; `npx eslint client/plaintext.ts client/__tests__/plaintext-device-key.test.ts` clean; `npx jest` — 24 suites passed, 186 passed / 19 skipped, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches sign-in and device-remembering paths in authentication code; behavior change is intentional but could affect users with alias-keyed legacy device storage until fallback runs.
> 
> **Overview**
> Aligns **plaintext password auth** with the SRP flow so remembered-device records use the **canonical user id** instead of the login alias (email/phone).
> 
> After `initiateAuth`, the flow now derives that id from `USER_ID_FOR_SRP` on challenge responses or from the access token `username` claim when auth completes immediately. Device lookup tries the canonical id first, then the as-entered username for **legacy** records, and passes the canonical id into `handleAuthResponse` so MFA/device challenges and storage stay consistent with SRP.
> 
> Adds **`plaintext-device-key.test.ts`** with mocked Cognito responses covering canonical lookup, legacy fallback, token-based resolution, and the no-canonical-id case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2266e47f854d9bc2ca8e150a2315bab6675924b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->