### PR TITLE
Add SRP-6a safety checks: B mod N != 0, u != 0, hex input validation

### DIFF
--- a/client/__tests__/srp.test.ts
+++ b/client/__tests__/srp.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Copyright Amazon.com, Inc. and its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You
+ * may not use this file except in compliance with the License. A copy of
+ * the License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+import { webcrypto } from "crypto";
+import { TextEncoder } from "util";
+import { configure, MinimalCrypto } from "../config.js";
+
+// jsdom does not provide TextEncoder
+if (typeof globalThis.TextEncoder === "undefined") {
+  globalThis.TextEncoder = TextEncoder as typeof globalThis.TextEncoder;
+}
+
+// jsdom's Blob does not implement arrayBuffer(), node's Blob does
+if (typeof Blob.prototype.arrayBuffer === "undefined") {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  globalThis.Blob = require("buffer").Blob as typeof globalThis.Blob;
+}
+import {
+  calculateSrpSignature,
+  generateSmallA,
+  calculateLargeAHex,
+  getConstants,
+  hexToArrayBuffer,
+  modPow,
+} from "../srp.js";
+
+const realCrypto = webcrypto as unknown as MinimalCrypto;
+
+function configureWithCrypto(crypto: MinimalCrypto) {
+  configure({
+    userPoolId: "eu-west-1_abc",
+    clientId: "test-client",
+    crypto,
+  });
+}
+
+describe("SRP safety checks", () => {
+  beforeEach(() => {
+    configureWithCrypto(realCrypto);
+  });
+
+  describe("B mod N validation (RFC 5054 section 2.5.3)", () => {
+    test("rejects B = 0", async () => {
+      await expect(
+        calculateSrpSignature({
+          smallA: BigInt(1234),
+          largeAHex: "abc",
+          srpBHex: "0",
+          salt: "ab12",
+          secretBlock: "c2VjcmV0",
+          creds: {
+            userPoolId: "eu-west-1_abc",
+            username: "alice",
+            password: "secret",
+          },
+        })
+      ).rejects.toThrow("B cannot be zero");
+    });
+
+    test("rejects B = N", async () => {
+      const { N } = await getConstants();
+      await expect(
+        calculateSrpSignature({
+          smallA: BigInt(1234),
+          largeAHex: "abc",
+          srpBHex: N.toString(16),
+          salt: "ab12",
+          secretBlock: "c2VjcmV0",
+          creds: {
+            userPoolId: "eu-west-1_abc",
+            username: "alice",
+            password: "secret",
+          },
+        })
+      ).rejects.toThrow("B cannot be zero");
+    });
+
+    test("rejects B = 2N (any multiple of N)", async () => {
+      const { N } = await getConstants();
+      await expect(
+        calculateSrpSignature({
+          smallA: BigInt(1234),
+          largeAHex: "abc",
+          srpBHex: (N * BigInt(2)).toString(16),
+          salt: "ab12",
+          secretBlock: "c2VjcmV0",
+          creds: {
+            deviceGroupKey: "group-key",
+            deviceKey: "device-key",
+            devicePassword: "device-secret",
+          },
+        })
+      ).rejects.toThrow("B cannot be zero");
+    });
+  });
+
+  describe("u != 0 validation (SRP-6a design)", () => {
+    test("rejects u = 0", async () => {
+      // Make sure the SRP constants are cached before mocking the digest,
+      // so that the mock only affects the computation of u
+      await getConstants();
+      const zeroDigestCrypto: MinimalCrypto = {
+        getRandomValues: realCrypto.getRandomValues.bind(realCrypto),
+        subtle: {
+          digest: () => Promise.resolve(new Uint8Array(32).buffer),
+          importKey: realCrypto.subtle.importKey.bind(realCrypto.subtle),
+          sign: realCrypto.subtle.sign.bind(realCrypto.subtle),
+        },
+      };
+      configureWithCrypto(zeroDigestCrypto);
+      await expect(
+        calculateSrpSignature({
+          smallA: BigInt(1234),
+          largeAHex: "abc",
+          srpBHex: "5",
+          salt: "ab12",
+          secretBlock: "c2VjcmV0",
+          creds: {
+            userPoolId: "eu-west-1_abc",
+            username: "alice",
+            password: "secret",
+          },
+        })
+      ).rejects.toThrow("U cannot be zero");
+    });
+  });
+
+  test("accepts a well-formed B and produces a signature", async () => {
+    const { g, N } = await getConstants();
+    const smallA = generateSmallA();
+    const largeAHex = await calculateLargeAHex(smallA);
+    // Craft a structurally valid (non-degenerate) server B value
+    const srpBHex = modPow(g, BigInt(98765), N).toString(16);
+    const { passwordClaimSignature, timestamp } = await calculateSrpSignature({
+      smallA,
+      largeAHex,
+      srpBHex,
+      salt: "ab12",
+      secretBlock: "c2VjcmV0",
+      creds: {
+        userPoolId: "eu-west-1_abc",
+        username: "alice",
+        password: "secret",
+      },
+    });
+    expect(typeof passwordClaimSignature).toBe("string");
+    expect(passwordClaimSignature.length).toBeGreaterThan(0);
+    expect(typeof timestamp).toBe("string");
+  });
+
+  describe("hexToArrayBuffer input validation", () => {
+    test("throws a clear error on empty input", () => {
+      expect(() => hexToArrayBuffer("")).toThrow(
+        "hex string should be non-empty and contain only hex characters"
+      );
+    });
+
+    test("throws a clear error on non-hex input", () => {
+      expect(() => hexToArrayBuffer("zzzz")).toThrow(
+        "hex string should be non-empty and contain only hex characters"
+      );
+    });
+
+    test("throws on odd-length input", () => {
+      expect(() => hexToArrayBuffer("abc")).toThrow(
+        "hex string should have even number of characters"
+      );
+    });
+
+    test("decodes valid hex", () => {
+      expect([...hexToArrayBuffer("00ff10")]).toEqual([0, 255, 16]);
+    });
+  });
+});

