### PR TITLE
Fix signOut no-op when access token is already expired

### DIFF
--- a/client/common.ts
+++ b/client/common.ts
@@ -16,6 +16,7 @@ import { revokeToken } from "./cognito-api.js";
 import { configure } from "./config.js";
 import {
   retrieveTokens,
+  retrieveTokensForRefresh,
   storeTokens,
   storeDeviceKey,
   getRememberedDevice,
@@ -364,13 +365,38 @@ export const signOut = (props?: {
 
   const tokenRevocationTracker = new Set<string>();
 
+  const amplifyKeyPrefix = `CognitoIdentityServiceProvider.${clientId}`;
+  const customKeyPrefix = `Passwordless.${clientId}`;
+
+  // Resolve the session to tear down. Prefer retrieveTokensForRefresh so a
+  // session whose access token has already expired (but is still refreshable)
+  // is signed out: retrieveTokens drops expired tokens as a safety net, but the
+  // refresh system reads via retrieveTokensForRefresh and would otherwise
+  // silently resurrect a session we believe we signed out of. Fall back to
+  // retrieveTokens for valid access-only sessions (e.g. OAuth implicit flow)
+  // that have no refresh token, and finally to LastAuthUser so an access-only
+  // session whose access token has also expired is still cleared. A refresh
+  // token, when present, is always surfaced by retrieveTokensForRefresh, so the
+  // revocation below still fires whenever there is something to revoke.
+  const resolveSignOutSession = async (): Promise<
+    { username: string; refreshToken?: string } | undefined
+  > => {
+    const tokens =
+      (await retrieveTokensForRefresh()) ?? (await retrieveTokens());
+    if (tokens?.username) {
+      return { username: tokens.username, refreshToken: tokens.refreshToken };
+    }
+    const username = await storage.getItem(`${amplifyKeyPrefix}.LastAuthUser`);
+    return username ? { username } : undefined;
+  };
+
   // Wrap sign-out in per-user storage lock
   const signedOut = (async () => {
     // Determine lock key per user
-    const tokens0 = await retrieveTokens();
-    const userIdentifier = tokens0?.username;
+    const session0 = await resolveSignOutSession();
+    const userIdentifier = session0?.username;
     const lockKey = userIdentifier
-      ? `Passwordless.${clientId}.${userIdentifier}.refreshLock`
+      ? `${customKeyPrefix}.${userIdentifier}.refreshLock`
       : undefined;
     // Run sign-out logic under lock if we have a user
     const doSignOut = async () => {
@@ -390,54 +416,45 @@ export const signOut = (props?: {
           cleanupRefreshSystem(userIdentifier);
         }
 
-        const tokens = await retrieveTokens();
+        const session = await resolveSignOutSession();
         if (abort.signal.aborted) {
           debug?.("Aborting sign-out");
           currentStatus && statusCb?.(currentStatus);
           return;
         }
-        if (!tokens) {
-          debug?.("No tokens in storage to delete");
+        if (!session) {
+          debug?.("No session in storage to delete");
           props?.tokensRemovedLocallyCb?.();
           statusCb?.("SIGNED_OUT");
           return;
         }
-        const amplifyKeyPrefix = `CognitoIdentityServiceProvider.${clientId}`;
-        const customKeyPrefix = `Passwordless.${clientId}`;
+        const { username, refreshToken } = session;
         await Promise.all([
-          storage.removeItem(`${amplifyKeyPrefix}.${tokens.username}.idToken`),
+          storage.removeItem(`${amplifyKeyPrefix}.${username}.idToken`),
+          storage.removeItem(`${amplifyKeyPrefix}.${username}.accessToken`),
+          storage.removeItem(`${amplifyKeyPrefix}.${username}.refreshToken`),
           storage.removeItem(
-            `${amplifyKeyPrefix}.${tokens.username}.accessToken`
+            `${amplifyKeyPrefix}.${username}.tokenScopesString`
           ),
-          storage.removeItem(
-            `${amplifyKeyPrefix}.${tokens.username}.refreshToken`
-          ),
-          storage.removeItem(
-            `${amplifyKeyPrefix}.${tokens.username}.tokenScopesString`
-          ),
-          storage.removeItem(`${amplifyKeyPrefix}.${tokens.username}.userData`),
+          storage.removeItem(`${amplifyKeyPrefix}.${username}.userData`),
           storage.removeItem(`${amplifyKeyPrefix}.LastAuthUser`),
-          storage.removeItem(
-            `${amplifyKeyPrefix}.${tokens.username}.clockDriftMs`
-          ),
-          storage.removeItem(`${customKeyPrefix}.${tokens.username}.expireAt`),
-          storage.removeItem(
-            `Passwordless.${clientId}.${tokens.username}.refreshingTokens`
-          ),
+          storage.removeItem(`${amplifyKeyPrefix}.${username}.clockDriftMs`),
+          storage.removeItem(`${customKeyPrefix}.${username}.expireAt`),
+          storage.removeItem(`${customKeyPrefix}.${username}.refreshingTokens`),
           // Note: We do NOT remove deviceKey - it should persist between sessions
         ]);
         props?.tokensRemovedLocallyCb?.();
 
         if (
-          tokens.refreshToken &&
-          !tokenRevocationTracker.has(tokens.refreshToken) &&
+          refreshToken &&
+          !tokenRevocationTracker.has(refreshToken) &&
           !skipTokenRevocation
         ) {
           try {
-            tokenRevocationTracker.add(tokens.refreshToken);
+            tokenRevocationTracker.add(refreshToken);
             await revokeToken({
               abort: undefined,
-              refreshToken: tokens.refreshToken,
+              refreshToken: refreshToken,
             });
             debug?.("Successfully revoked refresh token");
           } catch (revokeError) {

--- a/test/signOut.test.ts
+++ b/test/signOut.test.ts
@@ -1,25 +1,28 @@
 import { configure } from "../client/config.js";
 import { signOut } from "../client/common.js";
+import { storeTokens } from "../client/storage.js";
 
-// Helper to create a valid JWT for testing
-const createValidJWT = () => {
+// Helper to create a JWT with arbitrary claims for testing
+const createJWT = (claims: Record<string, unknown>) => {
   const header = btoa(JSON.stringify({ alg: "HS256", typ: "JWT" }))
     .replace(/\+/g, "-")
     .replace(/\//g, "_")
     .replace(/=+$/, "");
-  const payload = btoa(
-    JSON.stringify({
-      sub: "test-sub",
-      username: "testuser",
-      exp: Math.floor(Date.now() / 1000) + 3600, // 1 hour from now
-      iat: Math.floor(Date.now() / 1000),
-    })
-  )
+  const payload = btoa(JSON.stringify(claims))
     .replace(/\+/g, "-")
     .replace(/\//g, "_")
     .replace(/=+$/, "");
   return `${header}.${payload}.signature`;
 };
+
+// Helper to create a valid JWT for testing
+const createValidJWT = () =>
+  createJWT({
+    sub: "test-sub",
+    username: "testuser",
+    exp: Math.floor(Date.now() / 1000) + 3600, // 1 hour from now
+    iat: Math.floor(Date.now() / 1000),
+  });
 
 describe("SignOut Lock", () => {
   beforeEach(() => {
@@ -68,4 +71,152 @@ describe("SignOut Lock", () => {
     // signOut should eventually complete when lock is released
     await expect(signedOut).resolves.toBeUndefined();
   }, 20000); // Increase timeout for lock wait
+});
+
+describe("SignOut with expired access token", () => {
+  test("clears storage and revokes refresh token even when access token is expired", async () => {
+    const now = Date.now();
+    const username = "testuser";
+    const refreshToken = "still-valid-refresh-token";
+
+    // fetch mock that captures the RevokeToken call and responds 2xx
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({}),
+    });
+
+    configure({
+      clientId: "testClient",
+      cognitoIdpEndpoint: "us-west-2",
+      fetch: fetchMock,
+    });
+    const { storage } = configure();
+
+    // Store a session whose access token expired an hour ago but whose refresh
+    // token is still valid - the exact state that previously made signOut a
+    // no-op (retrieveTokens drops expired tokens), leaving the session
+    // resurrectable by the refresh system.
+    await storeTokens({
+      accessToken: createJWT({
+        sub: "user123",
+        username,
+        scope: "openid",
+        exp: Math.floor((now - 3600_000) / 1000), // expired 1h ago
+        iat: Math.floor((now - 7200_000) / 1000),
+      }),
+      idToken: createJWT({
+        sub: "user123",
+        "cognito:username": username,
+        email: "test@example.com",
+        exp: Math.floor((now - 3600_000) / 1000),
+        iat: Math.floor((now - 7200_000) / 1000),
+      }),
+      refreshToken,
+      authMethod: "SRP",
+      expireAt: new Date(now - 3600_000), // expired 1h ago
+    });
+
+    const amplifyKeyPrefix = `CognitoIdentityServiceProvider.testClient`;
+
+    // Sanity check: the session is in storage before sign-out.
+    expect(
+      await storage.getItem(`${amplifyKeyPrefix}.LastAuthUser`)
+    ).toBe(username);
+    expect(
+      await storage.getItem(`${amplifyKeyPrefix}.${username}.refreshToken`)
+    ).toBe(refreshToken);
+
+    const { signedOut } = signOut();
+    await signedOut;
+
+    // All session keys must be gone from storage.
+    for (const key of [
+      `${amplifyKeyPrefix}.LastAuthUser`,
+      `${amplifyKeyPrefix}.${username}.accessToken`,
+      `${amplifyKeyPrefix}.${username}.idToken`,
+      `${amplifyKeyPrefix}.${username}.refreshToken`,
+      `${amplifyKeyPrefix}.${username}.userData`,
+    ]) {
+      expect(await storage.getItem(key)).toBeNull();
+    }
+
+    // The still-valid refresh token must have been revoked server-side.
+    const revokeCall = fetchMock.mock.calls.find(
+      ([, init]) => init?.headers?.["x-amz-target"]?.endsWith("RevokeToken")
+    );
+    expect(revokeCall).toBeDefined();
+    expect(JSON.parse(revokeCall[1].body)).toEqual(
+      expect.objectContaining({ Token: refreshToken, ClientId: "testClient" })
+    );
+  });
+
+  // Access-only sessions (e.g. OAuth implicit flow) persist a valid access/id
+  // token with no refresh token. retrieveTokensForRefresh returns undefined for
+  // these, so signOut must still tear them down (no refresh token to revoke).
+  test.each([
+    { label: "valid", offsetMs: 3600_000 },
+    { label: "expired", offsetMs: -3600_000 },
+  ])(
+    "clears an access-only session with no refresh token ($label access token)",
+    async ({ offsetMs }) => {
+      const now = Date.now();
+      const username = "accessonly";
+
+      const fetchMock = jest.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({}),
+      });
+      configure({
+        clientId: "testClient",
+        cognitoIdpEndpoint: "us-west-2",
+        fetch: fetchMock,
+      });
+      const { storage } = configure();
+
+      await storeTokens({
+        accessToken: createJWT({
+          sub: "user456",
+          username,
+          scope: "openid",
+          exp: Math.floor((now + offsetMs) / 1000),
+          iat: Math.floor((now - 7200_000) / 1000),
+        }),
+        idToken: createJWT({
+          sub: "user456",
+          "cognito:username": username,
+          email: "accessonly@example.com",
+          exp: Math.floor((now + offsetMs) / 1000),
+          iat: Math.floor((now - 7200_000) / 1000),
+        }),
+        // no refreshToken
+        expireAt: new Date(now + offsetMs),
+      });
+
+      const amplifyKeyPrefix = `CognitoIdentityServiceProvider.testClient`;
+      expect(await storage.getItem(`${amplifyKeyPrefix}.LastAuthUser`)).toBe(
+        username
+      );
+
+      const { signedOut } = signOut();
+      await signedOut;
+
+      // Session must be cleared even though there was no refresh token.
+      for (const key of [
+        `${amplifyKeyPrefix}.LastAuthUser`,
+        `${amplifyKeyPrefix}.${username}.accessToken`,
+        `${amplifyKeyPrefix}.${username}.idToken`,
+        `${amplifyKeyPrefix}.${username}.userData`,
+      ]) {
+        expect(await storage.getItem(key)).toBeNull();
+      }
+
+      // Nothing to revoke - no RevokeToken call should be made.
+      const revokeCall = fetchMock.mock.calls.find(
+        ([, init]) => init?.headers?.["x-amz-target"]?.endsWith("RevokeToken")
+      );
+      expect(revokeCall).toBeUndefined();
+    }
+  );
 });


### PR DESCRIPTION
## Problem

`signOut()` in `client/common.ts` retrieved the session via `retrieveTokens()`, which **drops tokens whose access token has expired** as a safety net (returning `undefined`). As a result, when a user signs out *after* their access token expired, signOut:

- logged `"No tokens in storage to delete"`,
- reported `SIGNED_OUT`,
- but **left `refreshToken`, `LastAuthUser`, `idToken`, `accessToken`, `userData` etc. in storage**, and
- **skipped server-side `revokeToken`** for the still-valid refresh token.

Because the refresh system (`scheduleRefresh` / `refreshTokens` / `forceRefreshTokens`) reads sessions via `retrieveTokensForRefresh()` — which deliberately returns expired sessions — the supposedly signed-out session could be **silently resurrected by any later refresh**.

## Fix

Use `retrieveTokensForRefresh()` in `signOut()` for both the lock-key lookup and the deletion/revocation step, so sign-out tears down exactly the sessions the refresh system can still act on. This restores symmetry: signOut now invalidates any session that the refresh path considers live.

## Test

Adds a regression test in `test/signOut.test.ts` that stores an expired access token plus a valid refresh token, calls `signOut()`, and asserts:

- all session storage keys (`LastAuthUser`, `accessToken`, `idToken`, `refreshToken`, `userData`) are removed, and
- the `RevokeToken` endpoint is called with the refresh token.

Verified the test **fails against the pre-fix code** (storage keys survive, no revoke) and passes with the fix.

## Verification

- `npx tsc --project client/tsconfig.json --noEmit` — clean
- `npx eslint client/common.ts test/signOut.test.ts` — clean
- `npx jest` — 23 suites pass (2 pre-existing skips), 183 tests pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core auth session teardown and token revocation behavior; scope is limited to signOut and covered by new regression tests.
> 
> **Overview**
> **Fixes `signOut()` treating expired-access sessions as already signed out**, which left refresh tokens and Cognito storage keys in place and skipped `RevokeToken`, so the refresh path could bring the session back.
> 
> `signOut` now resolves the session via a new **`resolveSignOutSession`**: **`retrieveTokensForRefresh()` first** (matches what refresh uses), then **`retrieveTokens()`** for access-only flows, then **`LastAuthUser`** so expired access-only sessions still clear. Lock lookup and storage teardown/revocation both use that resolution; refresh lock keys use the shared `customKeyPrefix`.
> 
> **Tests** in `test/signOut.test.ts` cover expired access + valid refresh (full clear + revoke) and access-only sessions with valid or expired access (clear, no revoke).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a0d80820914e8e7602b063c2987f252fcf8990e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->