### PR TITLE
Harden base64url decoding and FIDO2 option validation against empty input

### DIFF
--- a/client/__tests__/base64url-validation.test.ts
+++ b/client/__tests__/base64url-validation.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Copyright Amazon.com, Inc. and its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You
+ * may not use this file except in compliance with the License. A copy of
+ * the License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+import {
+  bufferFromBase64,
+  bufferFromBase64Url,
+  bufferToBase64Url,
+} from "../util.js";
+import { prepareFido2SignIn } from "../fido2.js";
+import { configure } from "../config.js";
+import { Fido2ValidationError } from "../errors.js";
+import { initiateAuth } from "../cognito-api.js";
+import { retrieveDeviceKey } from "../storage.js";
+
+// Mock dependencies
+jest.mock("../config");
+jest.mock("../cognito-api");
+jest.mock("../storage");
+
+const mockConfigure = configure as jest.MockedFunction<typeof configure>;
+const mockInitiateAuth = initiateAuth as jest.MockedFunction<
+  typeof initiateAuth
+>;
+const mockRetrieveDeviceKey = retrieveDeviceKey as jest.MockedFunction<
+  typeof retrieveDeviceKey
+>;
+
+describe("bufferFromBase64Url defensive decoding", () => {
+  it("returns an empty buffer for an empty string", () => {
+    const result = bufferFromBase64Url("");
+    expect(result).toBeInstanceOf(Uint8Array);
+    expect(result.byteLength).toBe(0);
+  });
+
+  it("throws a descriptive error for characters outside the base64url alphabet", () => {
+    expect(() => bufferFromBase64Url("!!!!")).toThrow(
+      "Invalid base64 encoded string"
+    );
+  });
+
+  it("rejects standard base64 characters that are not base64url", () => {
+    expect(() => bufferFromBase64Url("a+b/")).toThrow(
+      "Invalid base64 encoded string"
+    );
+  });
+
+  it("decodes valid base64url input round-trip", () => {
+    const bytes = new Uint8Array([72, 101, 108, 108, 111, 251, 255]);
+    const encoded = bufferToBase64Url(bytes.buffer);
+    expect(new Uint8Array(bufferFromBase64Url(encoded))).toEqual(bytes);
+  });
+
+  it("still decodes padded base64 input (bufferFromBase64)", () => {
+    const result = bufferFromBase64("aGVsbG8=");
+    expect(new Uint8Array(result)).toEqual(
+      new Uint8Array([104, 101, 108, 108, 111]) // "hello"
+    );
+  });
+
+  it("returns an empty buffer for an empty padded base64 string", () => {
+    expect(bufferFromBase64("").byteLength).toBe(0);
+  });
+});
+
+describe("FIDO2 options validation of empty strings", () => {
+  const credentialGetter = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockConfigure.mockReturnValue({
+      debug: undefined,
+      fido2: {
+        rp: { id: "example.com", name: "Example" },
+        baseUrl: "https://example.com/fido2",
+      },
+    } as unknown as ReturnType<typeof configure>);
+    mockRetrieveDeviceKey.mockResolvedValue(undefined);
+  });
+
+  function mockFido2Options(fido2options: Record<string, unknown>) {
+    mockInitiateAuth.mockResolvedValueOnce({
+      ChallengeParameters: {
+        fido2options: JSON.stringify(fido2options),
+      },
+      Session: "session-token",
+    } as unknown as Awaited<ReturnType<typeof initiateAuth>>);
+  }
+
+  it("rejects an empty challenge with Fido2ValidationError", async () => {
+    mockFido2Options({ challenge: "" });
+    await expect(
+      prepareFido2SignIn({ username: "alice", credentialGetter })
+    ).rejects.toThrow(Fido2ValidationError);
+    expect(credentialGetter).not.toHaveBeenCalled();
+  });
+
+  it("rejects an empty credential id with Fido2ValidationError", async () => {
+    mockFido2Options({
+      challenge: "server-challenge",
+      credentials: [{ id: "" }],
+    });
+    await expect(
+      prepareFido2SignIn({ username: "alice", credentialGetter })
+    ).rejects.toThrow(Fido2ValidationError);
+    expect(credentialGetter).not.toHaveBeenCalled();
+  });
+
+  it("accepts valid options", async () => {
+    mockFido2Options({
+      challenge: "server-challenge",
+      credentials: [{ id: "cred-1" }],
+    });
+    const parsedAssertion = {
+      credentialIdB64: "cred-1",
+      authenticatorDataB64: "auth-data",
+      clientDataJSON_B64: "client-data",
+      signatureB64: "signature",
+      userHandleB64: null,
+    };
+    credentialGetter.mockResolvedValueOnce(parsedAssertion);
+
+    const result = await prepareFido2SignIn({
+      username: "alice",
+      credentialGetter,
+    });
+    expect(result.credential).toEqual(parsedAssertion);
+    expect(credentialGetter).toHaveBeenCalledWith(
+      expect.objectContaining({ challenge: "server-challenge" })
+    );
+  });
+});

--- a/client/fido2.ts
+++ b/client/fido2.ts
@@ -568,9 +568,13 @@ function assertIsFido2Options(o: unknown): asserts o is Fido2Options {
   }
 
   // Required: challenge
