### PR TITLE
Fix userHandle encoding to UTF-8 for usernameless sign-in with non-ASCII usernames

### DIFF
--- a/client/__tests__/fido2-core.test.ts
+++ b/client/__tests__/fido2-core.test.ts
@@ -15,6 +15,7 @@
 
 import {
   fido2getCredential,
+  fido2CreateCredential,
   prepareFido2SignIn,
   authenticateWithFido2,
 } from "../fido2.js";
@@ -34,14 +35,23 @@ import {
   assertTransformedCredentialMatches,
 } from "./__utils__/webauthn-mocks.js";
 import { initiateAuth } from "../cognito-api.js";
-import { retrieveDeviceKey } from "../storage.js";
+import { retrieveDeviceKey, retrieveTokens } from "../storage.js";
 import { bufferToBase64Url } from "../util.js";
-import { TextDecoder as NodeTextDecoder } from "util";
+import {
+  TextDecoder as NodeTextDecoder,
+  TextEncoder as NodeTextEncoder,
+} from "util";
 
 if (typeof globalThis.TextDecoder === "undefined") {
   (
     globalThis as unknown as { TextDecoder: typeof NodeTextDecoder }
   ).TextDecoder = NodeTextDecoder;
+}
+
+if (typeof globalThis.TextEncoder === "undefined") {
+  (
+    globalThis as unknown as { TextEncoder: typeof NodeTextEncoder }
+  ).TextEncoder = NodeTextEncoder;
 }
 
 // Mock dependencies
@@ -55,6 +65,9 @@ const mockInitiateAuth = initiateAuth as jest.MockedFunction<
 >;
 const mockRetrieveDeviceKey = retrieveDeviceKey as jest.MockedFunction<
   typeof retrieveDeviceKey
