### PR TITLE
Remove leftover per-user storage keys on sign-out

### DIFF
--- a/client/common.ts
+++ b/client/common.ts
@@ -439,6 +439,15 @@ export const signOut = (props?: {
           storage.removeItem(`${amplifyKeyPrefix}.${username}.userData`),
           storage.removeItem(`${amplifyKeyPrefix}.LastAuthUser`),
           storage.removeItem(`${amplifyKeyPrefix}.${username}.clockDriftMs`),
+          storage.removeItem(`${customKeyPrefix}.${username}.authMethod`),
+          storage.removeItem(
+            `${customKeyPrefix}.${username}.lastRefreshAttempt`
+          ),
+          storage.removeItem(
+            `${customKeyPrefix}.${username}.lastRefreshCompleted`
+          ),
+          // Legacy keys no longer written by current versions, removed for
+          // migration hygiene
           storage.removeItem(`${customKeyPrefix}.${username}.expireAt`),
           storage.removeItem(`${customKeyPrefix}.${username}.refreshingTokens`),
           // Note: We do NOT remove deviceKey - it should persist between sessions

--- a/test/signOut.test.ts
+++ b/test/signOut.test.ts
@@ -71,6 +71,71 @@ describe("SignOut Lock", () => {
     // signOut should eventually complete when lock is released
     await expect(signedOut).resolves.toBeUndefined();
   }, 20000); // Increase timeout for lock wait
+
+  test("should remove all per-user Passwordless keys from storage", async () => {
+    // Use an enumerable in-memory storage so we can assert on leftover keys
+    const backing = new Map<string, string>();
+    configure({
+      clientId: "testClient",
+      cognitoIdpEndpoint: "us-west-2",
+      storage: {
+        getItem: (key: string) => backing.get(key) ?? null,
+        setItem: (key: string, value: string) => {
+          backing.set(key, value);
+        },
+        removeItem: (key: string) => {
+          backing.delete(key);
+        },
+      },
+    });
+    const { storage } = configure();
+
+    // Populate everything the library writes for a signed-in user
+    const amplifyKeyPrefix = `CognitoIdentityServiceProvider.testClient`;
+    const customKeyPrefix = `Passwordless.testClient`;
+    await storage.setItem(`${amplifyKeyPrefix}.LastAuthUser`, "testuser");
+    await storage.setItem(
+      `${amplifyKeyPrefix}.testuser.accessToken`,
+      createValidJWT()
+    );
+    await storage.setItem(`${amplifyKeyPrefix}.testuser.idToken`, "id-token");
+    await storage.setItem(
+      `${amplifyKeyPrefix}.testuser.refreshToken`,
+      "test-refresh-token"
+    );
+    await storage.setItem(
+      `${amplifyKeyPrefix}.testuser.tokenScopesString`,
+      "openid"
+    );
+    await storage.setItem(`${amplifyKeyPrefix}.testuser.userData`, "{}");
+    await storage.setItem(`${amplifyKeyPrefix}.testuser.clockDriftMs`, "0");
+    await storage.setItem(`${customKeyPrefix}.testuser.authMethod`, "SRP");
+    await storage.setItem(
+      `${customKeyPrefix}.testuser.lastRefreshAttempt`,
+      `${Date.now()}:some-tab-id`
+    );
+    await storage.setItem(
+      `${customKeyPrefix}.testuser.lastRefreshCompleted`,
+      Date.now().toString()
+    );
+    // Device key uses a different shape and must survive sign-out
+    const deviceKey = `${customKeyPrefix}.device.testuser`;
+    await storage.setItem(deviceKey, JSON.stringify({ deviceKey: "dev-123" }));
+
+    const { signedOut } = signOut({ skipTokenRevocation: true });
+    await signedOut;
+
+    const leftoverUserKeys = [...backing.keys()].filter((key) =>
+      key.startsWith(`${customKeyPrefix}.testuser.`)
+    );
+    expect(leftoverUserKeys).toEqual([]);
+    const leftoverAmplifyKeys = [...backing.keys()].filter((key) =>
+      key.startsWith(amplifyKeyPrefix)
+    );
+    expect(leftoverAmplifyKeys).toEqual([]);
+    // Device key is intentionally preserved between sessions
+    expect(backing.has(deviceKey)).toBe(true);
+  }, 20000);
 });
 
 describe("SignOut with expired access token", () => {
@@ -120,9 +185,9 @@ describe("SignOut with expired access token", () => {
     const amplifyKeyPrefix = `CognitoIdentityServiceProvider.testClient`;
 
     // Sanity check: the session is in storage before sign-out.
-    expect(
-      await storage.getItem(`${amplifyKeyPrefix}.LastAuthUser`)
-    ).toBe(username);
+    expect(await storage.getItem(`${amplifyKeyPrefix}.LastAuthUser`)).toBe(
+      username
+    );
     expect(
       await storage.getItem(`${amplifyKeyPrefix}.${username}.refreshToken`)
     ).toBe(refreshToken);
@@ -142,8 +207,8 @@ describe("SignOut with expired access token", () => {
     }
 
     // The still-valid refresh token must have been revoked server-side.
-    const revokeCall = fetchMock.mock.calls.find(
-      ([, init]) => init?.headers?.["x-amz-target"]?.endsWith("RevokeToken")
+    const revokeCall = fetchMock.mock.calls.find(([, init]) =>
+      init?.headers?.["x-amz-target"]?.endsWith("RevokeToken")
     );
     expect(revokeCall).toBeDefined();
     expect(JSON.parse(revokeCall[1].body)).toEqual(
@@ -213,8 +278,8 @@ describe("SignOut with expired access token", () => {
       }
 
       // Nothing to revoke - no RevokeToken call should be made.
-      const revokeCall = fetchMock.mock.calls.find(
-        ([, init]) => init?.headers?.["x-amz-target"]?.endsWith("RevokeToken")
+      const revokeCall = fetchMock.mock.calls.find(([, init]) =>
+        init?.headers?.["x-amz-target"]?.endsWith("RevokeToken")
       );
       expect(revokeCall).toBeUndefined();
     }


### PR DESCRIPTION
## Summary
Sign-out now removes all per-user `Passwordless.<clientId>.<username>.*` storage keys the library actually writes, so a signed-out user leaves no auth-adjacent residue behind.

## Finding
- Severity: LOW, confidence: certain
- `client/common.ts:405-428` (pre-fix): the signOut cleanup did NOT remove three keys the library writes per user:
  - `Passwordless.<clientId>.<username>.authMethod` — written in `client/storage.ts:73-75`
  - `Passwordless.<clientId>.<username>.lastRefreshAttempt` — written in `client/refresh.ts:90,133`
  - `Passwordless.<clientId>.<username>.lastRefreshCompleted` — written in `client/refresh.ts:175-176`
- Concrete failure scenario: a `lastRefreshAttempt` timestamp written less than 5 seconds before sign-out survives sign-out. If the same user signs back in immediately, `shouldAttemptRefresh` (`client/refresh.ts:84-142`) sees the recent timestamp and vetoes the first refresh attempt of the new session. It self-heals once the 5s window passes, but the first refresh is wrongly skipped, and `authMethod`/`lastRefreshCompleted` linger in storage indefinitely.
- Meanwhile the cleanup removed `.expireAt` and `.refreshingTokens`, which nothing in the current codebase writes (verified by grep: no `setItem` for either key shape).

## Fix
- Added removals for `.authMethod`, `.lastRefreshAttempt`, and `.lastRefreshCompleted` to the signOut cleanup in `client/common.ts`.
- Kept the `.expireAt` and `.refreshingTokens` removals: they are dead for current versions, but older versions of the library wrote them, so retaining the removals is cheap migration hygiene for users upgrading with stale storage. Annotated them with a comment.
- The remembered-device key (`Passwordless.<clientId>.device.<username>`) is intentionally untouched — it must persist between sessions.
- Side note (no code change here): `lastRefreshCompleted` is written with a retry loop in `client/refresh.ts:165-198` but never read anywhere — dead coordination code worth a future cleanup.

## Test plan
- New regression test in `test/signOut.test.ts`: populates every per-user key the library writes (Amplify-prefixed token keys plus `authMethod`, `lastRefreshAttempt`, `lastRefreshCompleted`, and the device record) against an enumerable in-memory storage, runs `signOut`, then asserts no `Passwordless.testClient.testuser.*` or `CognitoIdentityServiceProvider.testClient*` keys remain while the device key persists.
- `npx tsc --project client/tsconfig.json --noEmit` — clean
- `npx eslint client/common.ts test/signOut.test.ts` — clean
- `npx jest test/` — 13 suites passed, 2 skipped; 57 tests passed, 19 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized sign-out cleanup and test coverage; no changes to login, token refresh logic, or device persistence behavior beyond removing stale keys at logout.
> 
> **Overview**
> **Sign-out storage cleanup** now deletes three per-user `Passwordless.<clientId>.<username>.*` keys that were previously left behind: `authMethod`, `lastRefreshAttempt`, and `lastRefreshCompleted`. That closes a gap where a recent `lastRefreshAttempt` could block the first token refresh after the same user signs back in quickly.
> 
> Removals for legacy `expireAt` and `refreshingTokens` are unchanged but documented as migration hygiene for older library versions. **Remembered device** keys (`Passwordless.<clientId>.device.<username>`) are still not cleared.
> 
> A new **`signOut` regression test** seeds all Amplify and Passwordless per-user keys (plus a device key), runs sign-out, and asserts no session keys remain while the device entry persists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cde7033e284c728cce0ae39081130862399ba0f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->