### PR TITLE
Fix react-context-stability test suite broken by parallel PR merges

### DIFF
--- a/client/__tests__/react-context-stability.test.tsx
+++ b/client/__tests__/react-context-stability.test.tsx
@@ -26,7 +26,7 @@ import {
   usePasswordless,
 } from "../react/hooks.js";
 import { configure } from "../config.js";
-import { retrieveTokens } from "../storage.js";
+import { retrieveTokens, onTokensStored } from "../storage.js";
 
 // Mocks
 jest.mock("../config");
@@ -35,6 +35,9 @@ jest.mock("../storage");
 const mockConfigure = configure as jest.MockedFunction<typeof configure>;
 const mockRetrieveTokens = retrieveTokens as jest.MockedFunction<
   typeof retrieveTokens
+>;
+const mockOnTokensStored = onTokensStored as jest.MockedFunction<
+  typeof onTokensStored
 >;
 
 describe("PasswordlessContext stability with activity tracking enabled", () => {
@@ -57,6 +60,10 @@ describe("PasswordlessContext stability with activity tracking enabled", () => {
 
     // No cached tokens
     mockRetrieveTokens.mockResolvedValue(undefined);
+
+    // The hook's mount effect subscribes via onTokensStored and calls the
+    // returned unsubscribe function in its cleanup
+    mockOnTokensStored.mockReturnValue(() => {});
   });
 
   afterEach(() => {

--- a/client/react/hooks.tsx
+++ b/client/react/hooks.tsx
@@ -817,7 +817,9 @@ function _usePasswordless() {
     // Cleanup function
     return () => {
       abortController.abort();
-      unsubscribeTokensStored();
+      if (typeof unsubscribeTokensStored === "function") {
+        unsubscribeTokensStored();
+      }
       if (typeof globalThis !== "undefined" && globalThis.removeEventListener) {
         globalThis.removeEventListener("storage", handleStorageChange);
       }


### PR DESCRIPTION
## Summary
Main's test suite is currently red: `client/__tests__/react-context-stability.test.tsx` fails all 4 tests with `TypeError: unsubscribeTokensStored is not a function` at the hook's mount-effect cleanup.

## Cause
Two recently merged PRs interact: #52 added the `onTokensStored(cb)` subscriber API to `client/storage.ts` (returns an unsubscribe function, called in the React hook's effect cleanup), and #74 added this test file, which mocks `../storage` without making `onTokensStored` return a function. Each PR was green alone; the combination broke on main.

## Fix
- Add the same mock pattern the sibling suites already use (`mockOnTokensStored.mockReturnValue(() => {})`) — see `react-oauth-simple.test.tsx` / `react-hooks-coverage.test.tsx`.
- Harden the hook cleanup with a `typeof` check so a future mock omission degrades gracefully instead of throwing during unmount.

## Test plan
- `npx jest client/__tests__/react-context-stability.test.tsx` → 4/4 pass
- `npx tsc --project client/tsconfig.json --noEmit` → clean
- `npx eslint` on both changed files → clean
- Full `npx jest` → 282 passed / 19 skipped / 0 failures — main's suite fully green with this change

Recommend merging this before the remaining open PRs so their CI runs against a green baseline.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test mock alignment plus a defensive typeof check on effect cleanup; no auth or storage behavior change in production when onTokensStored returns normally.
> 
> **Overview**
> Restores a green main test suite after **`onTokensStored`** was added to the React provider’s mount effect while **`react-context-stability.test.tsx`** mocked `../storage` without returning an unsubscribe function, which caused unmount cleanup to throw.
> 
> The stability test now imports and mocks **`onTokensStored`** the same way as **`react-oauth-simple`** / **`react-hooks-coverage`** (`mockReturnValue(() => {})`). The provider’s effect cleanup in **`hooks.tsx`** only invokes the unsubscribe when it is actually a function, so incomplete mocks or edge cases do not crash on unmount.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14c52ae87a381bbb5d75b2179027855bdcac234a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->