+>;
+const mockRetrieveTokens = retrieveTokens as jest.MockedFunction<
+  typeof retrieveTokens
 >;
 
 describe("FIDO2 Core Functionality", () => {
@@ -312,6 +325,89 @@ describe("FIDO2 Core Functionality", () => {
     // Note: Full integration tests for credential creation are complex
     // as they require mocking multiple API calls. These are covered by
     // the existing fido2-errors.test.ts file.
+
+    describe("user handle (user.id) encoding", () => {
+      const startCreateResponse = (userId: string) => ({
+        ok: true,
+        json: async () => ({
+          challenge: "test-challenge",
+          rp: { name: TEST_RP.name, id: TEST_RP.id },
+          user: { id: userId, name: "test", displayName: "Test User" },
+          pubKeyCredParams: [{ type: "public-key", alg: -7 }],
+          timeout: 60000,
+          excludeCredentials: [],
+          authenticatorSelection: { userVerification: "preferred" },
+        }),
+      });
+
+      const captureUserHandle = async (userId: string) => {
+        mockRetrieveTokens.mockResolvedValue({
+          username: "testuser",
+          idToken: "test-token",
+        } as Awaited<ReturnType<typeof retrieveTokens>>);
+        (baseConfig.fetch as jest.Mock).mockResolvedValue(
+          startCreateResponse(userId)
+        );
+        // Return null from create() so fido2CreateCredential throws after
+        // we have captured the assembled publicKey options
+        const mockCreate = jest.fn().mockResolvedValue(null);
+        Object.defineProperty(global.navigator, "credentials", {
+          value: { create: mockCreate },
+          configurable: true,
+        });
+        await expect(
+          fido2CreateCredential({ friendlyName: "Test" })
+        ).rejects.toThrow(Fido2CredentialError);
+        const { publicKey } = mockCreate.mock.calls[0][0] as {
+          publicKey: { user: { id: Uint8Array } };
+        };
+        return publicKey.user.id;
+      };
+
+      it("round-trips non-ASCII user handles through the sign-in decoder", async () => {
+        const userId = "u|Ünïcødé用户";
+        const userHandle = await captureUserHandle(userId);
+        // Sign-in decodes the userHandle with TextDecoder (UTF-8), so the
+        // registered bytes must decode back to the exact same string
+        expect(new TextDecoder().decode(userHandle)).toBe(userId);
+        // The old Latin-1 byte-stuffing encoding corrupted these bytes
+        expect(Array.from(userHandle)).not.toEqual(
+          Array.from(userId, (c) => c.charCodeAt(0))
+        );
+      });
+
+      it("encodes ASCII user handles identically to the previous encoding", async () => {
+        const userId = "u|user-123";
+        const userHandle = await captureUserHandle(userId);
+        expect(Array.from(userHandle)).toEqual(
+          Array.from(userId, (c) => c.charCodeAt(0))
+        );
+        expect(new TextDecoder().decode(userHandle)).toBe(userId);
+      });
+
+      it("throws a clear error when the user handle exceeds 64 bytes", async () => {
+        const userId = `u|${"用".repeat(22)}`; // 2 + 22 * 3 = 68 bytes UTF-8
+        mockRetrieveTokens.mockResolvedValue({
+          username: "testuser",
+          idToken: "test-token",
+        } as Awaited<ReturnType<typeof retrieveTokens>>);
+        (baseConfig.fetch as jest.Mock).mockResolvedValue(
+          startCreateResponse(userId)
+        );
+        const mockCreate = jest.fn();
+        Object.defineProperty(global.navigator, "credentials", {
+          value: { create: mockCreate },
+          configurable: true,
+        });
+        await expect(
+          fido2CreateCredential({ friendlyName: "Test" })
+        ).rejects.toThrow(Fido2ValidationError);
+        await expect(
+          fido2CreateCredential({ friendlyName: "Test" })
+        ).rejects.toThrow("User handle must not exceed 64 bytes");
+        expect(mockCreate).not.toHaveBeenCalled();
+      });
+    });
   });
 
   describe("Error Handling", () => {

--- a/client/__tests__/setup.ts
+++ b/client/__tests__/setup.ts
@@ -16,6 +16,23 @@
 // Mock localStorage for jsdom
 import "jest-localstorage-mock";
 
+// jsdom doesn't provide TextEncoder/TextDecoder, polyfill from Node
+import {
+  TextEncoder as NodeTextEncoder,
+  TextDecoder as NodeTextDecoder,
+} from "util";
+
+if (typeof globalThis.TextEncoder === "undefined") {
+  (
+    globalThis as unknown as { TextEncoder: typeof NodeTextEncoder }
+  ).TextEncoder = NodeTextEncoder;
+}
+if (typeof globalThis.TextDecoder === "undefined") {
+  (
+    globalThis as unknown as { TextDecoder: typeof NodeTextDecoder }
+  ).TextDecoder = NodeTextDecoder;
+}
+
 // Mock setTimeoutWallClock from util.js
 jest.mock("../util.js", () => {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment

--- a/client/fido2.ts
+++ b/client/fido2.ts
@@ -255,6 +255,27 @@ function isAuthenticatorAssertionResponseLike(
   );
 }
 
+/**
+ * Encode the server-provided user handle (user.id) as UTF-8 bytes.
+ *
+ * Sign-in decodes the userHandle returned by the authenticator with
+ * TextDecoder (UTF-8), so registration must use the symmetric encoding —
+ * otherwise non-ASCII usernames are corrupted at registration and
+ * usernameless sign-in permanently fails for that credential.
+ */
+function encodeUserHandle(id: string) {
+  const userHandle = new TextEncoder().encode(id);
+  // WebAuthn caps user handles at 64 bytes — fail loudly instead of
+  // letting the authenticator truncate or reject opaquely
+  if (userHandle.byteLength > 64) {
+    throw new Fido2ValidationError(
+      `User handle must not exceed 64 bytes (got ${userHandle.byteLength} bytes)`,
+      id
+    );
+  }
+  return userHandle;
+}
+
 export async function fido2CreateCredential({
   friendlyName,
 }: {
@@ -276,7 +297,7 @@ export async function fido2CreateCredential({
     challenge: bufferFromBase64Url(publicKeyOptions.challenge),
     user: {
       ...publicKeyOptions.user,
-      id: Uint8Array.from(publicKeyOptions.user.id, (c) => c.charCodeAt(0)),
+      id: encodeUserHandle(publicKeyOptions.user.id),
     },
     excludeCredentials: publicKeyOptions.excludeCredentials.map(
       (credential) => ({


### PR DESCRIPTION
## Summary
Registration and sign-in used asymmetric encodings for the WebAuthn user handle: registration byte-stuffed the server-sent `user.id` string as Latin-1 (`charCodeAt` truncated mod 256), while usernameless sign-in decodes the authenticator-returned `userHandle` as UTF-8. This corrupted non-ASCII usernames at registration and permanently broke usernameless sign-in for those credentials. Registration now encodes the user handle with `TextEncoder` (UTF-8), making the round-trip symmetric.

## Finding
- **Severity:** Low (only affects non-ASCII usernames in the usernameless flow)
- **Confidence:** High — externally validated with an executable repro
- **Where:**
  - `client/fido2.ts:279` (pre-fix) — `Uint8Array.from(publicKeyOptions.user.id, (c) => c.charCodeAt(0))` encodes UTF-16 code units truncated mod 256 (Latin-1 byte-stuffing)
  - `client/fido2.ts:1006-1008` (pre-fix line numbers) — usernameless flow decodes the returned `userHandle` with `new TextDecoder().decode(...)` (UTF-8)
- **Concrete failure scenario:** per the WebAuthn spec the user handle is an opaque byte sequence that discoverable credentials return verbatim in `response.userHandle`. For a user.id like `u|Ünïcødé用户`, the old encoding produces bytes that the UTF-8 decoder turns into mojibake (repro: `"Ünïcødé用户"` → bytes `[220,110,239,99,248,100,233,40,55]` → `"�n�c�d�(7"`). The derived `USERNAME` sent to `initiateAuth` (`client/fido2.ts:1027-1031`, pre-fix) never matches a Cognito user, so usernameless sign-in fails permanently for that credential.

**Caveat:** credentials already registered with the old encoding for non-ASCII usernames were already broken for usernameless sign-in — the corruption happened at registration time and is baked into the authenticator. This fix makes new registrations correct; affected users must re-register their passkey. ASCII user handles (including Cognito's typical `u|<sub>` values) are byte-identical under both encodings, so there is no behavior change for them.

## Fix
- `client/fido2.ts` — new `encodeUserHandle()` helper encodes `user.id` with `new TextEncoder().encode(...)` (UTF-8), symmetric with the sign-in decoder. If the UTF-8 encoding exceeds the WebAuthn 64-byte user handle limit (theoretical for Cognito's `u|<sub>` ids), it throws a clear `Fido2ValidationError` instead of letting the authenticator truncate or reject opaquely.
- `client/__tests__/setup.ts` — polyfill `TextEncoder`/`TextDecoder` from Node `util` for the jsdom test environment.

## Test plan
- Added regression tests in `client/__tests__/fido2-core.test.ts`:
  - Non-ASCII `user.id` (`u|Ünïcødé用户`) round-trips: bytes passed to `navigator.credentials.create` decode back to the identical string via the existing sign-in decode path, and differ from the old Latin-1 byte-stuffed bytes.
  - ASCII `user.id` is byte-identical to the previous encoding (no behavior change).
  - A >64-byte UTF-8 `user.id` throws `Fido2ValidationError` with a clear message before `navigator.credentials.create` is called.
- Gates: `npx tsc --project client/tsconfig.json --noEmit` clean; `npx eslint` clean on changed files; `npx jest client/__tests__` — 10 suites, 129 tests, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes authentication credential registration encoding for passkeys; ASCII users are unchanged but non-ASCII usernameless sign-in behavior shifts for newly registered credentials.
> 
> **Overview**
> **FIDO2 passkey registration** now UTF-8-encodes the WebAuthn `user.id` user handle via a new `encodeUserHandle()` helper, replacing Latin-1 `charCodeAt` byte-stuffing so it matches the **usernameless sign-in** path that decodes `userHandle` with `TextDecoder`. Non-ASCII usernames should round-trip correctly for discoverable credentials; ASCII handles stay byte-identical.
> 
> Handles longer than the WebAuthn **64-byte** limit throw **`Fido2ValidationError`** before `navigator.credentials.create`. Jest setup and **`fido2-core`** tests add `TextEncoder`/`TextDecoder` polyfills and cover non-ASCII round-trip, ASCII compatibility, and the length guard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4f7e10609e11ccc757172631e4dc81cf1268aa0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->