### PR TITLE
Report aborted FIDO2 sign-in as SIGNED_OUT, not FIDO2_SIGNIN_FAILED

### DIFF
--- a/client/__tests__/fido2-core.test.ts
+++ b/client/__tests__/fido2-core.test.ts
@@ -19,7 +19,11 @@ import {
   authenticateWithFido2,
 } from "../fido2.js";
 import { configure } from "../config.js";
-import { Fido2CredentialError, Fido2ValidationError } from "../errors.js";
+import {
+  Fido2AbortError,
+  Fido2CredentialError,
+  Fido2ValidationError,
+} from "../errors.js";
 import {
   MOCK_ASSERTION_CREDENTIAL,
   EXPECTED_TRANSFORMED_CREDENTIAL,
@@ -33,7 +37,7 @@ import {
   createWebAuthnError,
   assertTransformedCredentialMatches,
 } from "./__utils__/webauthn-mocks.js";
-import { initiateAuth } from "../cognito-api.js";
+import { initiateAuth, respondToAuthChallenge } from "../cognito-api.js";
 import { retrieveDeviceKey } from "../storage.js";
 import { bufferToBase64Url } from "../util.js";
 import { TextDecoder as NodeTextDecoder } from "util";
@@ -55,6 +59,9 @@ const mockInitiateAuth = initiateAuth as jest.MockedFunction<
 >;
 const mockRetrieveDeviceKey = retrieveDeviceKey as jest.MockedFunction<
   typeof retrieveDeviceKey
+>;
+const mockRespondToAuthChallenge = respondToAuthChallenge as jest.MockedFunction<
+  typeof respondToAuthChallenge
 >;
 
 describe("FIDO2 Core Functionality", () => {
@@ -565,6 +572,74 @@ describe("FIDO2 Core Functionality", () => {
       await expect(result.signedIn).rejects.toThrow(
         /Prepared credentials belong to username/
       );
+    });
+  });
+
+  describe("authenticateWithFido2 status on cancellation", () => {
+    const prepared = {
+      username: "bundle-user",
+      session: "mock-session",
+      credential: {
+        credentialIdB64: "cred-id",
+        authenticatorDataB64: "auth-data",
+        clientDataJSON_B64: "client-data",
+        signatureB64: "sig",
+        userHandleB64: null,
+      },
+    };
+
+    it("does not report FIDO2_SIGNIN_FAILED when the caller aborts a pending sign-in", async () => {
+      mockRespondToAuthChallenge.mockImplementationOnce(
+        ({ abort: signal }) =>
+          new Promise((_resolve, reject) => {
+            signal?.addEventListener("abort", () =>
+              reject(
+                new DOMException("The operation was aborted.", "AbortError")
+              )
+            );
+          })
+      );
+
+      const statusCb = jest.fn();
+      const { signedIn, abort } = authenticateWithFido2({
+        prepared,
+        statusCb,
+      });
+      // Let the flow reach respondToAuthChallenge before cancelling
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      abort();
+
+      await expect(signedIn).rejects.toThrow("aborted");
+      const statuses = statusCb.mock.calls.map(([status]) => status);
+      expect(statuses).not.toContain("FIDO2_SIGNIN_FAILED");
+      expect(statuses[statuses.length - 1]).toBe("SIGNED_OUT");
+    });
+
+    it("does not report FIDO2_SIGNIN_FAILED when WebAuthn is cancelled (Fido2AbortError)", async () => {
+      mockRespondToAuthChallenge.mockRejectedValueOnce(new Fido2AbortError());
+
+      const statusCb = jest.fn();
+      const { signedIn } = authenticateWithFido2({ prepared, statusCb });
+
+      await expect(signedIn).rejects.toThrow(Fido2AbortError);
+      const statuses = statusCb.mock.calls.map(([status]) => status);
+      expect(statuses).not.toContain("FIDO2_SIGNIN_FAILED");
+      expect(statuses[statuses.length - 1]).toBe("SIGNED_OUT");
+    });
+
+    it("still reports FIDO2_SIGNIN_FAILED for genuine failures", async () => {
+      mockRespondToAuthChallenge.mockRejectedValueOnce(
+        new Error("Incorrect username or password.")
+      );
+
+      const statusCb = jest.fn();
+      const { signedIn } = authenticateWithFido2({ prepared, statusCb });
+
+      await expect(signedIn).rejects.toThrow(
+        "Incorrect username or password."
+      );
+      const statuses = statusCb.mock.calls.map(([status]) => status);
+      expect(statuses[statuses.length - 1]).toBe("FIDO2_SIGNIN_FAILED");
     });
   });
 });

