### PR TITLE
Redact tokens and device keys from debug logging

### DIFF
--- a/client/cognito-api.ts
+++ b/client/cognito-api.ts
@@ -12,7 +12,13 @@
  * ANY KIND, either express or implied. See the License for the specific
  * language governing permissions and limitations under the License.
  */
-import { parseJwtPayload, throwIfNot2xx, bufferToBase64 } from "./util.js";
+import {
+  parseJwtPayload,
+  throwIfNot2xx,
+  bufferToBase64,
+  redactSecret,
+  redactTokensFromObject,
+} from "./util.js";
 import { configure, MinimalResponse } from "./config.js";
 import { retrieveTokens } from "./storage.js";
 import { CognitoSecurityProvider } from "./cognito-security.js";
@@ -278,7 +284,9 @@ export async function initiateAuth<
       authflow === "USER_SRP_AUTH" ||
       authflow === "CUSTOM_AUTH")
   ) {
-    debug?.(`Including device key ${deviceKey} in ${authflow} flow`);
+    debug?.(
+      `Including device key ${redactSecret(deviceKey)} in ${authflow} flow`
+    );
     authParameters.DEVICE_KEY = deviceKey;
   }
 
@@ -530,7 +538,9 @@ export async function getTokensFromRefreshToken({
 
   // Add optional parameters if provided
   if (deviceKey) {
-    debug?.(`Including device key in refresh token request: ${deviceKey}`);
+    debug?.(
+      `Including device key in refresh token request: ${redactSecret(deviceKey)}`
+    );
     requestBody.DeviceKey = deviceKey;
   }
 
@@ -1063,11 +1073,17 @@ export async function handleAuthResponse({
       if (authResponse.AuthenticationResult.NewDeviceMetadata?.DeviceKey) {
         deviceKey =
           authResponse.AuthenticationResult.NewDeviceMetadata.DeviceKey;
-        debug?.("Device key obtained from authentication result:", deviceKey);
+        debug?.(
+          "Device key obtained from authentication result:",
+          redactSecret(deviceKey)
+        );
       } else if (currentDeviceHandler?.deviceKey) {
         // If we're using a device key for authentication, keep track of it
         deviceKey = currentDeviceHandler.deviceKey;
-        debug?.("Using device key from device handler:", deviceKey);
+        debug?.(
+          "Using device key from device handler:",
+          redactSecret(deviceKey)
+        );
       }
 
       return {
@@ -1138,7 +1154,9 @@ export async function handleAuthResponse({
 
       debug?.("Handling DEVICE_PASSWORD_VERIFIER challenge");
       debug?.("DEVICE_PASSWORD_VERIFIER parameters:", {
-        ChallengeParameters: authResponse.ChallengeParameters,
+        ChallengeParameters: redactTokensFromObject(
+          authResponse.ChallengeParameters
+        ),
       });
 
       // Ensure we have a handler (might have been established in previous step)
@@ -1177,7 +1195,10 @@ export async function handleAuthResponse({
       session: authResponse.Session,
       abort,
     });
-    debug?.(`Response from respondToAuthChallenge:`, nextAuthResult);
+    debug?.(
+      `Response from respondToAuthChallenge:`,
+      redactTokensFromObject(nextAuthResult)
+    );
     authResponse = nextAuthResult;
   }
 }
@@ -1724,14 +1745,14 @@ export async function confirmDevice({
   const { fetch, cognitoIdpEndpoint, proxyApiHeaders, debug } = configure();
 
   debug?.("📱 [Confirm Device] Initiating device confirmation API call");
-  debug?.("📱 [Confirm Device] Device key:", deviceKey);
+  debug?.("📱 [Confirm Device] Device key:", redactSecret(deviceKey));
   debug?.("📱 [Confirm Device] Device name:", deviceName || "Not provided");
 
   // Validate device key format before making the API call
   if (!deviceKey.includes("_")) {
     debug?.(
       "❌ [Confirm Device] Invalid device key format (missing underscore):",
-      deviceKey
+      redactSecret(deviceKey)
     );
     throw new Error("Invalid device key format: missing region_uuid format");
   }
@@ -1750,7 +1771,7 @@ export async function confirmDevice({
   ) {
     debug?.(
       "❌ [Confirm Device] Device key contains invalid UUID format:",
-      uuid
+      redactSecret(uuid)
     );
     throw new Error("Invalid device key: UUID part has invalid format");
   }
@@ -1785,7 +1806,7 @@ export async function confirmDevice({
       JSON.stringify({
         hasAccessToken: !!accessToken,
         accessTokenLength: accessToken.length,
-        deviceKey,
+        deviceKey: redactSecret(deviceKey),
         hasDeviceName: !!deviceName,
         verifierLength: deviceSecretVerifierConfig.passwordVerifier.length,
         saltLength: deviceSecretVerifierConfig.salt.length,
@@ -1815,7 +1836,10 @@ export async function confirmDevice({
     assertIsNotErrorResponse(json);
 
     debug?.("✅ [Confirm Device] Device confirmation API call successful");
-    debug?.("📱 [Confirm Device] Response:", JSON.stringify(json));
+    debug?.(
+      "📱 [Confirm Device] Response:",
+      JSON.stringify(redactTokensFromObject(json))
+    );
 
     return json as { UserConfirmationNecessary?: boolean };
   } catch (error) {

--- a/client/common.ts
+++ b/client/common.ts
@@ -29,7 +29,7 @@ import {
   busyState,
 } from "./model.js";
 import { scheduleRefresh, cleanupRefreshSystem } from "./refresh.js";
-import { computeClockDriftMs } from "./util.js";
+import { computeClockDriftMs, redactSecret } from "./util.js";
 import { handleDeviceConfirmation } from "./device.js";
 import { withStorageLock, LockTimeoutError } from "./lock.js";
 import { parseJwtPayload } from "./util.js";
@@ -101,7 +101,7 @@ async function processTokensInternal(
   ) {
     debug?.(
       "🔄 [Process Tokens] Detected new device metadata with device key:",
-      normalizedTokens.newDeviceMetadata.deviceKey
+      redactSecret(normalizedTokens.newDeviceMetadata.deviceKey)
     );
 
     // Complete device confirmation if this is a sign-in (has accessToken)
@@ -146,7 +146,7 @@ async function processTokensInternal(
     const record = await getRememberedDevice(normalizedTokens.username);
     const remembered = record?.remembered ?? false;
     debug?.(
-      `🔄 [Process Tokens] Using existing device key ${normalizedTokens.deviceKey}, remembered: ${remembered}`
+      `🔄 [Process Tokens] Using existing device key ${redactSecret(normalizedTokens.deviceKey)}, remembered: ${remembered}`
     );
   } else {
     debug?.("🔄 [Process Tokens] No device key available in tokens");

--- a/client/config.ts
+++ b/client/config.ts
@@ -242,7 +242,15 @@ export function configure(config?: ConfigInput) {
         "Cognito Hosted UI configured, will use cognitoIdpEndpoint for OAuth domain"
       );
     }
-    config_.debug?.("Configuration loaded:", config);
+    // Note: don't log the client secret (only that one is configured).
+    // (Inlined rather than using util.js redaction helpers, to avoid a
+    // circular import: util.js imports configure from this module.)
+    config_.debug?.("Configuration loaded:", {
+      ...config,
+      ...(config.clientSecret && {
+        clientSecret: `[redacted, ${config.clientSecret.length} chars]`,
+      }),
+    });
   } else {
     if (!config_) {
       throw new Error("Call configure(config) first");

--- a/client/device.ts
+++ b/client/device.ts
@@ -14,7 +14,7 @@
  */
 import { configure } from "./config.js";
 
-import { bufferToBase64 } from "./util.js";
+import { bufferToBase64, redactSecret } from "./util.js";
 import {
   modPow,
   getConstants,
@@ -209,7 +209,7 @@ export async function createDeviceSrpAuthHandler(
         throw new Error("Missing salt for DEVICE_PASSWORD_VERIFIER");
       }
       debug?.(`🔑 [Device SRP] Salt: ${salt}`);
-      debug?.(`🔑 [Device SRP] Secret Block: ${secretBlock}`);
+      debug?.(`🔑 [Device SRP] Secret Block: ${redactSecret(secretBlock)}`);
       const result = await verifyDeviceSrp({
         deviceGroupKey,
         deviceKey,
@@ -256,7 +256,7 @@ export async function handleDeviceConfirmation(
   debug?.(
     "🔍 [Device Confirmation] Device metadata received:",
     JSON.stringify({
-      deviceKey,
+      deviceKey: redactSecret(deviceKey),
       deviceGroupKey,
     })
   );
@@ -265,7 +265,7 @@ export async function handleDeviceConfirmation(
   if (!deviceKey.includes("_")) {
     debug?.(
       "❌ [Device Confirmation] Invalid device key format (missing underscore): " +
-        deviceKey
+        redactSecret(deviceKey)
     );
     // Just return tokens without attempting confirmation
     tokens.deviceKey = deviceKey;
@@ -278,7 +278,7 @@ export async function handleDeviceConfirmation(
     "🔍 [Device Confirmation] Device key components: region=" +
       region +
       ", uuid=" +
-      uuid
+      redactSecret(uuid)
   );
 
   if (!region || !uuid) {
@@ -331,8 +331,8 @@ export async function handleDeviceConfirmation(
     debug?.(
       `🔍 [Device Confirmation] Access token length: ${tokens.accessToken.length}`
     );
-    debug?.(`🔍 [Device Confirmation] Request details: 
-      - deviceKey: ${deviceKey}
+    debug?.(`🔍 [Device Confirmation] Request details:
+      - deviceKey: ${redactSecret(deviceKey)}
       - deviceName: ${finalDeviceName}
       - passwordVerifier length: ${deviceVerifierConfig.passwordVerifier.length}
       - salt length: ${deviceVerifierConfig.salt.length}

--- a/client/fido2.ts
+++ b/client/fido2.ts
@@ -26,6 +26,7 @@ import {
   throwIfNot2xx,
   bufferFromBase64Url,
   bufferToBase64Url,
+  redactTokensFromObject,
 } from "./util.js";
 import { configure } from "./config.js";
 import { retrieveTokens, retrieveDeviceKey } from "./storage.js";
@@ -1236,7 +1237,10 @@ export function authenticateWithFido2({
 
       let tokens;
       if (isAuthenticatedResponse(authResult)) {
-        debug?.(`Response from respondToAuthChallenge (tokens):`, authResult);
+        debug?.(
+          `Response from respondToAuthChallenge (tokens):`,
+          redactTokensFromObject(authResult)
+        );
         tokens = {
           accessToken: authResult.AuthenticationResult.AccessToken,
           idToken: authResult.AuthenticationResult.IdToken,

--- a/client/hosted-oauth.ts
+++ b/client/hosted-oauth.ts
@@ -18,6 +18,8 @@ import {
   parseJwtPayload,
   bufferFromBase64Url,
   bufferToBase64Url,
+  redactSecret,
+  redactTokensFromObject,
 } from "./util.js";
 import { CognitoAccessTokenPayload } from "./jwt-model.js";
 import { withStorageLock, LockTimeoutError } from "./lock.js";
@@ -115,7 +117,15 @@ export async function signInWithRedirect({
     query.code_challenge_method = method;
   }
 
-  debug?.(`Initiating OAuth redirect with params: ${JSON.stringify(query)}`);
+  debug?.(
+    `Initiating OAuth redirect with params: ${JSON.stringify({
+      ...query,
+      state: redactSecret(state),
+      ...(query.code_challenge && {
+        code_challenge: redactSecret(query.code_challenge),
+      }),
+    })}`
+  );
   const qs = new URLSearchParams(query).toString();
 
   const oauthUrl = `${authorizeEndpoint}?${qs}`;
@@ -243,9 +253,7 @@ export async function handleCognitoOAuthCallback(): Promise<TokensFromSignIn | n
   // `-<base64url(customState)>` (see signInWithRedirect). The random part is
   // hex only, so the first "-" (if any) marks the start of the customState
   let customState: string | undefined;
-  const customStateMatch = returnedState?.match(
-    /^[0-9a-f]+-([A-Za-z0-9_-]+)$/
-  );
+  const customStateMatch = returnedState?.match(/^[0-9a-f]+-([A-Za-z0-9_-]+)$/);
   if (customStateMatch) {
     try {
       customState = new TextDecoder().decode(
@@ -276,7 +284,11 @@ export async function handleCognitoOAuthCallback(): Promise<TokensFromSignIn | n
     debug?.("Using implicit flow, extracting tokens from URL hash");
     const hash = url.hash.substring(1);
     const params = new URLSearchParams(hash);
-    debug?.(`Hash parameters: ${JSON.stringify(Object.fromEntries(params))}`);
+    debug?.(
+      `Hash parameters: ${JSON.stringify(
+        redactTokensFromObject(Object.fromEntries(params))
+      )}`
+    );
 
     const access_token = params.get("access_token");
     const id_token = params.get("id_token");

--- a/client/plaintext.ts
+++ b/client/plaintext.ts
@@ -22,6 +22,7 @@ import {
 import { processTokens } from "./common.js";
 import { retrieveDeviceKey } from "./storage.js";
 import { createDeviceSrpAuthHandler } from "./device.js";
+import { redactTokensFromObject } from "./util.js";
 
 export function authenticateWithPlaintextPassword({
   username,
@@ -75,7 +76,10 @@ export function authenticateWithPlaintextPassword({
         clientMetadata,
         abort: abort.signal,
       });
-      debug?.(`Response from initiateAuth:`, authResponse);
+      debug?.(
+        `Response from initiateAuth:`,
+        redactTokensFromObject(authResponse)
+      );
 
       // Now that we have initiated authentication, we can look up device key
       // using the confirmed username for this session

--- a/client/srp.ts
+++ b/client/srp.ts
@@ -22,7 +22,12 @@ import {
   handleAuthResponse,
 } from "./cognito-api.js";
 import { processTokens } from "./common.js";
-import { bufferFromBase64, bufferToBase64 } from "./util.js";
+import {
+  bufferFromBase64,
+  bufferToBase64,
+  redactSecret,
+  redactTokensFromObject,
+} from "./util.js";
 import { retrieveDeviceKey } from "./storage.js";
 import { createDeviceSrpAuthHandler } from "./device.js";
 
@@ -350,7 +355,7 @@ export function authenticateWithSRP({
         clientMetadata,
         abort: abort.signal,
       });
-      debug?.(`Response from initiateAuth:`, challenge);
+      debug?.(`Response from initiateAuth:`, redactTokensFromObject(challenge));
       assertIsChallengeResponse(challenge);
       const {
         SALT: saltHex,
@@ -401,7 +406,9 @@ export function authenticateWithSRP({
       // Include the device key if it's available, regardless of remembered status
       // AWS documentation indicates the device key should be provided if available
       if (actualDeviceKey) {
-        debug?.(`Including device key in authentication: ${actualDeviceKey}`);
+        debug?.(
+          `Including device key in authentication: ${redactSecret(actualDeviceKey)}`
+        );
         challengeResponses.DEVICE_KEY = actualDeviceKey;
       }
 
@@ -412,7 +419,10 @@ export function authenticateWithSRP({
         session: challenge.Session,
         abort: abort.signal,
       });
-      debug?.(`Response from respondToAuthChallenge:`, authResult);
+      debug?.(
+        `Response from respondToAuthChallenge:`,
+        redactTokensFromObject(authResult)
+      );
 
       // Handle any authentication challenges
       // Pass userIdForSrp instead of original username to fix device confirmation

--- a/client/storage.ts
+++ b/client/storage.ts
@@ -12,7 +12,11 @@
  * ANY KIND, either express or implied. See the License for the specific
  * language governing permissions and limitations under the License.
  */
-import { parseJwtPayload } from "./util.js";
+import {
+  parseJwtPayload,
+  redactSecret,
+  redactTokensFromObject,
+} from "./util.js";
 import { configure } from "./config.js";
 import {
   CognitoIdTokenPayload,
@@ -116,7 +120,7 @@ export async function retrieveClockDriftMs(username: string): Promise<number> {
 
 export async function storeTokens(tokens: TokensToStore) {
   const { clientId, storage, debug } = configure();
-  debug?.("[storeTokens] tokens to store:", tokens);
+  debug?.("[storeTokens] tokens to store:", redactTokensFromObject(tokens));
 
   // --------- 1. Derive username ---------
   let username = tokens.username;
@@ -406,7 +410,9 @@ export async function setRememberedDevice(
 ) {
   const { clientId, storage, debug } = configure();
   const key = buildDeviceStorageKey(clientId, username);
-  debug?.(`Saving remembered device for user ${username}: ${record.deviceKey}`);
+  debug?.(
+    `Saving remembered device for user ${username}: ${redactSecret(record.deviceKey)}`
+  );
   await storage.setItem(key, JSON.stringify(record));
 }
 
@@ -449,7 +455,7 @@ export async function clearRememberedDevice(username: string) {
 export async function storeDeviceKey(username: string, deviceKey: string) {
   if (!username || !deviceKey) return;
   const { debug } = configure();
-  debug?.(`Storing device key for ${username}: ${deviceKey}`);
+  debug?.(`Storing device key for ${username}: ${redactSecret(deviceKey)}`);
 
   // Check if we already have a record for this user
   const existingRecord = await getRememberedDevice(username);

--- a/client/util.ts
+++ b/client/util.ts
@@ -78,6 +78,64 @@ export function computeClockDriftMs(accessToken?: string): number {
 }
 
 /**
+ * Redact a secret value for debug logging: keep a short prefix (so logs stay
+ * diagnostically useful) plus the length, but never emit the full value.
+ */
+export function redactSecret(value: string, visibleChars = 5): string {
+  if (value.length <= visibleChars) {
+    return `[redacted, ${value.length} chars]`;
+  }
+  return `${value.slice(0, visibleChars)}…[redacted, ${value.length} chars]`;
+}
+
+/**
+ * Keys whose string values must never appear in debug output. Keys are
+ * compared case-insensitively with underscores stripped, so e.g.
+ * AccessToken, accessToken and access_token all match.
+ */
+const SENSITIVE_DEBUG_KEYS = new Set([
+  "accesstoken",
+  "idtoken",
+  "refreshtoken",
+  "secretblock",
+  "passwordclaimsecretblock",
+  "devicekey",
+  "password",
+  "clientsecret",
+]);
+
+/**
+ * Return a copy of the given value in which the string values of known
+ * sensitive keys (tokens, SRP secret blocks, device keys, ...) are redacted
+ * via redactSecret. Plain objects and arrays are copied recursively (up to
+ * a maximum depth); all other values pass through unchanged.
+ */
+export function redactTokensFromObject(value: unknown, depth = 5): unknown {
+  if (depth <= 0 || typeof value !== "object" || value === null) {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => redactTokensFromObject(item, depth - 1));
+  }
+  const proto: unknown = Object.getPrototypeOf(value);
+  if (proto !== Object.prototype && proto !== null) {
+    // Leave class instances (Date, Error, ...) alone
+    return value;
+  }
+  return Object.fromEntries(
+    Object.entries(value).map(([key, val]) => {
+      if (
+        typeof val === "string" &&
+        SENSITIVE_DEBUG_KEYS.has(key.toLowerCase().replace(/_/g, ""))
+      ) {
+        return [key, redactSecret(val)];
+      }
+      return [key, redactTokensFromObject(val, depth - 1)];
+    })
+  );
+}
+
+/**
  * Schedule a callback once, like setTimeout, but count
  * time spent sleeping also as time spent. This way, if the browser tab
  * where this is happening is activated again after sleeping,

--- a/test/redact.test.ts
+++ b/test/redact.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Tests for the debug-log redaction helpers: token material (access/ID/refresh
+ * tokens, SRP secret blocks, device keys, client secrets) must never appear in
+ * full in debug output, while logs stay diagnostically useful (short prefix +
+ * length are preserved).
+ */
+// jsdom doesn't define TextDecoder/TextEncoder, which parseJwtPayload (used
+// internally by storeTokens) relies on. Provide Node's.
+import { TextEncoder, TextDecoder } from "util";
+Object.assign(globalThis, {
+  TextEncoder: globalThis.TextEncoder ?? TextEncoder,
+  TextDecoder: globalThis.TextDecoder ?? TextDecoder,
+});
+
+import { redactSecret, redactTokensFromObject } from "../client/util.js";
+import { configure } from "../client/config.js";
+import { storeTokens } from "../client/storage.js";
+import { handleAuthResponse } from "../client/cognito-api.js";
+
+// Minimal unsigned JWT builder (matches the helper used in the other tests)
+const createJWT = (claims: Record<string, unknown>) => {
+  const enc = (obj: unknown) =>
+    btoa(JSON.stringify(obj))
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+  return `${enc({ alg: "HS256", typ: "JWT" })}.${enc(claims)}.signature`;
+};
+
+describe("redactSecret", () => {
+  test("keeps a short prefix and the length, never the full value", () => {
+    expect(redactSecret("abcdefghij")).toBe("abcde…[redacted, 10 chars]");
+  });
+
+  test("supports a custom number of visible chars", () => {
+    expect(redactSecret("abcdefghij", 2)).toBe("ab…[redacted, 10 chars]");
+  });
+
+  test("emits no prefix at all for values shorter than the visible prefix", () => {
+    expect(redactSecret("abc")).toBe("[redacted, 3 chars]");
+    expect(redactSecret("")).toBe("[redacted, 0 chars]");
+  });
+});
+
+describe("redactTokensFromObject", () => {
+  test("redacts tokens nested in a Cognito AuthenticationResult", () => {
+    const accessToken = "eyAccessToken.AAAA.BBBB";
+    const refreshToken = "eyRefreshToken-CCCC-DDDD";
+    const response = {
+      AuthenticationResult: {
+        AccessToken: accessToken,
+        IdToken: "eyIdToken.EEEE.FFFF",
+        RefreshToken: refreshToken,
+        ExpiresIn: 3600,
+        TokenType: "Bearer",
+        NewDeviceMetadata: {
+          DeviceKey: "us-west-2_11111111-2222-3333-4444-555555555555",
+          DeviceGroupKey: "-group",
+        },
+      },
+    };
+    const redacted = redactTokensFromObject(response);
+    const serialized = JSON.stringify(redacted);
+    expect(serialized).not.toContain(accessToken);
+    expect(serialized).not.toContain(refreshToken);
+    expect(serialized).not.toContain("eyIdToken.EEEE.FFFF");
+    expect(serialized).not.toContain(
+      "us-west-2_11111111-2222-3333-4444-555555555555"
+    );
+    // Non-sensitive diagnostics are preserved
+    const result = (
+      redacted as { AuthenticationResult: Record<string, unknown> }
+    ).AuthenticationResult;
+    expect(result.ExpiresIn).toBe(3600);
+    expect(result.TokenType).toBe("Bearer");
+    expect(result.AccessToken).toBe(
+      `eyAcc…[redacted, ${accessToken.length} chars]`
+    );
+  });
+
+  test("redacts the SRP SECRET_BLOCK in challenge parameters but keeps public values", () => {
+    const challenge = {
+      ChallengeName: "PASSWORD_VERIFIER",
+      ChallengeParameters: {
+        SECRET_BLOCK: "c2VjcmV0LWJsb2NrLWNvbnRlbnQ=",
+        SRP_B: "abcdef123456",
+        SALT: "deadbeef",
+        USER_ID_FOR_SRP: "user-1",
+      },
+    };
+    const redacted = redactTokensFromObject(challenge) as typeof challenge;
+    expect(JSON.stringify(redacted)).not.toContain(
+      "c2VjcmV0LWJsb2NrLWNvbnRlbnQ="
+    );
+    expect(redacted.ChallengeParameters.SRP_B).toBe("abcdef123456");
+    expect(redacted.ChallengeParameters.SALT).toBe("deadbeef");
+    expect(redacted.ChallengeParameters.USER_ID_FOR_SRP).toBe("user-1");
+  });
+
+  test("matches sensitive keys case-insensitively and with underscores (OAuth style)", () => {
+    const hashParams = {
+      access_token: "oauth-access-token-value",
+      id_token: "oauth-id-token-value",
+      refresh_token: "oauth-refresh-token-value",
+      expires_in: "3600",
+      token_type: "Bearer",
+    };
+    const redacted = redactTokensFromObject(hashParams) as typeof hashParams;
+    expect(JSON.stringify(redacted)).not.toContain("oauth-access-token-value");
+    expect(JSON.stringify(redacted)).not.toContain("oauth-refresh-token-value");
+    expect(redacted.expires_in).toBe("3600");
+    expect(redacted.token_type).toBe("Bearer");
+  });
+
+  test("passes non-object and non-string values through unchanged", () => {
+    expect(redactTokensFromObject("just a string")).toBe("just a string");
+    expect(redactTokensFromObject(42)).toBe(42);
+    expect(redactTokensFromObject(null)).toBeNull();
+    expect(redactTokensFromObject(undefined)).toBeUndefined();
+    // A sensitive key with a non-string value is left as-is
+    const redacted = redactTokensFromObject({ AccessToken: 42 }) as {
+      AccessToken: number;
+    };
+    expect(redacted.AccessToken).toBe(42);
+  });
+
+  test("leaves class instances alone and does not mutate the input", () => {
+    const expireAt = new Date();
+    const tokens = {
+      accessToken: "the-access-token-value",
+      refreshToken: "the-refresh-token-value",
+      expireAt,
+      username: "testuser",
+    };
+    const redacted = redactTokensFromObject(tokens) as typeof tokens;
+    expect(redacted.expireAt).toBe(expireAt);
+    expect(redacted.username).toBe("testuser");
+    expect(redacted.accessToken).not.toBe("the-access-token-value");
+    // Original untouched
+    expect(tokens.accessToken).toBe("the-access-token-value");
+    expect(tokens.refreshToken).toBe("the-refresh-token-value");
+  });
+});
+
+describe("debug call sites do not leak token material", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  test("storeTokens debug output never contains the full tokens", async () => {
+    const debug = jest.fn();
+    configure({
+      clientId: "testClient",
+      cognitoIdpEndpoint: "us-west-2",
+      fetch: jest.fn(),
+      debug,
+    });
+
+    const accessToken = createJWT({
+      sub: "sub-1",
+      username: "testuser",
+      iat: Math.floor(Date.now() / 1000),
+      exp: Math.floor(Date.now() / 1000) + 3600,
+    });
+    const refreshToken =
+      "eyJjdHkiOiJKV1QiLCJlbmMiOiJBMjU2R0NNIn0.this-is-a-very-secret-refresh-token";
+    const deviceKey = "us-west-2_11111111-2222-3333-4444-555555555555";
+
+    await storeTokens({
+      accessToken,
+      refreshToken,
+      deviceKey,
+      username: "testuser",
+      expireAt: new Date(Date.now() + 3600_000),
+    });
+
+    expect(debug).toHaveBeenCalled();
+    const allDebugOutput = JSON.stringify(debug.mock.calls);
+    expect(allDebugOutput).not.toContain(accessToken);
+    expect(allDebugOutput).not.toContain(refreshToken);
+    expect(allDebugOutput).not.toContain(deviceKey);
+  });
+
+  test("DEVICE_PASSWORD_VERIFIER challenge parameters are redacted in debug output", async () => {
+    const debug = jest.fn();
+    const secretBlock = "ZGV2aWNlLXNycC1zZWNyZXQtYmxvY2stY29udGVudA==";
+    const deviceKey = "us-west-2_66666666-7777-8888-9999-000000000000";
+    const accessToken = "eyAccessToken.GGGG.HHHH";
+    const refreshToken = "eyRefreshToken-KKKK-LLLL";
+    // Pretend the Cognito advanced security script is already loaded, so
+    // respondToAuthChallenge doesn't try to inject a <script> in jsdom
+    (
+      window as { AmazonCognitoAdvancedSecurityData?: unknown }
+    ).AmazonCognitoAdvancedSecurityData = { getData: () => undefined };
+    configure({
+      clientId: "testClient",
+      cognitoIdpEndpoint: "us-west-2",
+      fetch: jest.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            AuthenticationResult: {
+              AccessToken: accessToken,
+              IdToken: "eyIdToken.MMMM.NNNN",
+              RefreshToken: refreshToken,
+              ExpiresIn: 3600,
+              TokenType: "Bearer",
+            },
+            ChallengeParameters: {},
+          }),
+      }),
+      debug,
+    });
+
+    const result = await handleAuthResponse({
+      authResponse: {
+        ChallengeName: "DEVICE_PASSWORD_VERIFIER",
+        ChallengeParameters: {
+          SRP_B: "abcdef123456",
+          SECRET_BLOCK: secretBlock,
+          DEVICE_KEY: deviceKey,
+          SALT: "deadbeef",
+          USERNAME: "testuser",
+        },
+        Session: "session-1",
+      },
+      username: "testuser",
+      deviceHandler: {
+        deviceKey,
+        generateStep1: () => Promise.resolve({ srpAHex: "aa" }),
+        generateStep2: () =>
+          Promise.resolve({
+            passwordVerifier: "password-claim-signature",
+            passwordClaimSecretBlock: secretBlock,
+            timestamp: "Mon Jun 9 00:00:00 UTC 2026",
+          }),
+      },
+    });
+
+    // The flow itself still works on the unredacted values
+    expect(result.accessToken).toBe(accessToken);
+
+    expect(debug).toHaveBeenCalledWith(
+      "DEVICE_PASSWORD_VERIFIER parameters:",
+      expect.anything()
+    );
+    const allDebugOutput = JSON.stringify(debug.mock.calls);
+    expect(allDebugOutput).not.toContain(secretBlock);
+    expect(allDebugOutput).not.toContain(deviceKey);
+    expect(allDebugOutput).not.toContain(accessToken);
+    expect(allDebugOutput).not.toContain(refreshToken);
+    // Public SRP values stay visible for diagnostics
+    expect(allDebugOutput).toContain("abcdef123456");
+  });
+});


### PR DESCRIPTION
## Summary
Debug logging (the user-configurable `debug` callback) previously emitted full secret material. Applications routinely wire `debug` to `console.log` or a remote logger, which ships refresh tokens, SRP secret blocks, and device keys into log pipelines. This PR adds redaction helpers and applies them at every debug call site that logged token material, so logs stay diagnostically useful (short prefix + length) but never contain full secrets.

## Finding
- Severity: LOW. Confidence: certain (verified at HEAD).
- Concrete failure scenario: an app sets `configure({ debug: console.log })` (or forwards debug to Datadog/Sentry/CloudWatch). On any SRP or FIDO2 sign-in, the full Cognito auth response — including `AccessToken`, `IdToken`, and the long-lived `RefreshToken` — lands verbatim in the log pipeline; anyone with log access can hijack the session.
- Verified call sites that leaked secrets:
  - `client/device.ts:206` — full SRP `SECRET_BLOCK`; `client/device.ts:250-256, 328-334` — device keys
  - `client/srp.ts:353, 415` — full `initiateAuth`/`respondToAuthChallenge` responses (access/ID/refresh tokens, secret block); `client/srp.ts:404` — device key
  - `client/cognito-api.ts:251, 503, 1036, 1040, 1697, 1758` — device keys; `client/cognito-api.ts:1150` — full auth response
  - `client/hosted-oauth.ts:255` — complete implicit-flow fragment params (`access_token`, `id_token`, `refresh_token`); `client/hosted-oauth.ts:112` — full outgoing authorize query (`state` + PKCE challenge), inconsistent with the existing truncation policy (code truncated to 5 chars at line 240, state to 10 at lines 208/216)
  - Additional sites found by grepping debug calls for token material: `client/fido2.ts:1234`, `client/plaintext.ts:78` (full auth responses), `client/storage.ts:119` (full token set), `client/storage.ts:409, 452`, `client/common.ts:102, 148` (device keys), `client/config.ts:241` (full config incl. `clientSecret`)
- Note: `client/cognito-api.ts:516-518` (flagged in the finding) already logs only the client-secret length, not the value, so it was left unchanged.

## Fix
- New helpers in `client/util.ts`:
  - `redactSecret(value, visibleChars = 5)` → `"abcde…[redacted, N chars]"` (no prefix at all when the value is shorter than the visible window)
  - `redactTokensFromObject(obj)` → recursive copy (depth-limited, plain objects/arrays only) that redacts string values of sensitive keys, matched case-insensitively ignoring underscores: access/ID/refresh tokens, `SECRET_BLOCK`/`PASSWORD_CLAIM_SECRET_BLOCK`, device keys, `password`, `clientSecret`. Non-sensitive values (lengths, flow names, `ExpiresIn`, salts, `SRP_B`) pass through so logs remain useful.
- Applied at all call sites listed above. `config.ts` redacts `clientSecret` inline (importing util.js there would create a module cycle that breaks under the Jest util mock).

## Test plan
- New `test/redact.test.ts`: `redactSecret` truncation/short-value/custom-prefix behavior; `redactTokensFromObject` on Cognito `AuthenticationResult`, SRP challenge params, and OAuth snake_case hash params; non-object/non-string passthrough; class instances (Date) preserved; input not mutated; call-site test spying on the `debug` fn through `storeTokens`, asserting no full access/refresh token or device key appears in any debug output.
- Gates: `npx tsc --project client/tsconfig.json --noEmit` clean; `npx eslint` clean on all changed files; `npx prettier --check` clean; `npx jest` → 24 suites passed, 2 skipped (pre-existing skips), 191 tests passed including 9 new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only change; runtime auth and storage behavior are unchanged aside from what the debug callback receives.
> 
> **Overview**
> Adds **`redactSecret`** and **`redactTokensFromObject`** in `util.ts` so the configurable `debug` callback no longer prints full Cognito tokens, SRP secret blocks, device keys, passwords, or client secrets—only a short prefix plus length where useful.
> 
> Those helpers are wired through auth-related modules (`cognito-api`, `srp`, `plaintext`, `fido2`, `device`, `storage`, `common`, `hosted-oauth`). Full auth/OAuth responses and hash params are logged via deep redaction; standalone secrets use `redactSecret`. **`configure()`** redacts `clientSecret` inline to avoid a `config` ↔ `util` import cycle.
> 
> New **`test/redact.test.ts`** covers helper behavior and asserts `storeTokens` / `handleAuthResponse` debug output never contains full token or device-key material.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9830e9f0f9876df7bf37756a922f76eb5a6a0aab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->