### PR TITLE
Fix device salt: canonicalize as big integer before hashing and upload

### DIFF
--- a/client/__tests__/device-salt.test.ts
+++ b/client/__tests__/device-salt.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Copyright Amazon.com, Inc. and its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You
+ * may not use this file except in compliance with the License. A copy of
+ * the License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+/**
+ * Regression tests for device-verifier salt canonicalization.
+ *
+ * Cognito stores and echoes the device salt as a big integer: the SALT
+ * ChallengeParameter returned in DEVICE_PASSWORD_VERIFIER challenges has any
+ * leading zero bytes stripped. Before this fix, confirmation-time x was
+ * hashed over the raw 16 random salt bytes (top bit cleared), so a salt with
+ * a leading 0x00 byte (P ~ 1/128) produced a verifier that could never be
+ * matched again at device sign-in time: the recomputed x - derived from the
+ * echoed SALT hex via padHex - hashed over fewer bytes, permanently breaking
+ * DEVICE_PASSWORD_VERIFIER auth for that device.
+ *
+ * The fix mirrors amazon-cognito-identity-js: the salt is canonicalized
+ * through BigInt + padHex BEFORE hashing, and the same canonical bytes are
+ * uploaded in DeviceSecretVerifierConfig.Salt, so what's hashed always equals
+ * what the server stores and echoes back.
+ */
+
+// jsdom doesn't define TextDecoder/TextEncoder, nor Blob.arrayBuffer(), which
+// the SRP calculations rely on. Provide Node's.
+import { TextEncoder, TextDecoder } from "util";
+import { Blob as NodeBlob } from "buffer";
+import { webcrypto } from "crypto";
+Object.assign(globalThis, {
+  TextEncoder: globalThis.TextEncoder ?? TextEncoder,
+  TextDecoder: globalThis.TextDecoder ?? TextDecoder,
+  Blob: NodeBlob,
+});
+
+import { configure, MinimalCrypto } from "../config.js";
+import { calculateDeviceVerifier } from "../device.js";
+import {
+  getConstants,
+  modPow,
+  padHex,
+  hexToArrayBuffer,
+  arrayBufferToHex,
+  arrayBufferToBigInt,
+} from "../srp.js";
+import { bufferFromBase64, bufferToBase64 } from "../util.js";
+
+const DEVICE_KEY = "eu-west-1_12345678-1234-1234-1234-123456789012";
+const DEVICE_GROUP_KEY = "-fakeGroupKey";
+const DEVICE_PASSWORD = "secret-device-password";
+
+/** The next salt that the mocked crypto.getRandomValues will produce */
+let nextSalt: Uint8Array | undefined;
+
+const testCrypto: MinimalCrypto = {
+  getRandomValues: <T extends ArrayBufferView | null>(arr: T): T => {
+    if (!(arr instanceof Uint8Array)) {
+      throw new Error("Unexpected getRandomValues argument in test");
+    }
+    if (nextSalt) {
+      if (nextSalt.length !== arr.length) {
+        throw new Error("Crafted salt length mismatch");
+      }
+      arr.set(nextSalt);
+      nextSalt = undefined;
+    } else {
+      webcrypto.getRandomValues(arr);
+    }
+    return arr;
+  },
+  subtle: {
+    digest: webcrypto.subtle.digest.bind(webcrypto.subtle),
+    importKey: webcrypto.subtle.importKey.bind(
+      webcrypto.subtle
+    ) as MinimalCrypto["subtle"]["importKey"],
+    sign: webcrypto.subtle.sign.bind(webcrypto.subtle),
+  },
+};
+
+beforeAll(() => {
+  configure({
+    userPoolId: "eu-west-1_test",
+    clientId: "test-client-id",
+    crypto: testCrypto,
+  });
+});
+
+/**
+ * Recompute the device password verifier the way later device sign-ins do
+ * (srp.ts calculateSrpSignature): x is hashed over
+ * hexToArrayBuffer(padHex(SALT)) where SALT is the hex string echoed by
+ * Cognito in the DEVICE_PASSWORD_VERIFIER ChallengeParameters.
+ */
+async function recomputeVerifierFromEchoedSalt(echoedSaltHex: string) {
+  const fullPasswordHash = await testCrypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(
+      `${DEVICE_GROUP_KEY}${DEVICE_KEY}:${DEVICE_PASSWORD}`
+    )
+  );
+  const xBuf = await testCrypto.subtle.digest(
+    "SHA-256",
+    await new Blob([
+      hexToArrayBuffer(padHex(echoedSaltHex)),
+      fullPasswordHash,
+    ]).arrayBuffer()
+  );
+  const { g, N } = await getConstants();
+  const verifier = modPow(g, arrayBufferToBigInt(xBuf), N);
+  return bufferToBase64(hexToArrayBuffer(padHex(verifier.toString(16))));
+}
+
+/**
+ * Simulate Cognito's serialization of the stored salt: it's treated as a big
+ * integer, so leading zero bytes are stripped from the echoed hex.
+ */
+function echoSaltAsBigIntegerHex(uploadedSaltB64: string) {
+  const storedBytes = new Uint8Array(bufferFromBase64(uploadedSaltB64));
+  return BigInt(`0x${arrayBufferToHex(storedBytes.buffer)}`).toString(16);
+}
+
+async function confirmAndSignIn(craftedSalt: Uint8Array) {
+  nextSalt = craftedSalt;
+  const { passwordVerifier, salt } = await calculateDeviceVerifier(
+    "test-user",
+    DEVICE_KEY,
+    DEVICE_GROUP_KEY,
+    DEVICE_PASSWORD
+  );
+  const echoedSaltHex = echoSaltAsBigIntegerHex(salt);
+  const recomputedVerifier = await recomputeVerifierFromEchoedSalt(
+    echoedSaltHex
+  );
+  return { passwordVerifier, salt, recomputedVerifier };
+}
+
+describe("device verifier salt canonicalization", () => {
+  test("salt with leading zero byte: uploaded salt is the canonical big-integer encoding and sign-in x matches confirmation x", async () => {
+    // First byte 0x00 and second byte < 0x80: a big-integer round-trip strips
+    // the leading zero byte for good (padHex won't re-add it). This is the
+    // case that permanently broke DEVICE_PASSWORD_VERIFIER before the fix.
+    const craftedSalt = new Uint8Array([
+      0x00, 0x5a, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa,
+      0xbb, 0xcc, 0xdd, 0xee,
+    ]);
+    const { passwordVerifier, salt, recomputedVerifier } =
+      await confirmAndSignIn(craftedSalt);
+
+    // The uploaded salt must be the canonical big-integer encoding (leading
+    // zero byte stripped), i.e. exactly what Cognito will store and echo back
+    const canonicalHex = padHex(
+      arrayBufferToBigInt(craftedSalt.buffer).toString(16)
+    );
+    expect(arrayBufferToHex(bufferFromBase64(salt))).toBe(canonicalHex);
+    expect(bufferFromBase64(salt).byteLength).toBe(15);
+
+    // Sign-in-time x (recomputed from the echoed SALT) must agree with
+    // confirmation-time x, i.e. yield the registered verifier
+    expect(recomputedVerifier).toBe(passwordVerifier);
+  });
+
+  test("salt with most significant bit set gets proper sign handling (00 prefix) and round-trips", async () => {
+    const craftedSalt = new Uint8Array([
+      0xff, 0x5a, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa,
+      0xbb, 0xcc, 0xdd, 0xee,
+    ]);
+    const { passwordVerifier, salt, recomputedVerifier } =
+      await confirmAndSignIn(craftedSalt);
+
+    // padHex must prefix "00" to keep the big integer positive, like the
+    // reference implementation (amazon-cognito-identity-js) does
+    const saltBytes = new Uint8Array(bufferFromBase64(salt));
+    expect(saltBytes.byteLength).toBe(17);
+    expect(saltBytes[0]).toBe(0x00);
+    expect(arrayBufferToHex(saltBytes.buffer)).toBe(
+      `00${arrayBufferToHex(craftedSalt.buffer)}`
+    );
+
+    expect(recomputedVerifier).toBe(passwordVerifier);
+  });
+
+  test("ordinary salt (no leading zero, MSB clear) is uploaded as-is and round-trips", async () => {
+    const craftedSalt = new Uint8Array([
+      0x12, 0x5a, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa,
+      0xbb, 0xcc, 0xdd, 0xee,
+    ]);
+    const { passwordVerifier, salt, recomputedVerifier } =
+      await confirmAndSignIn(craftedSalt);
+
+    expect(arrayBufferToHex(bufferFromBase64(salt))).toBe(
+      arrayBufferToHex(craftedSalt.buffer)
+    );
+    expect(recomputedVerifier).toBe(passwordVerifier);
+  });
+});