--- a/client/fido2.ts
+++ b/client/fido2.ts
@@ -37,6 +37,7 @@ import {
   Fido2ValidationError,
   Fido2AuthError,
   fromDOMException,
+  isFido2AbortError,
 } from "./errors.js";
 
 // Enhanced type definitions for mediation support
@@ -1292,7 +1293,16 @@ export function authenticateWithFido2({
       statusCb?.("SIGNED_IN_WITH_FIDO2");
       return processedTokens;
     } catch (err) {
-      statusCb?.("FIDO2_SIGNIN_FAILED");
+      if (
+        isFido2AbortError(err) ||
+        (err instanceof Error && err.name === "AbortError")
+      ) {
+        // Deliberate cancellation (e.g. the caller invoked abort()) is not a
+        // sign-in failure: revert to the idle state the flow started from
+        statusCb?.("SIGNED_OUT");
+      } else {
+        statusCb?.("FIDO2_SIGNIN_FAILED");
+      }
       throw err;
     }
   })();


### PR DESCRIPTION
## Summary
Deliberate cancellation of a pending FIDO2 sign-in (via the `abort()` returned by `authenticateWithFido2`, or a cancelled WebAuthn ceremony) was reported through `statusCb` as `FIDO2_SIGNIN_FAILED`, so routine cancellations rendered as failed sign-ins in UIs driven by the React hook.

## Finding
- Severity: LOW, confidence: certain
- `client/fido2.ts:1294-1296` (pre-fix): the catch-all in `authenticateWithFido2` emitted `statusCb("FIDO2_SIGNIN_FAILED")` for every error, including `Fido2AbortError` and unwrapped `DOMException` `AbortError`s that escape the Cognito fetch calls (`respondToAuthChallenge` / `handleAuthResponse` / `processTokens` pass the signal straight to `fetch`, which rejects with an unwrapped `AbortError`).
- `client/react/hooks.tsx:1493` feeds `statusCb` directly into `signingInStatus` UI state.
- Concrete failure scenario: an app starts a conditional/autofill FIDO2 request, then cancels it because the user chose another sign-in method or the component unmounted — the standard pattern. The UI then shows a failed passkey sign-in even though nothing failed.
- The library defines `Fido2AbortError` / `isFido2AbortError` (`client/errors.ts`) for exactly this distinction but never consulted it on its own status path.

## Fix
In the catch path of `authenticateWithFido2`, detect abort errors with `isFido2AbortError(err) || (err instanceof Error && err.name === "AbortError")` (the latter covers unwrapped `DOMException` aborts from fetch) and emit `SIGNED_OUT` — the idle state the flow started from and the hook's initial/reset status — instead of `FIDO2_SIGNIN_FAILED`. The error is still rethrown, so promise rejection behavior for callers is unchanged. No new status value added; no exported union widened.

## Test plan
- New tests in `client/__tests__/fido2-core.test.ts`:
  - `abort()` during a pending sign-in (fetch-style `DOMException` `AbortError`) → status sequence does NOT contain `FIDO2_SIGNIN_FAILED`, ends in `SIGNED_OUT`, promise still rejects.
  - `Fido2AbortError` rejection → same non-failure behavior.
  - Genuine failure (regular `Error`) → still ends in `FIDO2_SIGNIN_FAILED`.
- Gates: `npx tsc --project client/tsconfig.json --noEmit` clean; `npx eslint client/fido2.ts client/__tests__/fido2-core.test.ts` clean; `npx jest client/__tests__` → 129 passed, 10 suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow status-callback behavior change for abort paths only; promise rejection semantics unchanged and covered by new unit tests.
> 
> **Overview**
> **`authenticateWithFido2`** no longer reports deliberate cancellation as a failed sign-in. When the flow is aborted via **`abort()`**, **`Fido2AbortError`**, or an **`AbortError`** from fetch, **`statusCb`** now emits **`SIGNED_OUT`** instead of **`FIDO2_SIGNIN_FAILED`**; real errors still end in **`FIDO2_SIGNIN_FAILED`**, and promises still reject on abort.
> 
> Tests cover abort during **`respondToAuthChallenge`**, **`Fido2AbortError`**, and a genuine Cognito-style failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51a1bac6fbde489fadd3b8d9d55d01c5fdb6935f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->