--- a/client/srp.ts
+++ b/client/srp.ts
@@ -134,6 +134,15 @@ async function calculateSrpSignature({
   creds: UserCreds | DeviceCreds;
 }) {
   const { crypto } = configure();
+  const { g, N, k } = await getConstants();
+
+  // ---- 0. SRP-6a safety check on B ----
+  // RFC 5054 (section 2.5.3) mandates that the client MUST abort the
+  // handshake if B mod N = 0
+  const srpB = BigInt(`0x${srpBHex}`);
+  if (modulo(srpB, N) === BigInt(0)) {
+    throw new Error("B cannot be zero");
+  }
 
   // ---- 1. scramble parameter (u) ----
   const aPlusBHex = padHex(largeAHex) + padHex(srpBHex);
@@ -141,6 +150,11 @@ async function calculateSrpSignature({
     "SHA-256",
     hexToArrayBuffer(aPlusBHex)
   );
+  // The SRP-6a design (srp.stanford.edu/design.html) requires the client
+  // to abort if the scramble parameter u = 0
+  if (arrayBufferToBigInt(uBuf) === BigInt(0)) {
+    throw new Error("U cannot be zero");
+  }
 
   // ---- 2. credential-specific hash (x) ----
   let identityHash: ArrayBuffer;
@@ -174,9 +188,8 @@ async function calculateSrpSignature({
   );
 
   // ---- 3. shared secret (S) ----
-  const { g, N, k } = await getConstants();
   const gModPowXN = modPow(g, arrayBufferToBigInt(xBuf), N);
-  const int = BigInt(`0x${srpBHex}`) - k * gModPowXN;
+  const int = srpB - k * gModPowXN;
   const s = modPow(
     int,
     smallA + arrayBufferToBigInt(uBuf) * arrayBufferToBigInt(xBuf),
@@ -258,6 +271,11 @@ async function calculateSrpSignature({
 function hexToArrayBuffer(hexStr: string) {
   if (hexStr.length % 2 !== 0) {
     throw new Error("hex string should have even number of characters");
+  }
+  if (!hexStr.length || !/^[0-9a-f]+$/i.test(hexStr)) {
+    throw new Error(
+      "hex string should be non-empty and contain only hex characters"
+    );
   }
   const octets = hexStr.match(/.{2}/gi)!.map((m) => parseInt(m, 16));
   return new Uint8Array(octets);


### PR DESCRIPTION
## Summary
Adds the missing SRP-6a safety checks to the SRP client implementation: the handshake now aborts if the server-supplied `B` is congruent to 0 mod N or if the scramble parameter `u` is 0, and `hexToArrayBuffer` now rejects empty/non-hex input with a clear error.

## Finding
- Severity: LOW (hardening), externally validated
- Confidence: high
- `client/srp.ts:139-143` and `client/srp.ts:176-184` (pre-fix line numbers): `srpBHex` from `ChallengeParameters` was used directly in `S = (B - k*g^x)^(a+ux) mod N` without verifying `B mod N != 0`, and the scramble parameter `u` was used without verifying `u != 0`. RFC 5054 §2.5.3 mandates "The client MUST abort the handshake with an illegal_parameter alert if B % N = 0" (reinforced by §3.1: "CRUCIAL for security and MUST be performed"); the `u != 0` abort comes from the SRP-6a design spec (srp.stanford.edu/design.html: "The user will abort if he receives B == 0 (mod N) or u == 0"). The reference client (amazon-cognito-identity-js) enforces both ("B cannot be zero.", "U cannot be zero.").
- Concrete failure scenario: this library supports arbitrary `cognitoIdpEndpoint`/proxy configurations, so a malicious or MITM'd endpoint can send a degenerate `SRP_B` (0, N, or a multiple of N), which collapses the shared secret `S` to a value independent of the password, weakening the password proof the client then signs and returns.
- `client/srp.ts:262` (pre-fix): `hexToArrayBuffer` used a non-null assertion on `.match()`, so an empty server-supplied hex string (e.g. empty `SALT`) threw an opaque `TypeError` instead of a descriptive error.

## Fix
All in `client/srp.ts`, inside `calculateSrpSignature` so both the user-password flow (`authenticateWithSRP`) and the device-password flow (`verifyDeviceSrp`, which delegates here; it does not parse a separate `SRP_B`) are covered:
- Parse `B` once at the top and throw `"B cannot be zero"` if `B mod N === 0` (RFC 5054 MUST).
- After computing the `u` digest, throw `"U cannot be zero"` if `u === 0` (SRP-6a design requirement).
- `hexToArrayBuffer` now throws a descriptive `Error` on empty or non-hex input instead of a `TypeError` from the non-null assertion.

Error messages mirror the reference client (amazon-cognito-identity-js).

## Test plan
New `client/__tests__/srp.test.ts` (9 tests, all passing):
- `B = 0`, `B = N`, `B = 2N` are rejected with "B cannot be zero" (covers user and device cred shapes)
- `u = 0` rejected: forced via a configured crypto whose `subtle.digest` returns all zeros, exercising the public `calculateSrpSignature` path
- Happy path: well-formed `B` still produces a signature
- `hexToArrayBuffer`: empty input and non-hex input throw the clear error; odd-length input keeps its existing error; valid hex round-trips

Gates: `npx tsc --project client/tsconfig.json --noEmit` clean; `npx eslint client/srp.ts client/__tests__/srp.test.ts` clean; `npx jest` — 24/24 suites passed (2 skipped pre-existing), 191 passed / 19 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication crypto in `calculateSrpSignature` (user and device SRP flows); changes reject malicious inputs but could break misconfigured endpoints that sent invalid parameters.
> 
> **Overview**
> Hardens the SRP client handshake so **degenerate server values cannot proceed** to shared-secret derivation.
> 
> In `calculateSrpSignature`, the client now **aborts** if server `B` satisfies `B mod N = 0` (`"B cannot be zero"`) and if the scramble parameter `u` is zero (`"U cannot be zero"`), matching RFC 5054 / SRP-6a and the reference Cognito client. `srpB` is parsed once up front and reused when computing the shared secret.
> 
> `hexToArrayBuffer` now rejects **empty or non-hex** strings with an explicit error instead of failing opaquely on bad input.
> 
> Adds `client/__tests__/srp.test.ts` covering invalid `B`, forced `u = 0`, a happy-path signature, and hex decoding edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 794754aee18a05ce76fe0bfe4f6b99161ef7fada. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->