### PR TITLE
Make OAuth customState UTF-8 safe and surface it on the callback

### DIFF
--- a/client/__tests__/hosted-oauth.test.ts
+++ b/client/__tests__/hosted-oauth.test.ts
@@ -13,8 +13,17 @@
  * language governing permissions and limitations under the License.
  */
 
-import { handleCognitoOAuthCallback } from "../hosted-oauth.js";
-import { configure } from "../config.js";
+import { TextEncoder, TextDecoder } from "util";
+
+// jsdom doesn't provide TextEncoder/TextDecoder
+Object.assign(globalThis, { TextEncoder, TextDecoder });
+
+import {
+  handleCognitoOAuthCallback,
+  signInWithRedirect,
+} from "../hosted-oauth.js";
+import { webcrypto } from "crypto";
+import { configure, getAuthorizeEndpoint } from "../config.js";
 import { processTokens } from "../common.js";
 import { withStorageLock } from "../lock.js";
 import type { ConfigWithDefaults } from "../config.js";
@@ -26,6 +35,9 @@ jest.mock("../lock");
 jest.mock("../storage");
 
 const mockConfigure = configure as jest.MockedFunction<typeof configure>;
+const mockGetAuthorizeEndpoint = getAuthorizeEndpoint as jest.MockedFunction<
+  typeof getAuthorizeEndpoint
+>;
 const mockProcessTokens = processTokens as jest.MockedFunction<
   typeof processTokens
 >;
@@ -299,6 +311,84 @@ describe("OAuth Integration with processTokens", () => {
         "invalid_grant"
       );
       expect(mockProcessTokens).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("customState round-trip", () => {
+    // Runs signInWithRedirect and returns the state parameter of the
+    // authorize URL that the browser would be redirected to
+    const signIn = async (customState?: string) => {
+      mockGetAuthorizeEndpoint.mockReturnValue(
+        "https://cognito.example.com/oauth2/authorize"
+      );
+      mockConfig.crypto = webcrypto as unknown as ConfigWithDefaults["crypto"];
+      await signInWithRedirect(customState ? { customState } : {});
+      const state = new URL(mockLocation.href).searchParams.get("state");
+      expect(state).toBeTruthy();
+      return state!;
+    };
+
+    // Simulates the redirect back from Cognito with the given state
+    const runCallback = async (returnedState: string, storedState: string) => {
+      mockLocation.href = `https://app.example.com/signin-redirect?code=test-code&state=${encodeURIComponent(
+        returnedState
+      )}`;
+      mockStorage.getItem.mockImplementation((key: string) => {
+        if (key === "cognito_oauth_in_progress") return Promise.resolve("true");
+        if (key === "cognito_oauth_state") return Promise.resolve(storedState);
+        if (key === "cognito_oauth_pkce")
+          return Promise.resolve("test-verifier");
+        return Promise.resolve(null);
+      });
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          access_token: "mock-access-token",
+          id_token: "mock-id-token",
+          refresh_token: "mock-refresh-token",
+          expires_in: 3600,
+          token_type: "Bearer",
+        }),
+      });
+      mockProcessTokens.mockImplementation(async (tokens) => tokens);
+      return handleCognitoOAuthCallback();
+    };
+
+    it("should round-trip non-ASCII customState through sign-in URL and callback", async () => {
+      const customState = "café-🎉/path?q=1";
+      const state = await signIn(customState);
+
+      // URL-safe: random hex prefix, base64url suffix (no "+", "/" or "=")
+      expect(state).toMatch(/^[0-9a-f]{64}-[A-Za-z0-9_-]+$/);
+
+      // The exact same state must have been stored for later validation
+      expect(mockStorage.setItem).toHaveBeenCalledWith(
+        "cognito_oauth_state",
+        state
+      );
+
+      const result = await runCallback(state, state);
+      expect(result).not.toBeNull();
+      expect(result?.customState).toBe(customState);
+    });
+
+    it("should reject a mismatched random prefix even when customState matches", async () => {
+      const state = await signIn("café-🎉/path?q=1");
+      const forgedState = "a".repeat(64) + state.slice(state.indexOf("-"));
+
+      await expect(runCallback(forgedState, state)).rejects.toThrow(
+        "OAuth state mismatch"
+      );
+      expect(mockProcessTokens).not.toHaveBeenCalled();
+    });
+
+    it("should leave customState undefined when signing in without customState", async () => {
+      const state = await signIn();
+      expect(state).toMatch(/^[0-9a-f]{64}$/);
+
+      const result = await runCallback(state, state);
+      expect(result).not.toBeNull();
+      expect(result?.customState).toBeUndefined();
     });
   });
 

--- a/client/hosted-oauth.ts
+++ b/client/hosted-oauth.ts
@@ -14,7 +14,11 @@
  */
 import { configure, getAuthorizeEndpoint, getTokenEndpoint } from "./config.js";
 import { generateRandomString, generatePkcePair } from "./oauthUtil.js";
-import { parseJwtPayload } from "./util.js";
+import {
+  parseJwtPayload,
+  bufferFromBase64Url,
+  bufferToBase64Url,
+} from "./util.js";
 import { CognitoAccessTokenPayload } from "./jwt-model.js";
 import { withStorageLock, LockTimeoutError } from "./lock.js";
 import { processTokens } from "./common.js";
