### PR TITLE
SRP device-key parity: stale-key recovery and no unconfirmed-key persistence

### DIFF
--- a/client/__tests__/srp-device-key.test.ts
+++ b/client/__tests__/srp-device-key.test.ts
@@ -1,0 +1,314 @@
+/**
+ * Copyright Amazon.com, Inc. and its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You
+ * may not use this file except in compliance with the License. A copy of
+ * the License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+import { Blob as NodeBlob } from "buffer";
+import { webcrypto } from "crypto";
+import { TextEncoder as NodeTextEncoder } from "util";
+
+// jsdom does not provide TextEncoder
+if (typeof globalThis.TextEncoder === "undefined") {
+  globalThis.TextEncoder = NodeTextEncoder as typeof globalThis.TextEncoder;
+}
+// jsdom's Blob lacks arrayBuffer(); use Node's implementation
+if (typeof Blob.prototype.arrayBuffer !== "function") {
+  globalThis.Blob = NodeBlob as unknown as typeof Blob;
+}
+
+import { authenticateWithSRP } from "../srp.js";
+import { handleDeviceConfirmation } from "../device.js";
+import { configure } from "../config.js";
+import type { MinimalCrypto } from "../config.js";
+import { setRememberedDevice, getRememberedDevice } from "../storage.js";
+import type { TokensFromSignIn } from "../model.js";
+import * as cognitoApi from "../cognito-api.js";
+import { processTokens } from "../common.js";
+
+// cognito-api.ts and device.ts import each other; a jest.mock factory with
+// requireActual re-enters that cycle mid-construction and splits the module
+// identity (device.ts ends up calling a different confirmDevice instance
+// than the test configured). jest.spyOn on the namespace avoids this: the
+// CommonJS transform resolves the property at call time, so every importer
+// sees the spy.
+jest.mock("../common.js", () => ({
+  processTokens: jest.fn(),
+}));
+
+let mockInitiateAuth: jest.MockedFunction<typeof cognitoApi.initiateAuth>;
+let mockRespondToAuthChallenge: jest.MockedFunction<
+  typeof cognitoApi.respondToAuthChallenge
+>;
+let mockHandleAuthResponse: jest.MockedFunction<
+  typeof cognitoApi.handleAuthResponse
+>;
+let mockConfirmDevice: jest.MockedFunction<typeof cognitoApi.confirmDevice>;
+const mockProcessTokens = processTokens as jest.MockedFunction<
+  typeof processTokens
+>;
+
+const USER_ID_FOR_SRP = "canonical-user-sub";
+
+function createMemoryStorage() {
+  const store = new Map<string, string>();
+  return {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      store.set(key, value);
+    },
+    removeItem: (key: string) => {
+      store.delete(key);
+    },
+  };
+}
+
+function passwordVerifierChallenge() {
+  return {
+    ChallengeName: "PASSWORD_VERIFIER",
+    ChallengeParameters: {
+      SALT: "aabbccddeeff112233",
+      SRP_B: "1234abcd9876ef01",
+      SECRET_BLOCK: "c2VjcmV0LWJsb2Nr",
+      USER_ID_FOR_SRP,
+      USERNAME: USER_ID_FOR_SRP,
+    },
+    Session: "test-session",
+  } as unknown as Awaited<ReturnType<typeof cognitoApi.initiateAuth>>;
+}
+
+function authenticatedResult() {
+  return {
+    AuthenticationResult: {
+      AccessToken: "test-access-token",
+      IdToken: "test-id-token",
+      RefreshToken: "test-refresh-token",
+      ExpiresIn: 3600,
+      TokenType: "Bearer",
+    },
+    ChallengeParameters: {},
+  } as unknown as Awaited<ReturnType<typeof cognitoApi.respondToAuthChallenge>>;
+}
+
+function deviceNotFoundError() {
+  const err = new Error("Device does not exist.");
+  err.name = "ResourceNotFoundException";
+  return err;
+}
+
+/** challengeResponses of the n-th respondToAuthChallenge call */
+function challengeResponses(call: number) {
+  return mockRespondToAuthChallenge.mock.calls[call][0].challengeResponses;
+}
+
+beforeEach(() => {
+  jest.restoreAllMocks();
+  mockProcessTokens.mockClear();
+  mockInitiateAuth = jest.spyOn(
+    cognitoApi,
+    "initiateAuth"
+  ) as unknown as jest.MockedFunction<typeof cognitoApi.initiateAuth>;
+  mockRespondToAuthChallenge = jest.spyOn(
+    cognitoApi,
+    "respondToAuthChallenge"
+  ) as unknown as jest.MockedFunction<
+    typeof cognitoApi.respondToAuthChallenge
+  >;
+  mockHandleAuthResponse = jest.spyOn(
+    cognitoApi,
+    "handleAuthResponse"
+  ) as unknown as jest.MockedFunction<typeof cognitoApi.handleAuthResponse>;
+  mockConfirmDevice = jest.spyOn(
+    cognitoApi,
+    "confirmDevice"
+  ) as unknown as jest.MockedFunction<typeof cognitoApi.confirmDevice>;
+  configure({
+    clientId: "test-client",
+    userPoolId: "us-east-1_testpool",
+    storage: createMemoryStorage(),
+    // Real WebCrypto: the SRP signature is computed for real
+    crypto: webcrypto as unknown as MinimalCrypto,
+  });
+  mockInitiateAuth.mockResolvedValue(passwordVerifierChallenge());
+  mockRespondToAuthChallenge.mockResolvedValue(authenticatedResult());
+  mockHandleAuthResponse.mockImplementation(({ username }) =>
+    Promise.resolve({
+      accessToken: "test-access-token",
+      idToken: "test-id-token",
+      refreshToken: "test-refresh-token",
+      expireAt: new Date(Date.now() + 3600 * 1000),
+      username,
+      deviceKey: undefined,
+      newDeviceMetadata: undefined,
+    })
+  );
+  mockProcessTokens.mockImplementation((tokens) => Promise.resolve(tokens));
+});
+
+describe("authenticateWithSRP device key handling", () => {
+  test("sends DEVICE_KEY from a complete remembered record", async () => {
+    await setRememberedDevice(USER_ID_FOR_SRP, {
+      deviceKey: "remembered-device-key",
+      groupKey: "group-key",
+      password: "device-password",
+      remembered: true,
+    });
+
+    await authenticateWithSRP({
+      username: "alice@example.com",
+      password: "secret",
+    }).signedIn;
+
+    expect(mockRespondToAuthChallenge).toHaveBeenCalledTimes(1);
+    expect(challengeResponses(0).DEVICE_KEY).toBe("remembered-device-key");
+  });
+
+  test("does not send a device key from a placeholder record without device password", async () => {
+    // Placeholder records (created by storeDeviceKey without a confirmed
+    // device) have no device password: sending their key would make
+    // Cognito issue a DEVICE_SRP_AUTH challenge this client cannot answer
+    await setRememberedDevice(USER_ID_FOR_SRP, {
+      deviceKey: "shadow-device-key",
+      groupKey: "",
+      password: "",
+      remembered: false,
+    });
+
+    await authenticateWithSRP({
+      username: "alice@example.com",
+      password: "secret",
+    }).signedIn;
+
+    expect(mockRespondToAuthChallenge).toHaveBeenCalledTimes(1);
+    expect(challengeResponses(0).DEVICE_KEY).toBeUndefined();
+  });
+
+  test("clears the stale record and retries the challenge once without DEVICE_KEY", async () => {
+    // The device was forgotten server-side (e.g. forgetDevice from another
+    // browser) while the local record survived. Previously this PERMANENTLY
+    // bricked SRP sign-in: every attempt sent the stale key, Cognito
+    // rejected it, and the record was never cleared.
+    await setRememberedDevice(USER_ID_FOR_SRP, {
+      deviceKey: "stale-device-key",
+      groupKey: "group-key",
+      password: "device-password",
+      remembered: true,
+    });
+    mockRespondToAuthChallenge
+      .mockRejectedValueOnce(deviceNotFoundError())
+      .mockResolvedValueOnce(authenticatedResult());
+
+    const tokens = await authenticateWithSRP({
+      username: "alice@example.com",
+      password: "secret",
+    }).signedIn;
+
+    // Sign-in succeeded where it used to hard-fail, with a single
+    // initiateAuth (the SRP proof is unchanged, so the same signature and
+    // session are re-sent — mirroring amazon-cognito-identity-js)
+    expect(tokens.accessToken).toBe("test-access-token");
+    expect(mockInitiateAuth).toHaveBeenCalledTimes(1);
+    expect(mockRespondToAuthChallenge).toHaveBeenCalledTimes(2);
+    expect(challengeResponses(0).DEVICE_KEY).toBe("stale-device-key");
+    expect(challengeResponses(1).DEVICE_KEY).toBeUndefined();
+    expect(challengeResponses(1).PASSWORD_CLAIM_SIGNATURE).toBe(
+      challengeResponses(0).PASSWORD_CLAIM_SIGNATURE
+    );
+    expect(mockRespondToAuthChallenge.mock.calls[1][0].session).toBe(
+      mockRespondToAuthChallenge.mock.calls[0][0].session
+    );
+    // The stale record was cleared, so it won't be sent again
+    expect(await getRememberedDevice(USER_ID_FOR_SRP)).toBeUndefined();
+    // The retry must not hand a handler built around the rejected key to
+    // the challenge loop
+    expect(
+      mockHandleAuthResponse.mock.calls[0][0].deviceHandler
+    ).toBeUndefined();
+  });
+
+  test("does not retry on non-device errors", async () => {
+    await setRememberedDevice(USER_ID_FOR_SRP, {
+      deviceKey: "some-device-key",
+      groupKey: "group-key",
+      password: "device-password",
+      remembered: true,
+    });
+    const err = new Error("Incorrect username or password.");
+    err.name = "NotAuthorizedException";
+    mockRespondToAuthChallenge.mockRejectedValue(err);
+
+    await expect(
+      authenticateWithSRP({
+        username: "alice@example.com",
+        password: "secret",
+      }).signedIn
+    ).rejects.toThrow("Incorrect username or password.");
+
+    expect(mockRespondToAuthChallenge).toHaveBeenCalledTimes(1);
+    // Record untouched: the key was not the problem
+    expect(await getRememberedDevice(USER_ID_FOR_SRP)).toMatchObject({
+      deviceKey: "some-device-key",
+    });
+  });
+});
+
+describe("handleDeviceConfirmation failure", () => {
+  test("drops the unconfirmed device key: not set on tokens, nothing persisted", async () => {
+    // Regression: a failed ConfirmDevice used to set tokens.deviceKey
+    // anyway, which storeTokens then persisted as a placeholder record
+    // (no device password) — the planting mechanism for keys that get
+    // replayed on future sign-ins but can never complete device auth
+    mockConfirmDevice.mockRejectedValue(new Error("network error"));
+
+    const tokens: TokensFromSignIn = {
+      accessToken: "test-access-token",
+      idToken: "test-id-token",
+      refreshToken: "test-refresh-token",
+      expireAt: new Date(Date.now() + 3600 * 1000),
+      username: USER_ID_FOR_SRP,
+      newDeviceMetadata: {
+        deviceKey: "us-east-1_fresh-device",
+        deviceGroupKey: "fresh-group-key",
+      },
+    };
+
+    const result = await handleDeviceConfirmation(tokens);
+
+    expect(result.deviceKey).toBeUndefined();
+    expect(await getRememberedDevice(USER_ID_FOR_SRP)).toBeUndefined();
+  });
+
+  test("persists the full record when confirmation succeeds", async () => {
+    mockConfirmDevice.mockResolvedValue({
+      UserConfirmationNecessary: false,
+    } as unknown as Awaited<ReturnType<typeof cognitoApi.confirmDevice>>);
+
+    const tokens: TokensFromSignIn = {
+      accessToken: "test-access-token",
+      idToken: "test-id-token",
+      refreshToken: "test-refresh-token",
+      expireAt: new Date(Date.now() + 3600 * 1000),
+      username: USER_ID_FOR_SRP,
+      newDeviceMetadata: {
+        deviceKey: "us-east-1_fresh-device",
+        deviceGroupKey: "fresh-group-key",
+      },
+    };
+
+    const result = await handleDeviceConfirmation(tokens);
+
+    expect(result.deviceKey).toBe("us-east-1_fresh-device");
+    const record = await getRememberedDevice(USER_ID_FOR_SRP);
+    expect(record).toMatchObject({ deviceKey: "us-east-1_fresh-device" });
+    expect(record?.password).toBeTruthy();
+  });
+});

