### PR TITLE
Fix abort-listener leak in retry backoff wait

### DIFF
--- a/client/__tests__/retry.test.ts
+++ b/client/__tests__/retry.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Copyright Amazon.com, Inc. and its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You
+ * may not use this file except in compliance with the License. A copy of
+ * the License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+import { createFetchWithRetry } from "../retry.js";
+import type { MinimalResponse } from "../config.js";
+
+describe("createFetchWithRetry", () => {
+  const okResponse: MinimalResponse = {
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve({}),
+  };
+
+  test("removes abort listener when backoff wait completes normally", async () => {
+    const controller = new AbortController();
+    const addSpy = jest.spyOn(controller.signal, "addEventListener");
+    const removeSpy = jest.spyOn(controller.signal, "removeEventListener");
+
+    // Fail twice with a network error, then succeed: two backoff waits
+    let calls = 0;
+    const fetchFn = jest.fn().mockImplementation(() => {
+      calls++;
+      if (calls <= 2) {
+        return Promise.reject(new Error("NetworkError"));
+      }
+      return Promise.resolve(okResponse);
+    });
+
+    const fetchWithRetry = createFetchWithRetry(fetchFn, undefined, 3, 1);
+    const res = await fetchWithRetry("https://example.com", {
+      signal: controller.signal,
+    });
+
+    expect(res).toBe(okResponse);
+    expect(fetchFn).toHaveBeenCalledTimes(3);
+
+    // Every "abort" listener added during a backoff wait must be removed
+    // again once the timer fires, so a long-lived signal doesn't
+    // accumulate dead listeners across retries.
+    const abortAdds = addSpy.mock.calls.filter(([type]) => type === "abort");
+    const abortRemoves = removeSpy.mock.calls.filter(
+      ([type]) => type === "abort"
+    );
+    expect(abortAdds.length).toBe(2);
+    expect(abortRemoves.length).toBe(abortAdds.length);
+  });
+
+  test("abort during backoff wait still rejects with AbortError", async () => {
+    const controller = new AbortController();
+
+    const fetchFn = jest
+      .fn()
+      .mockImplementation(() => Promise.reject(new Error("NetworkError")));
+
+    // Long backoff so we can abort mid-wait
+    const fetchWithRetry = createFetchWithRetry(fetchFn, undefined, 3, 60000);
+    const pending = fetchWithRetry("https://example.com", {
+      signal: controller.signal,
+    });
+    const assertion = expect(pending).rejects.toThrow("Aborted");
+
+    // Let the first attempt fail and the backoff wait start, then abort
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    controller.abort();
+
+    await assertion;
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/client/retry.ts
+++ b/client/retry.ts
@@ -46,19 +46,20 @@ export function createFetchWithRetry(
   ): Promise<MinimalResponse> => {
     // Helper to wait with abort support
     const wait = (ms: number): Promise<void> => {
-      if (init?.signal?.aborted) {
+      const signal = init?.signal;
+      if (signal?.aborted) {
         return Promise.reject(new DOMException("Aborted", "AbortError"));
       }
       return new Promise((resolve, reject) => {
-        const id = setTimeout(resolve, ms);
-        init?.signal?.addEventListener(
-          "abort",
-          () => {
-            clearTimeout(id);
-            reject(new DOMException("Aborted", "AbortError"));
-          },
-          { once: true }
-        );
+        const onAbort = () => {
+          clearTimeout(id);
+          reject(new DOMException("Aborted", "AbortError"));
+        };
+        const id = setTimeout(() => {
+          signal?.removeEventListener("abort", onAbort);
+          resolve();
+        }, ms);
+        signal?.addEventListener("abort", onAbort, { once: true });
       });
     };
 


### PR DESCRIPTION
## Summary
Fixes a leak in `createFetchWithRetry`'s backoff `wait` helper: the "abort" listener added to the caller's `AbortSignal` was never removed when the backoff timer fired normally.

## Finding
- Severity: LOW, confidence: certain
- Location: `client/retry.ts:52-62` (pre-fix)
- Each backoff sleep called `signal.addEventListener("abort", ..., { once: true })`. `{ once: true }` only removes the listener if the abort event actually fires, so when the timeout resolved normally the listener stayed registered forever.
- Concrete failure scenario: an application reuses one long-lived `AbortSignal` (e.g. a page-lifetime controller) across many requests; every retried request leaves one dead listener per backoff sleep on the signal. Over time this is a slow memory leak, and in Node-based test environments it produces `MaxListenersExceededWarning` noise once more than 10 listeners accumulate.

## Fix
Restructured `wait` so the abort handler is a named reference shared by both completion paths:
- timer fires normally → `removeEventListener("abort", onAbort)` then resolve;
- signal aborts → `clearTimeout(timer)` then reject with `AbortError` (unchanged behavior, the timer was already cleared on abort before this change).

Behavior is otherwise identical; only the cleanup symmetry changed.

## Test plan
- New `client/__tests__/retry.test.ts`:
  - spies on `addEventListener`/`removeEventListener` of an `AbortController` signal, runs two backoff waits to completion, asserts add/remove call counts for "abort" balance (2 adds, 2 removes);
  - aborts mid-backoff and asserts the in-flight call rejects with `AbortError` after a single fetch attempt.
- `npx tsc --project client/tsconfig.json --noEmit` — clean
- `npx eslint client/retry.ts client/__tests__/retry.test.ts` — clean
- `npx jest` — 24 suites passed, 184 tests passed (2 suites / 19 tests skipped, same as baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to retry delay cleanup with tests; abort-on-wait behavior is preserved.
> 
> **Overview**
> Fixes a **memory/listener leak** in `createFetchWithRetry`'s backoff `wait` helper: when exponential backoff finished without an abort, the temporary `"abort"` listener on the caller's `AbortSignal` was never removed (`{ once: true }` only cleans up if abort fires).
> 
> The `wait` implementation now uses a named `onAbort` handler and **explicitly `removeEventListener` when the timer resolves**, while still clearing the timer and rejecting with `AbortError` on abort.
> 
> Adds **`client/__tests__/retry.test.ts`** to assert balanced add/remove for completed backoffs and that aborting mid-backoff still rejects after a single fetch attempt.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 635bac6f0a22ae986242a86731436fcc3e3364de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->