--- a/client/device.ts
+++ b/client/device.ts
@@ -19,7 +19,6 @@ import {
   modPow,
   getConstants,
   hexToArrayBuffer,
-  arrayBufferToHex,
   arrayBufferToBigInt,
   padHex,
   generateSmallA,
@@ -76,8 +75,10 @@ async function generateDevicePassword(): Promise<string> {
 /**
  * Calculate SRP verification values for device confirmation
  * This follows the same pattern as the Python example
+ *
+ * Exported for testing purposes only.
  */
-async function calculateDeviceVerifier(
+export async function calculateDeviceVerifier(
   _username: string,
   deviceKey: string,
   deviceGroupKey: string,
@@ -91,9 +92,15 @@ async function calculateDeviceVerifier(
   // Generate salt
   const saltBuffer = new Uint8Array(16);
   crypto.getRandomValues(saltBuffer);
-  // Ensure first bit is not set (making it positive)
-  saltBuffer[0] = saltBuffer[0] & 0x7f;
-  const salt = bufferToBase64(saltBuffer);
+  // Canonicalize the salt as a big integer (like amazon-cognito-identity-js
+  // does): Cognito stores and echoes the salt back as a big integer, which
+  // strips any leading zero bytes (and padHex re-adds a "00" prefix when the
+  // top bit is set, to keep it positive). Hash x over, and upload, that same
+  // canonical encoding, so the salt hashed here is always identical to the
+  // SALT echoed back in later DEVICE_PASSWORD_VERIFIER challenges.
+  const saltHex = padHex(arrayBufferToBigInt(saltBuffer.buffer).toString(16));
+  const saltBytes = hexToArrayBuffer(saltHex);
+  const salt = bufferToBase64(saltBytes);
 
   // Create FULL_PASSWORD = SHA256_HASH(DeviceGroupKey + deviceKey + ":" + DEVICE_PASSWORD)
   const fullPasswordString = `${deviceGroupKey}${deviceKey}:${devicePassword}`;
@@ -103,9 +110,8 @@ async function calculateDeviceVerifier(
   );
 
   // Create x = SHA256_HASH(salt + FULL_PASSWORD)
-  const saltHex = arrayBufferToHex(saltBuffer);
   const saltAndPassword = await new Blob([
-    hexToArrayBuffer(padHex(saltHex)),
+    saltBytes,
     fullPasswordHash,
   ]).arrayBuffer();
 


### PR DESCRIPTION
## Summary
Device-verifier salts with a leading zero byte produced a `DeviceSecretVerifierConfig` whose hashed salt could never be reproduced from the `SALT` value Cognito echoes back, permanently breaking `DEVICE_PASSWORD_VERIFIER` auth for that device. The salt is now canonicalized through BigInt + `padHex` before being hashed and uploaded, mirroring `amazon-cognito-identity-js`.

## Finding
- Severity: HIGH impact when hit (device auth permanently broken for the affected device), LOW probability (~1/128 per confirmed device).
- Confidence: high — confirmed in code and validated against the reference client.
- `client/device.ts:92-110` (pre-fix): at confirmation time, `x` was hashed over the raw 16 salt bytes (top bit cleared via `& 0x7f`) and the salt was uploaded as base64 of those same raw bytes.
- `client/srp.ts:173`: at later device sign-in, `x` is recomputed from the server-echoed `ChallengeParameters.SALT` hex via `padHex`.
- Concrete failure: if `saltBuffer[0] === 0x00` (P ≈ 1/128 after the mask), Cognito — which treats the stored salt as a big integer — echoes the SALT hex with the leading zero byte stripped. When the next byte is < 0x80, `padHex` does not re-add it, so sign-in-time `x` is hashed over 15 bytes while the registered verifier was computed over 16. The signatures never match again and the device permanently fails `DEVICE_PASSWORD_VERIFIER`.
- The reference client (`amazon-cognito-identity-js`) deliberately routes its random device salt through `BigInteger` + `padHex` before hashing (`this.SaltToHashDevices = this.padHex(new BigInteger(hexRandom, 16))`) and parses the echoed SALT as `new BigInteger(challengeParameters.SALT, 16)`, avoiding exactly this.

## Fix
In `calculateDeviceVerifier` (`client/device.ts`):
- Derive the canonical salt hex via `padHex(arrayBufferToBigInt(saltBuffer.buffer).toString(16))` before hashing.
- Hash `x` over those canonical bytes, and upload the same canonical bytes (base64) in `DeviceSecretVerifierConfig.Salt`, so what is hashed always equals what Cognito stores and echoes.
- Drop the explicit `& 0x7f` top-bit masking: `padHex` now supplies the `00` sign prefix when the MSB is set, exactly like the reference implementation.
- `calculateDeviceVerifier` is exported for testing.

## Test plan
- New regression tests in `client/__tests__/device-salt.test.ts` use a crafted random source and real WebCrypto to simulate the full round trip (Cognito big-integer salt echo + sign-in-time `x` recomputation per `client/srp.ts`):
  - leading-zero salt byte: uploaded salt equals the canonical big-integer encoding (15 bytes) and the recomputed verifier matches the registered one;
  - MSB-set salt: gets the `00` sign prefix (17 bytes) and round-trips;
  - ordinary salt: uploaded unchanged (16 bytes) and round-trips.
- Verified the leading-zero and MSB tests fail against the pre-fix salt logic.
- Gates: `npx tsc --project client/tsconfig.json --noEmit` clean; `npx eslint` clean on changed files; full `npx jest`: 24 suites passed, 2 skipped; 185 tests passed, 19 skipped, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Cognito device SRP registration and auth crypto; wrong salt encoding permanently breaks remembered devices, but the change aligns with the reference client and is covered by targeted regression tests.
> 
> **Overview**
> Fixes **device verifier salt handling** in `calculateDeviceVerifier` so confirmation-time hashing matches what Cognito stores and echoes during later **`DEVICE_PASSWORD_VERIFIER`** sign-in.
> 
> Instead of hashing and uploading raw 16-byte salt (with the old top-bit mask), the salt is **canonicalized as a big integer** via `BigInt` + `padHex`, then those same bytes are used for `x` and for `DeviceSecretVerifierConfig.Salt`—matching **amazon-cognito-identity-js** and avoiding the ~1/128 case where a leading zero byte made registered verifiers impossible to reproduce.
> 
> Adds **`client/__tests__/device-salt.test.ts`** regression tests (crafted salts: leading zero, MSB set, normal) and exports `calculateDeviceVerifier` for testing only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8360ea138c53f9e53df221d7693e0047604d7c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->