--- a/client/device.ts
+++ b/client/device.ts
@@ -33,6 +33,21 @@ import {
 } from "./storage.js";
 import { confirmDevice } from "./cognito-api.js";
 
+/**
+ * Cognito rejects a device key it no longer knows (device forgotten
+ * server-side, user pool migrated, ...) with a ResourceNotFoundException
+ * whose message mentions the device, e.g. "Device does not exist.".
+ * Same detection as amazon-cognito-identity-js uses before it clears its
+ * cached device data and retries without the device key.
+ */
+export function isDeviceNotFoundError(err: unknown): err is Error {
+  return (
+    err instanceof Error &&
+    err.name === "ResourceNotFoundException" &&
+    err.message.toLowerCase().includes("device")
+  );
+}
+
 // Helper function to get device info for naming
 function getDeviceName(): string {
   if (typeof navigator === "undefined") {
@@ -403,10 +418,19 @@ export async function handleDeviceConfirmation(
     );
     const errorMsg = error instanceof Error ? error.message : String(error);
     debug?.(`❌ [Device Confirmation] Error details: ${errorMsg}`);
-    // If device confirmation fails, we still set the deviceKey on the tokens object
-    // for the current session, but DON'T store it in persistent storage
-    // as it may be invalid for future authentication attempts
-    tokens.deviceKey = deviceKey;
+    // The device was NOT confirmed: drop the key entirely. Setting it on
+    // the tokens object used to leak it into persistent storage via
+    // storeTokens -> storeDeviceKey, creating a placeholder record (no
+    // device password) whose key would be replayed on future sign-ins but
+    // could never complete device auth. Without a confirmed device,
+    // Cognito issues fresh NewDeviceMetadata on a later sign-in and
+    // confirmation is retried cleanly then.
+    debug?.(
+      "❌ [Device Confirmation] Dropping unconfirmed device key (not stored, not set on tokens)"
+    );
+    // The key may already have been set if the failure happened after the
+    // ConfirmDevice call itself (e.g. while persisting the record)
+    delete tokens.deviceKey;
     return tokens;
   }
 }

