### PR TITLE
Make refresh-bugs suite deterministic under parallel load

### DIFF
--- a/test/refresh-bugs.test.ts
+++ b/test/refresh-bugs.test.ts
@@ -1,7 +1,17 @@
-import { configure } from "../client/config.js";
-import { scheduleRefresh, cleanupRefreshSystem } from "../client/refresh.js";
-import { storeTokens, retrieveTokens } from "../client/storage.js";
-import { processTokens } from "../client/common.js";
+// NOTE on test isolation: processTokens launches fire-and-forget
+// scheduleRefresh() chains whose hops (storage-lock jitter sleeps, poll
+// loops) routinely outlive the test that started them. With static imports,
+// such a straggler chain re-reads the process-global config singleton at
+// execution time and operates on the NEXT test's storage/mocks — the source
+// of this suite's flakiness under load. Each test therefore gets a FRESH
+// module graph (jest.resetModules + dynamic imports): stragglers stay bound
+// to the previous test's module instances and can't touch the new test.
+let configure: typeof import("../client/config.js").configure;
+let scheduleRefresh: typeof import("../client/refresh.js").scheduleRefresh;
+let cleanupRefreshSystem: typeof import("../client/refresh.js").cleanupRefreshSystem;
+let storeTokens: typeof import("../client/storage.js").storeTokens;
+let retrieveTokens: typeof import("../client/storage.js").retrieveTokens;
+let processTokens: typeof import("../client/common.js").processTokens;
 
 // Poll until the predicate is true (used to await fire-and-forget chains)
 const waitFor = async (predicate: () => boolean, timeoutMs = 4000) => {
@@ -36,9 +46,17 @@ describe("Refresh System Bug Hunt", () => {
     removeItem: jest.Mock<Promise<void>, [string]>;
   };
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    // Fresh module graph per test (see note above the imports)
+    jest.resetModules();
+    ({ configure } = await import("../client/config.js"));
+    ({ scheduleRefresh, cleanupRefreshSystem } = await import(
+      "../client/refresh.js"
+    ));
+    ({ storeTokens, retrieveTokens } = await import("../client/storage.js"));
+    ({ processTokens } = await import("../client/common.js"));
+
     fetchMock = jest.fn();
-    debugLogs = [];
 
     // Clear all mocks
     jest.clearAllMocks();
@@ -59,6 +77,11 @@ describe("Refresh System Bug Hunt", () => {
       }),
     };
 
+    // Capture THIS test's log array by value: a straggler chain from a
+    // previous test holds the previous closure and keeps writing to its
+    // own (discarded) array, never into this test's logs
+    const logs: string[] = [];
+    debugLogs = logs;
     configure({
       clientId: "testClient",
       cognitoIdpEndpoint: "us-west-2",
@@ -66,15 +89,20 @@ describe("Refresh System Bug Hunt", () => {
       storage: mockStorage,
       debug: (...args: unknown[]) => {
         const msg = args.map(String).join(" ");
-        debugLogs.push(msg);
+        logs.push(msg);
         console.log("[DEBUG]", msg);
       },
     });
   });
 
-  afterEach(() => {
-    // Clean up any timers
-    jest.clearAllTimers();
+  afterEach(async () => {
+    // Tear down this test's module-global refresh machinery (watchdog,
+    // listeners, per-user timers) before the module graph is replaced —
+    // jest.clearAllTimers() would be a no-op here (real timers)
+    cleanupRefreshSystem();
+    // Give just-settling chains one macrotask to run their final hops
+    // against THIS test's (now torn down) module graph
+    await new Promise((resolve) => setTimeout(resolve, 0));
   });
 
   test("BUG: scheduleRefresh doesn't actually schedule anything", async () => {
@@ -129,7 +157,7 @@ describe("Refresh System Bug Hunt", () => {
     };
 
     // Clear logs
-    debugLogs = [];
+    debugLogs.length = 0; // clear in place: the debug closure writes to this same array
 
     // Process tokens (simulating post-refresh)
     await processTokens(tokens);
@@ -208,7 +236,7 @@ describe("Refresh System Bug Hunt", () => {
     });
 
     // Clear logs
-    debugLogs = [];
+    debugLogs.length = 0; // clear in place: the debug closure writes to this same array
 
     // Schedule refresh for expired tokens
     await scheduleRefresh();
@@ -257,7 +285,7 @@ describe("Refresh System Bug Hunt", () => {
     };
 
     // Clear logs
-    debugLogs = [];
+    debugLogs.length = 0; // clear in place: the debug closure writes to this same array
 
     // Process tokens multiple times
     await processTokens(tokens);
@@ -331,7 +359,7 @@ describe("Refresh System Bug Hunt", () => {
       expireAt: new Date(now + 600000),
     };
 
-    debugLogs = [];
+    debugLogs.length = 0; // clear in place: the debug closure writes to this same array
     await processTokens(refreshedTokens);
 
     // The new tokens MUST get their own refresh scheduled; deduplication
@@ -351,15 +379,17 @@ describe("Refresh System Bug Hunt", () => {
     const now = Date.now();
     const username = "selfabort-user";
 
-    // Spy on AbortController.prototype.abort: nothing in the happy-path
-    // refresh flow below should cancel anything. Before the fix, the
-    // nested processTokens (running inside the active refresh, with the
-    // schedule's own abort signal passed through by refreshTokens)
-    // aborted that very signal when replacing the tracked schedule,
-    // firing the old schedule's abort listeners and wiring the new
-    // schedule to an already-aborted signal.
-    const abortSpy = jest.spyOn(AbortController.prototype, "abort");
-
+    // Nothing in the happy-path refresh flow below should cancel anything.
+    // Before the fix, the nested processTokens (running inside the active
+    // refresh, with the schedule's own abort signal passed through by
+    // refreshTokens) aborted that very signal when replacing the tracked
+    // schedule, firing the old schedule's abort listeners ("Refresh
+    // scheduling aborted") and wiring the new schedule to an
+    // already-aborted signal. Asserted via this test's debug logs — which,
+    // thanks to the per-test module graph and per-test log array, no other
+    // test's straggler chain can write into (a prototype-wide
+    // AbortController spy used here previously picked up unrelated aborts
+    // from cross-test chains and made this test flaky under load).
     try {
       // Token that expires in 30 seconds: scheduleRefresh takes its
       // immediate-refresh path, so the chain
@@ -401,7 +431,7 @@ describe("Refresh System Bug Hunt", () => {
         }),
       });
 
-      debugLogs = [];
+      debugLogs.length = 0; // clear in place: the debug closure writes to this same array
       await processTokens(initialTokens);
 
       // Wait for the fire-and-forget refresh chain to complete: the
@@ -414,13 +444,20 @@ describe("Refresh System Bug Hunt", () => {
 
       // The nested processTokens replaced the tracked schedule while the
       // schedule's own abort signal was driving the call. That must not
-      // abort anything:
-      expect(abortSpy).not.toHaveBeenCalled();
+      // abort anything. In the regression, the armed schedule's abort
+      // listener fired (logging "Refresh scheduling aborted") — or the new
+      // schedule was wired to an already-aborted signal and never armed,
+      // which the waitFor above catches as a timeout. The log array is
+      // per-test (module isolation above), so no other test's chain can
+      // write into it.
       expect(
-        debugLogs.some((log) => log.includes("Refresh scheduling aborted"))
-      ).toBe(false);
+        debugLogs.filter(
+          (log) =>
+            log.includes("Refresh scheduling aborted") ||
+            log.includes("cancelling active refresh schedule")
+        )
+      ).toEqual([]);
     } finally {
-      abortSpy.mockRestore();
       cleanupRefreshSystem(username);
     }
   });

--- a/test/refresh-bugs.test.ts
+++ b/test/refresh-bugs.test.ts
@@ -9,6 +9,12 @@
 let configure: typeof import("../client/config.js").configure;
 let scheduleRefresh: typeof import("../client/refresh.js").scheduleRefresh;
 let cleanupRefreshSystem: typeof import("../client/refresh.js").cleanupRefreshSystem;
+let cleanupUserRefreshState: typeof import("../client/refresh.js").cleanupUserRefreshState;
+
+// Every username used by tests in this suite: cleanupRefreshSystem() without
+// a username only tears down the GLOBAL listeners/watchdog — per-user timers
+// must be cancelled per username (there is no all-users teardown API)
+const TEST_USERNAMES = ["testuser", "shortlived-user", "selfabort-user"];
 let storeTokens: typeof import("../client/storage.js").storeTokens;
 let retrieveTokens: typeof import("../client/storage.js").retrieveTokens;
 let processTokens: typeof import("../client/common.js").processTokens;
@@ -50,9 +56,8 @@ describe("Refresh System Bug Hunt", () => {
     // Fresh module graph per test (see note above the imports)
     jest.resetModules();
     ({ configure } = await import("../client/config.js"));
-    ({ scheduleRefresh, cleanupRefreshSystem } = await import(
-      "../client/refresh.js"
-    ));
+    ({ scheduleRefresh, cleanupRefreshSystem, cleanupUserRefreshState } =
+      await import("../client/refresh.js"));
     ({ storeTokens, retrieveTokens } = await import("../client/storage.js"));
     ({ processTokens } = await import("../client/common.js"));
 
@@ -96,9 +101,13 @@ describe("Refresh System Bug Hunt", () => {
   });
 
   afterEach(async () => {
-    // Tear down this test's module-global refresh machinery (watchdog,
-    // listeners, per-user timers) before the module graph is replaced —
-    // jest.clearAllTimers() would be a no-op here (real timers)
+    // Tear down this test's refresh machinery before the module graph is
+    // replaced — jest.clearAllTimers() would be a no-op here (real timers).
+    // cleanupRefreshSystem() without a username only removes the GLOBAL
+    // watchdog/listeners; per-user timers must be cancelled per username
+    for (const username of TEST_USERNAMES) {
+      cleanupUserRefreshState(username);
+    }
     cleanupRefreshSystem();
     // Give just-settling chains one macrotask to run their final hops
     // against THIS test's (now torn down) module graph


### PR DESCRIPTION
## Summary
`test/refresh-bugs.test.ts` failed ~25% of runs on loaded machines (reproduced 8/32 under 4-way parallel jest), always on the final self-abort regression test. First of the sequential follow-up series — fixing this first so every subsequent PR gets trustworthy CI.

## Root cause
`processTokens` launches fire-and-forget `scheduleRefresh()` chains whose hops (storage-lock jitter sleeps, 50–500ms poll loops) routinely outlive the test that started them. With static imports, a straggler chain re-reads the process-global `configure()` singleton at execution time, so it operates on the **next** test's storage and mocks: a straggler from test 5 force-refreshed the final test's user and legitimately aborted that test's tracked schedule — recorded by the prototype-wide `AbortController.prototype.abort` spy as a failure.

## Fix
- **Per-test module isolation**: `jest.resetModules()` + dynamic imports in `beforeEach`. Stragglers stay bound to the previous test's module graph and storage; they cannot touch the running test.
- **Captured log arrays**: the debug closure captures its array by value; mid-test clears mutate in place. A straggler's closure writes only to its own discarded array.
- **Scoped assertions instead of the prototype-wide spy**: the regression's observable signatures (`Refresh scheduling aborted` / `cancelling active refresh schedule`) in this test's own log array; the armed-timer `waitFor` catches the wired-to-aborted-signal variant as a timeout.
- **Real teardown in `afterEach`**: `cleanupRefreshSystem()` + a macrotask flush (`jest.clearAllTimers()` was a no-op under real timers).

## Test plan
- Suite green solo: 6/6.
- Determinism proof: **20/20 green with three full-suite jest runs hammering the CPU in parallel** — the exact load profile that previously reproduced the failures.
- Full suite: 416 passed / 0 failures; tsc and eslint clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to refresh-bugs isolation and teardown; no production auth or refresh logic is modified.
> 
> **Overview**
> Stabilizes **`test/refresh-bugs.test.ts`** under parallel Jest by isolating each test from lingering **`processTokens` → `scheduleRefresh()`** async work that previously reused the global config and polluted later tests.
> 
> **Per-test module graph:** static imports are replaced with **`jest.resetModules()`** and dynamic imports in **`beforeEach`**, so straggler chains stay on the prior test’s module instances and storage.
> 
> **Logging and assertions:** the debug callback captures a per-test **`logs`** array; mid-test clears use **`debugLogs.length = 0`** instead of rebinding. The self-abort regression drops **`AbortController.prototype.abort`** spying in favor of asserting this test’s debug logs stay free of **`Refresh scheduling aborted`** / **`cancelling active refresh schedule`**.
> 
> **Teardown:** **`afterEach`** calls **`cleanupUserRefreshState`** for known suite usernames, then **`cleanupRefreshSystem()`**, and yields one macrotask—replacing **`jest.clearAllTimers()`**, which did nothing with real timers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ff48d77aa5d0527cf04be8190552c7585270913. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->