### PR TITLE
Fix useAwaitableState hanging under React StrictMode

### DIFF
--- a/client/__tests__/react-awaitable-state.test.tsx
+++ b/client/__tests__/react-awaitable-state.test.tsx
@@ -1,0 +1,67 @@
+/**
+ * Copyright Amazon.com, Inc. and its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You
+ * may not use this file except in compliance with the License. A copy of
+ * the License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+import React from "react";
+import { renderHook, act } from "@testing-library/react";
+import { useAwaitableState } from "../react/hooks.js";
+
+describe("useAwaitableState", () => {
+  test("resolve() settles the awaitable with the current state", async () => {
+    const { result } = renderHook(() => useAwaitableState("mfa-code"));
+
+    const promise = result.current.awaitable();
+    act(() => result.current.resolve());
+
+    await expect(promise).resolves.toBe("mfa-code");
+    expect(result.current.awaited).toEqual({ value: "mfa-code" });
+  });
+
+  test("resolve() still settles the awaitable under React StrictMode (double mount)", async () => {
+    // StrictMode mounts, unmounts and remounts components in dev. Refs
+    // survive the simulated remount, so the unmount cleanup must not leave
+    // the hook permanently marked as unmounted (which would make
+    // resolve()/reject() no-ops and hang every MFA/new-password prompt).
+    const { result } = renderHook(() => useAwaitableState("mfa-code"), {
+      wrapper: React.StrictMode,
+    });
+
+    const promise = result.current.awaitable();
+    act(() => result.current.resolve());
+
+    await expect(promise).resolves.toBe("mfa-code");
+    expect(result.current.awaited).toEqual({ value: "mfa-code" });
+  });
+
+  test("reject() still settles the awaitable under React StrictMode (double mount)", async () => {
+    const { result } = renderHook(() => useAwaitableState("mfa-code"), {
+      wrapper: React.StrictMode,
+    });
+
+    const promise = result.current.awaitable();
+    const caught = promise.catch((err: Error) => err);
+    act(() => result.current.reject(new Error("user cancelled")));
+
+    await expect(caught).resolves.toEqual(new Error("user cancelled"));
+  });
+
+  test("resolve() is a no-op after a real unmount", () => {
+    const { result, unmount } = renderHook(() => useAwaitableState("value"));
+
+    const { resolve } = result.current;
+    unmount();
+
+    expect(() => resolve()).not.toThrow();
+  });
+});

--- a/client/react/hooks.tsx
+++ b/client/react/hooks.tsx
@@ -2092,6 +2092,10 @@ export function useAwaitableState<T>(state: T) {
 
   // Cleanup on unmount
   useEffect(() => {
+    // Mark as mounted (again) — under React StrictMode the effect cleanup
+    // below runs on the simulated unmount, but refs survive the remount,
+    // so we must reset the flag or resolve/reject become permanent no-ops
+    isMounted.current = true;
     return () => {
       isMounted.current = false;
       // Clear references to prevent memory leaks


### PR DESCRIPTION
## Summary
`useAwaitableState` never reset its `isMounted` ref after React StrictMode's simulated unmount, so in dev (StrictMode on, the default for Next.js/CRA/Vite) every promise it produced stayed pending forever — hanging MFA and new-password prompt flows. This PR resets the flag in the effect body and adds StrictMode regression tests.

## Finding
- Severity: LOW in production, MEDIUM in development; mechanism is certain.
- `client/react/hooks.tsx:2094-2102` — the unmount cleanup sets `isMounted.current = false` and nothing ever sets it back to `true`.
- Under React 18+ StrictMode's mount → unmount → remount cycle, refs survive the simulated remount, so after remount `isMounted.current` is permanently `false`.
- Both `resolve()` (`hooks.tsx:2109`) and `reject()` (`hooks.tsx:2118`) are guarded by `isMounted.current`, so they become permanent no-ops: `awaitable()` returns a promise that never settles and `awaited` is never populated.
- Concrete failure: the documented usage feeds `smsMfaCode`/`otpMfaCode`/`newPassword` callbacks — in dev StrictMode every MFA/new-password prompt hangs on `await awaitable()`. Production (no StrictMode double-invoke) is unaffected.

## Fix
Set `isMounted.current = true` in the cleanup effect's body before returning the cleanup (`client/react/hooks.tsx`). On a StrictMode remount all effects re-run, so the flag is restored and the initial-setup effect renews the promise refs the cleanup had cleared. Real unmounts behave exactly as before.

## Test plan
- New `client/__tests__/react-awaitable-state.test.tsx`: resolve/reject under `<React.StrictMode>` settle the promise (both fail by timeout on unfixed code — verified), plain resolve works, and resolve after a real unmount stays a safe no-op.
- `npx tsc --project client/tsconfig.json --noEmit` — clean.
- `npx eslint client/react/hooks.tsx client/__tests__/react-awaitable-state.test.tsx` — clean.
- `npx jest client/__tests__/` — 11 suites, 130 tests, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line lifecycle fix in a React hook plus tests; production without StrictMode double-mount is unchanged.
> 
> **Overview**
> Fixes **`useAwaitableState`** so MFA and new-password prompts no longer hang in **React StrictMode** (common in Next.js, CRA, and Vite dev).
> 
> StrictMode’s simulated unmount ran cleanup that set `isMounted` to `false` while refs survived remount, so **`resolve()` / `reject()`** stayed no-ops and promises never settled. The hook now sets **`isMounted.current = true`** when the mount effect runs again after remount; real unmount behavior is unchanged.
> 
> Adds **`client/__tests__/react-awaitable-state.test.tsx`** with StrictMode coverage for resolve/reject and a check that resolve after a real unmount remains a safe no-op.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8f005516f34ff11af90cab5592ece80dafb5d73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->