--- a/client/plaintext.ts
+++ b/client/plaintext.ts
@@ -26,24 +26,12 @@ import {
   getRememberedDevice,
   setRememberedDevice,
 } from "./storage.js";
-import { createDeviceSrpAuthHandler } from "./device.js";
+import {
+  createDeviceSrpAuthHandler,
+  isDeviceNotFoundError,
+} from "./device.js";
 import { parseJwtPayload, redactTokensFromObject } from "./util.js";
 import { CognitoAccessTokenPayload } from "./jwt-model.js";
-
-/**
- * Cognito rejects a device key it no longer knows (device forgotten
- * server-side, user pool migrated, ...) with a ResourceNotFoundException
- * whose message mentions the device, e.g. "Device does not exist.".
- * Same detection as amazon-cognito-identity-js uses before it clears its
- * cached device data and retries without the device key.
- */
-function isDeviceNotFoundError(err: unknown): err is Error {
-  return (
-    err instanceof Error &&
-    err.name === "ResourceNotFoundException" &&
-    err.message.toLowerCase().includes("device")
-  );
-}
 
 export function authenticateWithPlaintextPassword({
   username,

--- a/client/srp.ts
+++ b/client/srp.ts
@@ -28,8 +28,11 @@ import {
   redactSecret,
   redactTokensFromObject,
 } from "./util.js";
-import { retrieveDeviceKey } from "./storage.js";
-import { createDeviceSrpAuthHandler } from "./device.js";
+import { getRememberedDevice, clearRememberedDevice } from "./storage.js";
+import {
+  createDeviceSrpAuthHandler,
+  isDeviceNotFoundError,
+} from "./device.js";
 
 let _CONSTANTS: { g: bigint; N: bigint; k: bigint } | undefined;
 async function getConstants() {
@@ -389,13 +392,34 @@ export function authenticateWithSRP({
         `Using USER_ID_FOR_SRP (${userIdForSrp}) for all authentication challenges`
       );
 
-      // Now that we have initiated auth and have userIdForSrp, we can retrieve the device key
-      // for this specific user
-      const actualDeviceKey =
-        deviceKey ?? (await retrieveDeviceKey(userIdForSrp));
+      // Now that we have initiated auth and have userIdForSrp, we can
+      // retrieve the device key for this specific user. Only a COMPLETE
+      // record (with a device password) is usable: placeholder records
+      // created by storeDeviceKey would make Cognito issue a
+      // DEVICE_SRP_AUTH challenge this client cannot answer (same guard as
+      // the plaintext flow).
+      let actualDeviceKey = deviceKey;
+      // The storage key the device key was found under (so we can clear
+      // that exact record if Cognito rejects the key as stale)
+      let deviceKeyUsername: string | undefined;
+      if (!actualDeviceKey) {
+        const record = await getRememberedDevice(userIdForSrp);
+        if (record?.deviceKey && record.password) {
+          actualDeviceKey = record.deviceKey;
+          deviceKeyUsername = userIdForSrp;
+        }
+      } else {
+        // An explicitly passed device key may also live in the user's
+        // stored record; remember where it lives, so a stale rejection
+        // clears that record too (not just the in-memory value)
+        const record = await getRememberedDevice(userIdForSrp);
+        if (record?.deviceKey === actualDeviceKey) {
+          deviceKeyUsername = userIdForSrp;
+        }
+      }
 
       // Pre-create a device SRP handler if we have a device key
-      const deviceHandler = actualDeviceKey
+      let deviceHandler = actualDeviceKey
         ? await createDeviceSrpAuthHandler(userIdForSrp, actualDeviceKey)
         : undefined;
 
@@ -432,13 +456,46 @@ export function authenticateWithSRP({
         challengeResponses.DEVICE_KEY = actualDeviceKey;
       }
 
-      const authResult = await respondToAuthChallenge({
-        challengeName: challenge.ChallengeName,
-        challengeResponses,
-        clientMetadata,
-        session: challenge.Session,
-        abort: abort.signal,
-      });
+      let authResult: Awaited<ReturnType<typeof respondToAuthChallenge>>;
+      try {
+        authResult = await respondToAuthChallenge({
+          challengeName: challenge.ChallengeName,
+          challengeResponses,
+          clientMetadata,
+          session: challenge.Session,
+          abort: abort.signal,
+        });
+      } catch (err) {
+        if (!actualDeviceKey || !isDeviceNotFoundError(err)) {
+          throw err;
+        }
+        // The device key we sent is stale: Cognito no longer knows the
+        // device. Clear the local record it came from and retry ONCE
+        // without the device key — the SRP password proof is unchanged, so
+        // the same signature and session are still valid (mirrors
+        // amazon-cognito-identity-js, which re-sends the PASSWORD_VERIFIER
+        // response with DEVICE_KEY nulled).
+        debug?.(
+          `Cognito rejected the device key (${err.message}), clearing the stale device record and retrying the challenge without it`
+        );
+        if (deviceKeyUsername) {
+          await clearRememberedDevice(deviceKeyUsername);
+        }
+        // Fresh object for the retry: the first request's object was
+        // already handed out and must not be mutated retroactively
+        const retryResponses = { ...challengeResponses };
+        delete retryResponses.DEVICE_KEY;
+        // The device is unknown server-side: no device challenges can
+        // follow, and a handler built around the stale key must not be used
+        deviceHandler = undefined;
+        authResult = await respondToAuthChallenge({
+          challengeName: challenge.ChallengeName,
+          challengeResponses: retryResponses,
+          clientMetadata,
+          session: challenge.Session,
+          abort: abort.signal,
+        });
+      }
       debug?.(
         `Response from respondToAuthChallenge:`,
         redactTokensFromObject(authResult)


### PR DESCRIPTION
## Summary
Second PR of the sequential follow-up series. The post-merge re-review's top production finding: all of #67's stale-device hardening lives only in the plaintext flow — the SRP flow (the most-used sign-in path) still sends placeholder-record keys and has **zero recovery** when Cognito rejects a stale device key, permanently bricking sign-in until storage is cleared by hand. This PR brings SRP to parity and kills the placeholder-planting mechanism at its root.

## Changes
- **Complete-record guard** (`srp.ts`): the pre-auth lookup only uses records with a device password; placeholder keys are never sent (they'd trigger a `DEVICE_SRP_AUTH` challenge the client can't answer). Explicitly passed keys are attributed to their stored record so a stale rejection clears it too.
- **Stale-key recovery** (`srp.ts`): on `ResourceNotFoundException` mentioning the device, clear the exact record the key came from and retry the `PASSWORD_VERIFIER` response once without `DEVICE_KEY` — the SRP proof is unchanged, so the same signature and session are re-sent, exactly as amazon-cognito-identity-js does. The retry uses a fresh responses object and discards any device handler built around the rejected key.
- **Root cause** (`device.ts`): a failed `ConfirmDevice` no longer sets `tokens.deviceKey` — that value was flowing into `storeTokens → storeDeviceKey` and persisting a password-less placeholder record, directly contradicting the adjacent comment ("DON'T store it in persistent storage"). Unconfirmed keys are now dropped entirely; Cognito issues fresh `NewDeviceMetadata` on a later sign-in and confirmation retries cleanly.
- `isDeviceNotFoundError` moved to `device.ts` and shared by both flows.

## Test plan
- New `client/__tests__/srp-device-key.test.ts` (6 tests, real SRP crypto + spied cognito-api): complete-record key sent; placeholder key never sent; stale key → record cleared, one same-session retry without the key, sign-in succeeds, single `initiateAuth`; no retry on non-device errors; failed confirmation persists nothing and sets nothing; successful confirmation persists the full record.
- The three behavior-changing tests fail on unfixed main; the parity/unchanged-behavior tests pass on both.
- Full suite: 422 passed / 0 failures; tsc and eslint clean.

Testing note: the suite spies on the cognito-api namespace rather than factory-mocking the module — `cognito-api.ts` and `device.ts` import each other, and a `requireActual` factory re-enters that cycle mid-construction and splits the module identity.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches primary SRP authentication and device persistence; behavior changes fix sign-in bricking but alter how device keys are sent and stored on failure paths.
> 
> **Overview**
> Brings **SRP sign-in** device-key behavior in line with the plaintext flow and stops unconfirmed device keys from being persisted.
> 
> **SRP (`srp.ts`)** now loads remembered devices only when the stored record includes a device password (placeholder keys are omitted so Cognito does not issue `DEVICE_SRP_AUTH` the client cannot answer). On Cognito `ResourceNotFoundException` for a stale device, it clears the matching local record and retries `PASSWORD_VERIFIER` once without `DEVICE_KEY`, reusing the same SRP signature and session; the device handler is dropped on retry.
> 
> **Device confirmation (`device.ts`)** no longer sets `tokens.deviceKey` when `ConfirmDevice` fails—avoiding `storeTokens` → `storeDeviceKey` placeholder records that could brick future sign-ins. **`isDeviceNotFoundError`** is exported from `device.ts` for shared use (removed from `plaintext.ts`).
> 
> Adds **`client/__tests__/srp-device-key.test.ts`** with six tests covering complete vs placeholder keys, stale-key recovery, non-device errors, and confirmation success/failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d564bc2bc8861cc840cc4f1a5ae4f7f9da322c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->