-  if (!("challenge" in o) || typeof o.challenge !== "string") {
+  if (
+    !("challenge" in o) ||
+    typeof o.challenge !== "string" ||
+    !o.challenge.length
+  ) {
     throw new Fido2ValidationError(
-      "Fido2 options must have a challenge string",
+      "Fido2 options must have a non-empty challenge string",
       o
     );
   }
@@ -603,9 +607,9 @@ function assertIsFido2Options(o: unknown): asserts o is Fido2Options {
 
       const cred = credential as Record<string, unknown>;
 
-      if (!("id" in cred) || typeof cred.id !== "string") {
+      if (!("id" in cred) || typeof cred.id !== "string" || !cred.id.length) {
         throw new Fido2ValidationError(
-          "Each credential must have an id string",
+          "Each credential must have a non-empty id string",
           o
         );
       }

--- a/client/util.ts
+++ b/client/util.ts
@@ -188,7 +188,19 @@ const _bufferFromBase64 = function (characters: string, padChar = "") {
       (acc, char, index) => Object.assign(acc, { [char.charCodeAt(0)]: index }),
       {} as { [key: number]: number }
     );
+  // eslint-disable-next-line security/detect-non-literal-regexp
+  const validBase64 = new RegExp(
+    `^[${characters.replace(/[-\\\]]/g, "\\$&")}]+${
+      padChar ? `${padChar}{0,2}` : ""
+    }$`
+  );
   return function (base64: string) {
+    if (!base64.length) {
+      return new Uint8Array(0);
+    }
+    if (!validBase64.test(base64)) {
+      throw new Error("Invalid base64 encoded string");
+    }
     const paddingLength = padChar
       ? // eslint-disable-next-line security/detect-non-literal-regexp
         base64.match(new RegExp(`^.+?(${padChar}?${padChar}?)$`))![1].length


### PR DESCRIPTION
## Summary
Defensive fixes for the base64url decoder and FIDO2 option validation so that empty or malformed server-supplied strings fail with classified, descriptive errors instead of a raw `TypeError`.

## Finding
- Severity: LOW, confidence: certain (empirically verified)
- `client/util.ts:197` — `bufferFromBase64Url` used `base64.match(/.{1,4}/g)!`, where `match` returns `null` for `""`, producing `TypeError: Cannot read properties of null`. Characters outside the base64url alphabet decoded silently to garbage bytes.
- `client/fido2.ts:571-576` and `client/fido2.ts:606-611` — `assertIsFido2Options` only checked `typeof o.challenge === "string"` and `typeof cred.id === "string"`, so an empty challenge or credential id from a misbehaving backend passed validation and detonated downstream in `bufferFromBase64Url` as an unclassified `TypeError` instead of a `Fido2ValidationError`.
- Concrete failure scenario: the FIDO2 backend (or a proxy) returns `fido2options` with `"challenge": ""` (or a credential with `"id": ""`); sign-in fails with `TypeError: Cannot read properties of null` rather than the library's documented `Fido2ValidationError`, breaking the error-classification contract. Inputs are server-controlled, so impact is low.

## Fix
- `client/util.ts`: `_bufferFromBase64` (shared by `bufferFromBase64` and `bufferFromBase64Url`) now returns an empty `Uint8Array` for empty input and throws `Error("Invalid base64 encoded string")` for characters outside the configured alphabet (padding still allowed for the padded variant).
- `client/fido2.ts`: `assertIsFido2Options` now rejects empty `challenge` and empty credential `id` strings with a `Fido2ValidationError` carrying a descriptive message, before they can reach the decoder.

## Test plan
- New `client/__tests__/base64url-validation.test.ts`:
  - `bufferFromBase64Url("")` returns an empty buffer
  - `bufferFromBase64Url("!!!!")` and `bufferFromBase64Url("a+b/")` throw a descriptive Error
  - valid base64url round-trip; padded `bufferFromBase64` unchanged
  - `prepareFido2SignIn` with empty challenge / empty credential id rejects with `Fido2ValidationError`; valid options still pass
- Gates: `npx tsc --project client/tsconfig.json --noEmit` clean; `npx eslint` clean on changed files; full `npx jest` — 24 passed, 2 skipped suites; 191 passed, 19 skipped tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Defensive input validation in auth-adjacent client code with no change to happy-path behavior; impact is limited to misconfigured or malicious server responses that previously crashed or mis-decoded.
> 
> **Overview**
> Hardens **base64/base64url decoding** and **FIDO2 option validation** so malformed or empty server-supplied strings fail with clear, typed errors instead of a raw `TypeError`.
> 
> In `util.ts`, the shared `_bufferFromBase64` path (used by `bufferFromBase64` and `bufferFromBase64Url`) now returns an empty `Uint8Array` for `""`, validates input against the configured alphabet before decoding, and throws `Error("Invalid base64 encoded string")` for invalid characters (e.g. `+`/`/` in base64url). Padded standard base64 behavior is unchanged aside from the empty-string case.
> 
> In `fido2.ts`, `assertIsFido2Options` now requires a **non-empty** `challenge` and **non-empty** credential `id` values, surfacing `Fido2ValidationError` before `bufferFromBase64Url` runs—so empty `fido2options` from Cognito no longer bypass validation.
> 
> Adds `client/__tests__/base64url-validation.test.ts` covering decoder edge cases and `prepareFido2SignIn` rejection/acceptance paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73680b295dbe8c7bd20c69544e6f59b61ee37a81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->