@@ -66,8 +70,10 @@ export async function signInWithRedirect({
   }
 
   const stateRandom = generateRandomString(32);
+  // Encode customState as base64url of its UTF-8 bytes: btoa throws on
+  // non-Latin1 characters and emits "+", "/" and "=" which aren't URL-safe
   const state = customState
-    ? `${stateRandom}-${btoa(customState)}`
+    ? `${stateRandom}-${bufferToBase64Url(new TextEncoder().encode(customState))}`
     : stateRandom;
 
   const { verifier, challenge, method } = await generatePkcePair();
@@ -233,6 +239,24 @@ export async function handleCognitoOAuthCallback(): Promise<TokensFromSignIn | n
 
   debug?.("OAuth state validation successful");
 
+  // The state is a random hex string, optionally followed by
+  // `-<base64url(customState)>` (see signInWithRedirect). The random part is
+  // hex only, so the first "-" (if any) marks the start of the customState
+  let customState: string | undefined;
+  const customStateMatch = returnedState?.match(
+    /^[0-9a-f]+-([A-Za-z0-9_-]+)$/
+  );
+  if (customStateMatch) {
+    try {
+      customState = new TextDecoder().decode(
+        bufferFromBase64Url(customStateMatch[1])
+      );
+      debug?.("Recovered customState from OAuth state parameter");
+    } catch (err) {
+      debug?.("Failed to decode customState from OAuth state:", err);
+    }
+  }
+
   let tokens: TokensFromSignIn;
 
   if (responseType === "code") {
@@ -318,6 +342,10 @@ export async function handleCognitoOAuthCallback(): Promise<TokensFromSignIn | n
 
   await clear();
   debug?.("OAuth flow completed successfully");
+
+  if (customState !== undefined) {
+    tokens = { ...tokens, customState };
+  }
 
   return tokens;
 }

--- a/client/model.ts
+++ b/client/model.ts
@@ -40,6 +40,11 @@ export interface TokensFromSignIn {
    * Used to evaluate token expiry against a skew-corrected clock.
    */
   clockDriftMs?: number;
+  /**
+   * The customState that was passed to signInWithRedirect, recovered from
+   * the OAuth state parameter on the redirect callback (REDIRECT flow only)
+   */
+  customState?: string;
 }
 export interface TokensFromRefresh {
   accessToken: string;


### PR DESCRIPTION
## Summary
- Replace `btoa(customState)` in `signInWithRedirect` with the codebase's UTF-8-safe, URL-safe `bufferToBase64Url` helper (`client/util.ts`) over `TextEncoder` bytes
- Recover the customState on the callback side: after state validation succeeds, `handleCognitoOAuthCallback` splits the random hex prefix from the base64url suffix, decodes it, and returns it as a new optional `customState` field on `TokensFromSignIn`

## Finding
- Severity: LOW, confidence: certain
- `client/hosted-oauth.ts:69-71` (pre-fix): `btoa(customState)` throws `InvalidCharacterError` for any customState containing characters outside Latin-1 — e.g. `signInWithRedirect({ customState: "café-🎉/path?q=1" })` aborts sign-in before the redirect ever happens. `btoa` also emits `+`, `/`, `=`, which are not URL-safe.
- Separately, customState was write-only: nothing in `handleCognitoOAuthCallback` (`client/hosted-oauth.ts:120`) ever split off or decoded the `-${btoa(customState)}` suffix, so the value rode along only to satisfy the state equality check and was never surfaced to the app.

## Fix
- `client/hosted-oauth.ts`: encode with `bufferToBase64Url(new TextEncoder().encode(customState))`; on the callback, after the stored-state comparison succeeds, match `/^[0-9a-f]+-([A-Za-z0-9_-]+)$/` (the random prefix from `generateRandomString` is hex-only, so the first `-` is unambiguous), decode via `bufferFromBase64Url` + `TextDecoder`, and attach the result to the returned tokens. Decode failures are logged via `debug` and ignored.
- `client/model.ts`: add optional `customState?: string` to `TokensFromSignIn` (backward compatible; the React hook's `tokens` state picks it up automatically via `updateTokens`).
- State validation semantics are unchanged: the full returned state must still exactly equal the stored state; flows without customState produce/accept a bare hex state as before.

## Test plan
- New tests in `client/__tests__/hosted-oauth.test.ts`:
  - non-ASCII customState `"café-🎉/path?q=1"` round-trips through sign-in URL construction (state matches `^[0-9a-f]{64}-[A-Za-z0-9_-]+$`, same state stored) and callback parsing (`result.customState` equals the original)
  - forged state with matching customState suffix but different random prefix still rejects with "OAuth state mismatch"
  - no-customState flow unchanged: bare 64-hex state, `result.customState` undefined
- Gates: `npx tsc --project client/tsconfig.json --noEmit` clean; `npx eslint` clean on the three changed files; `npx jest client/__tests__/hosted-oauth.test.ts` 10/10 pass; full `npx jest` suite 185 passed, 19 skipped (skips pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized hosted OAuth redirect flow; CSRF state validation is unchanged and the new field is optional on the token type.
> 
> **Overview**
> **OAuth redirect `customState` is now UTF-8 safe and returned after the callback.**
> 
> `signInWithRedirect` no longer uses `btoa(customState)` (which breaks on non-Latin1 and is not URL-safe). It encodes the value as **base64url over UTF-8 bytes** via existing `bufferToBase64Url` / `TextEncoder`, still prefixed by the random hex state segment. **State equality checks are unchanged**—the full stored string must still match.
> 
> After successful state validation, `handleCognitoOAuthCallback` **parses the optional base64url suffix**, decodes it with `bufferFromBase64Url` + `TextDecoder`, and attaches **`customState` on the returned `TokensFromSignIn`** (new optional field on the model). Flows without `customState` still use a bare hex state and leave the field undefined.
> 
> Tests cover non-ASCII round-trip, rejection when only the random prefix is forged, and the no-`customState` path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41425633293d7479db0a3200b8c16009ef0b567e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->