### PR TITLE
Fix sign-out and lock liveness: timeout fallback, heartbeat cap, orphan takeover

### DIFF
--- a/client/common.ts
+++ b/client/common.ts
@@ -527,17 +527,33 @@ export const signOut = (props?: {
     };
     if (lockKey) {
       debug?.("signOut: waiting for lock", lockKey);
-      const result = await withStorageLock(
-        lockKey,
-        async () => {
-          debug?.("signOut: lock acquired", lockKey);
-          return doSignOut();
-        },
-        undefined,
-        abort.signal
-      );
-      debug?.("signOut: lock released", lockKey);
-      return result;
+      try {
+        const result = await withStorageLock(
+          lockKey,
+          async () => {
+            debug?.("signOut: lock acquired", lockKey);
+            return doSignOut();
+          },
+          undefined,
+          abort.signal
+        );
+        debug?.("signOut: lock released", lockKey);
+        return result;
+      } catch (err) {
+        if (!(err instanceof LockTimeoutError)) {
+          throw err;
+        }
+        // Sign-out must eventually win. The holder is most likely a hung or
+        // throttled refresh in another tab (its heartbeat is capped, but we
+        // won't make the user wait that out): proceed without the lock. A
+        // concurrent refresh that loses this race re-validates the session
+        // before acting on its result.
+        debug?.(
+          "signOut: could not acquire lock, signing out without it",
+          lockKey
+        );
+        return doSignOut();
+      }
     }
     debug?.("signOut: no lock key, running unlocked");
     return doSignOut();

--- a/client/common.ts
+++ b/client/common.ts
@@ -54,6 +54,45 @@ const activeRefreshSchedules = new Map<
 >();
 
 /**
+ * Storage key of the sign-out tombstone. signOut writes it BEFORE removing
+ * the session keys; the refresh path checks it immediately before and after
+ * writing refreshed tokens back, so a sign-out racing an in-flight refresh
+ * stays signed out in every interleaving. A fresh sign-in clears it.
+ */
+function signedOutTombstoneKey(clientId: string, username: string) {
+  return `Passwordless.${clientId}.${username}.signedOutAt`;
+}
+
+/**
+ * Remove the per-user session keys from storage. Shared by signOut's
+ * teardown and the refresh path's compensating cleanup (when a sign-out
+ * lands inside the refresh's check-to-write window). Deliberately does NOT
+ * remove the sign-out tombstone or the device key.
+ */
+async function removeSessionKeysFromStorage(username: string) {
+  const { clientId, storage } = configure();
+  const amplifyKeyPrefix = `CognitoIdentityServiceProvider.${clientId}`;
+  const customKeyPrefix = `Passwordless.${clientId}`;
+  await Promise.all([
+    storage.removeItem(`${amplifyKeyPrefix}.${username}.idToken`),
+    storage.removeItem(`${amplifyKeyPrefix}.${username}.accessToken`),
+    storage.removeItem(`${amplifyKeyPrefix}.${username}.refreshToken`),
+    storage.removeItem(`${amplifyKeyPrefix}.${username}.tokenScopesString`),
+    storage.removeItem(`${amplifyKeyPrefix}.${username}.userData`),
+    storage.removeItem(`${amplifyKeyPrefix}.LastAuthUser`),
+    storage.removeItem(`${amplifyKeyPrefix}.${username}.clockDriftMs`),
+    storage.removeItem(`${customKeyPrefix}.${username}.authMethod`),
+    storage.removeItem(`${customKeyPrefix}.${username}.lastRefreshAttempt`),
+    storage.removeItem(`${customKeyPrefix}.${username}.lastRefreshCompleted`),
+    // Legacy keys no longer written by current versions, removed for
+    // migration hygiene
+    storage.removeItem(`${customKeyPrefix}.${username}.expireAt`),
+    storage.removeItem(`${customKeyPrefix}.${username}.refreshingTokens`),
+    // Note: We do NOT remove deviceKey - it should persist between sessions
+  ]);
+}
+
+/**
  * Process tokens after authentication or refresh.
  * This function handles ALL required operations:
  * 1. Device confirmation
@@ -67,7 +106,17 @@ const activeRefreshSchedules = new Map<
  */
 async function processTokensInternal(
   tokens: TokensFromSignIn | TokensFromRefresh,
-  abort?: AbortSignal
+  abort?: AbortSignal,
+  opts?: {
+    /**
+     * Set by the refresh path: the session (same user, refresh token
+     * present, no sign-out tombstone newer than this timestamp) must still
+     * exist in storage immediately before the refreshed tokens are written
+     * back — and is re-checked right after the write — so a refresh racing
+     * a sign-out can never resurrect the signed-out session.
+     */
+    sessionMustExistSince?: number;
+  }
 ): Promise<TokensFromSignIn | TokensFromRefresh> {
   const { debug } = configure();
 
@@ -186,8 +235,68 @@ async function processTokensInternal(
     }
   }
 
+  const {
+    clientId: clientIdForGuard,
+    storage: storageForGuard,
+  } = configure();
+  const tombstoneKey = normalizedTokens.username
+    ? signedOutTombstoneKey(clientIdForGuard, normalizedTokens.username)
+    : undefined;
+  const discardRefreshedTokens = () =>
+    new Error(
+      "Session was signed out during the token refresh; refreshed tokens discarded"
+    );
+  if (opts?.sessionMustExistSince !== undefined && tombstoneKey) {
+    // Authoritative pre-write check, kept immediately before the write so
+    // the remaining race window is the write itself (covered by the
+    // post-write compensation below)
+    const tombstone = Number(
+      (await storageForGuard.getItem(tombstoneKey)) ?? 0
+    );
+    const lastAuthUser = await storageForGuard.getItem(
+      `CognitoIdentityServiceProvider.${clientIdForGuard}.LastAuthUser`
+    );
+    const storedRefreshToken = lastAuthUser
+      ? await storageForGuard.getItem(
+          `CognitoIdentityServiceProvider.${clientIdForGuard}.${lastAuthUser}.refreshToken`
+        )
+      : null;
+    if (
+      tombstone >= opts.sessionMustExistSince ||
+      lastAuthUser !== normalizedTokens.username ||
+      !storedRefreshToken
+    ) {
+      debug?.(
+        "🔄 [Process Tokens] Session was signed out before the refreshed tokens could be stored; discarding"
+      );
+      throw discardRefreshedTokens();
+    }
+  }
+
   // Store the already normalized tokens
   await storeTokens(normalizedTokens);
+
+  if (opts?.sessionMustExistSince !== undefined && tombstoneKey) {
+    // Compensating post-write check: a sign-out that began inside the tiny
+    // pre-check→write window left its tombstone (signOut writes it BEFORE
+    // removing keys). Undo our write so the sign-out stays won.
+    const tombstone = Number(
+      (await storageForGuard.getItem(tombstoneKey)) ?? 0
+    );
+    if (tombstone >= opts.sessionMustExistSince) {
+      debug?.(
+        "🔄 [Process Tokens] Sign-out raced the token write; removing the just-written session"
+      );
+      if (normalizedTokens.username) {
+        await removeSessionKeysFromStorage(normalizedTokens.username);
+      }
+      throw discardRefreshedTokens();
+    }
+  } else if (tombstoneKey) {
+    // Fresh sign-in: clear any stale sign-out tombstone so it cannot
+    // interfere with this session's future refreshes
+    await storageForGuard.removeItem(tombstoneKey);
+  }
   debug?.("🔄 [Process Tokens] After storeTokens, tokens:", {
     hasAccessToken: !!normalizedTokens.accessToken,
     hasIdToken: !!normalizedTokens.idToken,
@@ -317,7 +426,8 @@ async function processTokensInternal(
  */
 export async function processTokens(
   tokens: TokensFromSignIn | TokensFromRefresh,
-  abort?: AbortSignal
+  abort?: AbortSignal,
+  opts?: Parameters<typeof processTokensInternal>[2]
 ): Promise<TokensFromSignIn | TokensFromRefresh> {
   const { clientId, debug } = configure();
 
@@ -347,7 +457,7 @@ export async function processTokens(
   try {
     return await withStorageLock(
       lockKey,
-      async () => processTokensInternal(tokens, abort),
+      async () => processTokensInternal(tokens, abort, opts),
       undefined, // use default timeout
       abort
     );
@@ -487,32 +597,18 @@ export const signOut = (props?: {
           }
         };
 
+        // Tombstone FIRST, before revocation and removals: an in-flight
+        // refresh re-checks it immediately before AND after writing tokens
+        // back, so whichever way the race interleaves, the sign-out wins
+        await storage.setItem(
+          signedOutTombstoneKey(clientId, username),
+          Date.now().toString()
+        );
+
         if (props?.revokeTokensBeforeLocalRemoval) {
           await revokeRefreshTokenOnce();
         }
-        await Promise.all([
-          storage.removeItem(`${amplifyKeyPrefix}.${username}.idToken`),
-          storage.removeItem(`${amplifyKeyPrefix}.${username}.accessToken`),
-          storage.removeItem(`${amplifyKeyPrefix}.${username}.refreshToken`),
-          storage.removeItem(
-            `${amplifyKeyPrefix}.${username}.tokenScopesString`
-          ),
-          storage.removeItem(`${amplifyKeyPrefix}.${username}.userData`),
-          storage.removeItem(`${amplifyKeyPrefix}.LastAuthUser`),
-          storage.removeItem(`${amplifyKeyPrefix}.${username}.clockDriftMs`),
-          storage.removeItem(`${customKeyPrefix}.${username}.authMethod`),
-          storage.removeItem(
-            `${customKeyPrefix}.${username}.lastRefreshAttempt`
-          ),
-          storage.removeItem(
-            `${customKeyPrefix}.${username}.lastRefreshCompleted`
-          ),
-          // Legacy keys no longer written by current versions, removed for
-          // migration hygiene
-          storage.removeItem(`${customKeyPrefix}.${username}.expireAt`),
-          storage.removeItem(`${customKeyPrefix}.${username}.refreshingTokens`),
-          // Note: We do NOT remove deviceKey - it should persist between sessions
-        ]);
+        await removeSessionKeysFromStorage(username);
         props?.tokensRemovedLocallyCb?.();
 
         await revokeRefreshTokenOnce();

--- a/client/lock.ts
+++ b/client/lock.ts
@@ -25,9 +25,22 @@ export class LockTimeoutError extends Error {
 }
 
 const DEFAULT_RETRY_DELAY_MS = 50;
-const DEFAULT_TIMEOUT_MS = 15000; // 15 seconds to accommodate worst-case refresh (9s) + buffer
 const STALE_LOCK_TIMEOUT_MS = 30000; // 30 seconds without a heartbeat renewal
+// The default acquisition timeout MUST exceed the stale threshold (plus a
+// takeover margin): a lock orphaned by an abruptly closed page keeps its
+// last timestamp forever, and a waiter that gives up before the orphan CAN
+// go stale is guaranteed a LockTimeoutError — worst case the OAuth
+// callback's token exchange right after a redirect, when the one-time
+// authorization code is already spent.
+const DEFAULT_TIMEOUT_MS = STALE_LOCK_TIMEOUT_MS + 15000;
 const LOCK_HEARTBEAT_INTERVAL_MS = 10000; // renew held locks well within the stale timeout
+// Stop renewing the heartbeat after this long. A hung critical section
+// (e.g. a refresh fetch stuck on a dead connection) must not hold the lock
+// forever: once renewals stop, the lock goes stale within
+// STALE_LOCK_TIMEOUT_MS and other tabs (e.g. a user signing out) can take
+// over. Generous compared to the worst-case legitimate hold (a refresh
+// with retries and slow networks is tens of seconds).
+const MAX_LOCK_HOLD_MS = 120000;
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -241,12 +254,26 @@ export async function withStorageLock<T>(
   // stale and taken over by other tabs. If we ever detect that we no longer
   // (safely) hold the lock, stop renewing for good rather than risk
   // clobbering another tab's legitimate takeover
+  const holdStart = Date.now();
   let released = false;
   let lockLost = false;
   let heartbeatInFlight: Promise<void> = Promise.resolve();
   const renewLock = async () => {
     try {
       if (released || lockLost) {
+        return;
+      }
+      if (Date.now() - holdStart > MAX_LOCK_HOLD_MS) {
+        // The critical section has been running implausibly long (hung
+        // fetch, suspended tab, ...). Stop renewing so the lock can go
+        // stale and be taken over; if fn() does eventually finish, release
+        // below still removes the lock if it is still ours.
+        clearInterval(heartbeat);
+        debug?.(
+          "withStorageLock: max lock hold time reached, heartbeat stopped so the lock can go stale",
+          key,
+          { heldMs: Date.now() - holdStart }
+        );
         return;
       }
       const currentValue = await storage.getItem(key);

--- a/client/refresh.ts
+++ b/client/refresh.ts
@@ -611,6 +611,9 @@ export async function refreshTokens({
   const lockKey = `Passwordless.${clientId}.${userIdentifier}.refreshLock`;
 
   const doRefresh = async (): Promise<TokensFromRefresh> => {
+    // A sign-out tombstone newer than this moment means the user signed
+    // out while this refresh was in flight; the result must be discarded
+    const refreshStart = Date.now();
     // Get state for this user
     const state = getRefreshState(userIdentifier);
 
@@ -814,10 +817,12 @@ export async function refreshTokens({
 
       let processedTokens: TokensFromRefresh;
       try {
-        processedTokens = (await processTokens(
-          tokensFromRefresh,
-          abort
-        )) as TokensFromRefresh;
+        processedTokens = (await processTokens(tokensFromRefresh, abort, {
+          // The authoritative race guard: processTokens re-validates the
+          // session (and the sign-out tombstone) immediately before AND
+          // after the write, under the auth lock
+          sessionMustExistSince: refreshStart,
+        })) as TokensFromRefresh;
         state.lastRefreshTime = Date.now();
 
         // Call tokensCb first - if it fails, we don't want to mark as completed

--- a/client/refresh.ts
+++ b/client/refresh.ts
@@ -791,6 +791,27 @@ export async function refreshTokens({
         throw error;
       }
 
+      // The refresh round-trip may have raced a sign-out that proceeded
+      // without the refresh lock (signOut falls back to an unlocked
+      // teardown when lock acquisition times out). Re-validate that the
+      // session still exists in storage before writing anything back:
+      // storing now would resurrect the session the user just signed out
+      // of. (A rotated refresh token, if any, dies with this discard —
+      // RevokeToken revokes the whole token family, so it is unusable.)
+      const sessionStillExists = await retrieveTokensForRefresh();
+      if (
+        !sessionStillExists?.refreshToken ||
+        sessionStillExists.username !== username
+      ) {
+        logDebug(
+          "Session was signed out during the refresh round-trip; discarding refreshed tokens"
+        );
+        await clearRefreshAttemptLock();
+        throw new Error(
+          "Session was signed out during the token refresh; refreshed tokens discarded"
+        );
+      }
+
       let processedTokens: TokensFromRefresh;
       try {
         processedTokens = (await processTokens(

--- a/test/lock-liveness.test.ts
+++ b/test/lock-liveness.test.ts
@@ -1,0 +1,160 @@
+import { configure } from "../client/config.js";
+import { withStorageLock, LockTimeoutError } from "../client/lock.js";
+
+const KEY = "Passwordless.testClient.testuser.refreshLock";
+
+function createMemoryStorage() {
+  const store = new Map<string, string>();
+  return {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      store.set(key, value);
+    },
+    removeItem: (key: string) => {
+      store.delete(key);
+    },
+    _store: store,
+  };
+}
+
+let storage: ReturnType<typeof createMemoryStorage>;
+
+// Drive a promise to settlement under fake timers by advancing time in
+// steps (the lock's poll loops, jitters and heartbeats all use timers)
+async function drive<T>(
+  promise: Promise<T>,
+  maxSteps: number,
+  stepMs: number
+): Promise<{ settled: boolean; value?: T; error?: unknown }> {
+  const outcome: { settled: boolean; value?: T; error?: unknown } = {
+    settled: false,
+  };
+  promise.then(
+    (value) => {
+      outcome.settled = true;
+      outcome.value = value;
+    },
+    (error) => {
+      outcome.settled = true;
+      outcome.error = error;
+    }
+  );
+  for (let i = 0; i < maxSteps && !outcome.settled; i++) {
+    await jest.advanceTimersByTimeAsync(stepMs);
+  }
+  return outcome;
+}
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  storage = createMemoryStorage();
+  configure({
+    clientId: "testClient",
+    cognitoIdpEndpoint: "us-west-2",
+    storage,
+  });
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+describe("lock liveness", () => {
+  test("a waiter outlasts an orphaned lock: default timeout exceeds the stale threshold", async () => {
+    // A page killed mid-critical-section leaves its lock behind with a
+    // fresh timestamp and no process to renew or release it. The waiter's
+    // default timeout must be long enough for the orphan to go stale
+    // (30s) and be taken over — previously the default was 15s, so every
+    // waiter starting within ~15s of the orphan's last heartbeat was
+    // GUARANTEED a LockTimeoutError.
+    storage.setItem(
+      KEY,
+      JSON.stringify({ id: "orphaned-by-dead-page", timestamp: Date.now() })
+    );
+
+    const outcome = await drive(
+      withStorageLock(KEY, async () => "acquired"),
+      60,
+      1000
+    );
+
+    expect(outcome.settled).toBe(true);
+    expect(outcome.error).toBeUndefined();
+    expect(outcome.value).toBe("acquired");
+  });
+
+  test("heartbeat renewals are capped: a hung critical section loses the lock to a takeover", async () => {
+    // A refresh fetch stuck on a dead connection used to renew the lock's
+    // heartbeat forever, making the lock unstealable — no other tab could
+    // refresh or sign out. Renewals now stop after MAX_LOCK_HOLD_MS, the
+    // lock goes stale, and a contender takes over.
+    let releaseHang!: () => void;
+    const hang = new Promise<void>((resolve) => {
+      releaseHang = resolve;
+    });
+    const holderOutcome: { value?: string } = {};
+    void withStorageLock(KEY, async () => {
+      await hang;
+      return "holder-finished";
+    }).then((v) => {
+      holderOutcome.value = v;
+    });
+
+    // Let the holder acquire (poll + ownership-verify jitter)
+    await jest.advanceTimersByTimeAsync(100);
+    expect(storage.getItem(KEY)).toBeTruthy();
+
+    // Advance past the hold cap plus one heartbeat interval: renewals stop
+    await jest.advanceTimersByTimeAsync(135_000);
+    // ... then past the stale threshold with no renewals landing
+    await jest.advanceTimersByTimeAsync(31_000);
+
+    // A contender must now be able to clear the stale lock and acquire
+    const takeover = await drive(
+      withStorageLock(KEY, async () => "taken-over"),
+      30,
+      1000
+    );
+    expect(takeover.settled).toBe(true);
+    expect(takeover.error).toBeUndefined();
+    expect(takeover.value).toBe("taken-over");
+
+    // The hung holder eventually finishes; it must not clobber anything
+    // (its release only removes the lock if it still owns it)
+    releaseHang();
+    await jest.advanceTimersByTimeAsync(1000);
+    expect(holderOutcome.value).toBe("holder-finished");
+  });
+
+  test("a healthy long critical section is still protected by the heartbeat within the cap", async () => {
+    // Sanity check that the cap did not break the heartbeat's purpose: a
+    // legitimate 60s critical section (well under the cap) keeps the lock
+    // fresh, and a contender waits its full timeout rather than stealing.
+    let releaseHang!: () => void;
+    const hang = new Promise<void>((resolve) => {
+      releaseHang = resolve;
+    });
+    const holder = withStorageLock(KEY, async () => {
+      await hang;
+      return "ok";
+    });
+    await jest.advanceTimersByTimeAsync(100);
+
+    // Contender with a short explicit timeout starts at t≈0 of the hold;
+    // the holder renews every 10s, so the lock never goes stale and the
+    // contender must time out
+    const contender = await drive(
+      withStorageLock(KEY, async () => "stolen", 20_000),
+      30,
+      1000
+    );
+    expect(contender.settled).toBe(true);
+    expect(contender.error).toBeInstanceOf(LockTimeoutError);
+
+    releaseHang();
+    await jest.advanceTimersByTimeAsync(1000);
+    await expect(holder).resolves.toBe("ok");
+    // Released cleanly
+    expect(storage.getItem(KEY)).toBeNull();
+  });
+});

--- a/test/refresh-comprehensive.test.ts
+++ b/test/refresh-comprehensive.test.ts
@@ -266,9 +266,12 @@ describe("Refresh System Comprehensive Tests", () => {
         clientId: "testClient",
         cognitoIdpEndpoint: "us-west-2",
         fetch: fetchMock,
-        storage: localStorage as unknown as Parameters<
-          typeof configure
-        >[0]["storage"],
+        // Keep the SAME storage the tokens above were seeded into: the
+        // reuse-recovery re-reads the latest refresh token from storage,
+        // and the post-refresh session re-validation checks the session
+        // still exists there (switching to the global localStorage here
+        // only ever worked via leftovers from earlier tests)
+        storage: mockStorage,
         useGetTokensFromRefreshToken: true,
         debug: (...args: unknown[]) => {
           debugLogs.push(args.map(String).join(" "));

--- a/test/refresh-signout-race.test.ts
+++ b/test/refresh-signout-race.test.ts
@@ -1,0 +1,176 @@
+import { configure } from "../client/config.js";
+import { refreshTokens } from "../client/refresh.js";
+import { storeTokens } from "../client/storage.js";
+import { signOut } from "../client/common.js";
+
+// Helper to create JWT tokens
+const createJWT = (claims: Record<string, unknown>) => {
+  const header = btoa(JSON.stringify({ alg: "HS256", typ: "JWT" }))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+  const payload = btoa(JSON.stringify(claims))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+  return `${header}.${payload}.signature`;
+};
+
+function createMemoryStorage() {
+  const store = new Map<string, string>();
+  return {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      store.set(key, value);
+    },
+    removeItem: (key: string) => {
+      store.delete(key);
+    },
+  };
+}
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+test("a refresh completing after an unlocked sign-out must not resurrect the session", async () => {
+  // The exact scenario the signOut lock-timeout fallback creates: the
+  // refresh holds the lock with a hung network call, signOut waits out its
+  // acquisition timeout and tears the session down WITHOUT the lock, and
+  // then the refresh's response finally lands. The refresh must discard
+  // its result instead of re-storing the session.
+  jest.useFakeTimers();
+  const username = "testuser";
+  const now = Date.now();
+
+  let releaseRefreshResponse!: (value: unknown) => void;
+  const hangingRefreshResponse = new Promise((resolve) => {
+    releaseRefreshResponse = resolve;
+  });
+
+  const fetchMock = jest.fn(
+    (url: unknown, init?: { headers?: Record<string, string> }) => {
+      const target = init?.headers?.["x-amz-target"] ?? "";
+      if (target.endsWith("GetTokensFromRefreshToken")) {
+        // The refresh round-trip hangs until the test releases it
+        return hangingRefreshResponse.then(() => ({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            AuthenticationResult: {
+              AccessToken: createJWT({
+                sub: "user123",
+                username,
+                exp: Math.floor((now + 7200_000) / 1000),
+                iat: Math.floor(now / 1000),
+              }),
+              IdToken: createJWT({
+                sub: "user123",
+                "cognito:username": username,
+                exp: Math.floor((now + 7200_000) / 1000),
+                iat: Math.floor(now / 1000),
+              }),
+              ExpiresIn: 3600,
+              TokenType: "Bearer",
+              RefreshToken: "rotated-refresh-token",
+            },
+          }),
+        }));
+      }
+      // RevokeToken and anything else: immediate success
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: async () => ({}),
+      });
+    }
+  );
+
+  const storage = createMemoryStorage();
+  configure({
+    clientId: "testClient",
+    cognitoIdpEndpoint: "us-west-2",
+    storage,
+    fetch: fetchMock as unknown as typeof fetch,
+  });
+
+  await storeTokens({
+    accessToken: createJWT({
+      sub: "user123",
+      username,
+      scope: "openid",
+      exp: Math.floor((now + 3600_000) / 1000),
+      iat: Math.floor(now / 1000),
+    }),
+    idToken: createJWT({
+      sub: "user123",
+      "cognito:username": username,
+      exp: Math.floor((now + 3600_000) / 1000),
+      iat: Math.floor(now / 1000),
+    }),
+    refreshToken: "original-refresh-token",
+    authMethod: "SRP",
+    expireAt: new Date(now + 3600_000),
+  });
+
+  // 1. Start the refresh; it acquires the lock and hangs on the network
+  const refreshOutcome: { done: boolean; error?: unknown } = { done: false };
+  refreshTokens().then(
+    () => {
+      refreshOutcome.done = true;
+    },
+    (error) => {
+      refreshOutcome.done = true;
+      refreshOutcome.error = error;
+    }
+  );
+  await jest.advanceTimersByTimeAsync(3_000);
+  expect(
+    fetchMock.mock.calls.some(([, init]) =>
+      (init as { headers?: Record<string, string> })?.headers?.[
+        "x-amz-target"
+      ]?.endsWith("GetTokensFromRefreshToken")
+    )
+  ).toBe(true);
+
+  // 2. Sign out: the lock is held (and heartbeat-renewed) by the hung
+  //    refresh, so signOut waits out its timeout and falls back to the
+  //    unlocked teardown
+  const signOutOutcome: { done: boolean; error?: unknown } = { done: false };
+  signOut().signedOut.then(
+    () => {
+      signOutOutcome.done = true;
+    },
+    (error) => {
+      signOutOutcome.done = true;
+      signOutOutcome.error = error;
+    }
+  );
+  for (let i = 0; i < 90 && !signOutOutcome.done; i++) {
+    await jest.advanceTimersByTimeAsync(1000);
+  }
+  expect(signOutOutcome.done).toBe(true);
+  expect(signOutOutcome.error).toBeUndefined();
+
+  const amplifyKeyPrefix = `CognitoIdentityServiceProvider.testClient`;
+  expect(storage.getItem(`${amplifyKeyPrefix}.LastAuthUser`)).toBeNull();
+
+  // 3. The hung refresh response finally lands: the refresh must detect
+  //    the sign-out and discard its result
+  releaseRefreshResponse(undefined);
+  for (let i = 0; i < 20 && !refreshOutcome.done; i++) {
+    await jest.advanceTimersByTimeAsync(1000);
+  }
+  expect(refreshOutcome.done).toBe(true);
+  expect(refreshOutcome.error).toBeInstanceOf(Error);
+  expect(String(refreshOutcome.error)).toContain("signed out during");
+
+  // The session must STAY signed out: nothing re-stored
+  expect(storage.getItem(`${amplifyKeyPrefix}.LastAuthUser`)).toBeNull();
+  expect(
+    storage.getItem(`${amplifyKeyPrefix}.${username}.refreshToken`)
+  ).toBeNull();
+  expect(
+    storage.getItem(`${amplifyKeyPrefix}.${username}.accessToken`)
+  ).toBeNull();
+});

--- a/test/refresh-signout-race.test.ts
+++ b/test/refresh-signout-race.test.ts
@@ -1,7 +1,7 @@
 import { configure } from "../client/config.js";
 import { refreshTokens } from "../client/refresh.js";
 import { storeTokens } from "../client/storage.js";
-import { signOut } from "../client/common.js";
+import { signOut, processTokens } from "../client/common.js";
 
 // Helper to create JWT tokens
 const createJWT = (claims: Record<string, unknown>) => {
@@ -173,4 +173,115 @@ test("a refresh completing after an unlocked sign-out must not resurrect the ses
   expect(
     storage.getItem(`${amplifyKeyPrefix}.${username}.accessToken`)
   ).toBeNull();
+});
+
+describe("sign-out tombstone protocol", () => {
+  const username = "testuser";
+  const TOMBSTONE_KEY = `Passwordless.testClient.${username}.signedOutAt`;
+  const AMPLIFY_PREFIX = `CognitoIdentityServiceProvider.testClient`;
+  const now = () => Date.now();
+
+  const sessionTokens = (refreshToken: string) => ({
+    accessToken: createJWT({
+      sub: "user123",
+      username,
+      exp: Math.floor((now() + 3600_000) / 1000),
+      iat: Math.floor(now() / 1000),
+    }),
+    idToken: createJWT({
+      sub: "user123",
+      "cognito:username": username,
+      exp: Math.floor((now() + 3600_000) / 1000),
+      iat: Math.floor(now() / 1000),
+    }),
+    refreshToken,
+    username,
+    authMethod: "SRP" as const,
+    expireAt: new Date(now() + 3600_000),
+  });
+
+  test("a tombstone planted before the write discards the refreshed tokens", async () => {
+    const storage = createMemoryStorage();
+    configure({
+      clientId: "testClient",
+      cognitoIdpEndpoint: "us-west-2",
+      storage,
+    });
+    await storeTokens(sessionTokens("original-refresh-token"));
+
+    const since = now();
+    storage.setItem(TOMBSTONE_KEY, String(now()));
+
+    await expect(
+      processTokens(sessionTokens("rotated-refresh-token"), undefined, {
+        sessionMustExistSince: since,
+      })
+    ).rejects.toThrow("signed out during");
+
+    // The write never happened
+    expect(storage.getItem(`${AMPLIFY_PREFIX}.${username}.refreshToken`)).toBe(
+      "original-refresh-token"
+    );
+  });
+
+  test("a sign-out landing inside the check-to-write window is undone by the post-write compensation", async () => {
+    const storage = createMemoryStorage();
+    // Simulate signOut's FIRST action (the tombstone write) landing exactly
+    // while storeTokens is writing the rotated session: the moment the
+    // rotated refresh token hits storage, the tombstone appears
+    const baseSetItem = storage.setItem.bind(storage);
+    storage.setItem = (key: string, value: string) => {
+      baseSetItem(key, value);
+      if (
+        key === `${AMPLIFY_PREFIX}.${username}.refreshToken` &&
+        value === "rotated-refresh-token"
+      ) {
+        baseSetItem(TOMBSTONE_KEY, String(now()));
+      }
+    };
+    configure({
+      clientId: "testClient",
+      cognitoIdpEndpoint: "us-west-2",
+      storage,
+    });
+    await storeTokens(sessionTokens("original-refresh-token"));
+
+    const since = now();
+    await expect(
+      processTokens(sessionTokens("rotated-refresh-token"), undefined, {
+        sessionMustExistSince: since,
+      })
+    ).rejects.toThrow("signed out during");
+
+    // The just-written session was compensatingly removed: the sign-out won
+    expect(
+      storage.getItem(`${AMPLIFY_PREFIX}.${username}.refreshToken`)
+    ).toBeNull();
+    expect(
+      storage.getItem(`${AMPLIFY_PREFIX}.${username}.accessToken`)
+    ).toBeNull();
+    expect(storage.getItem(`${AMPLIFY_PREFIX}.LastAuthUser`)).toBeNull();
+    // The tombstone survives the compensation
+    expect(storage.getItem(TOMBSTONE_KEY)).toBeTruthy();
+  });
+
+  test("a fresh sign-in clears a stale tombstone", async () => {
+    const storage = createMemoryStorage();
+    configure({
+      clientId: "testClient",
+      cognitoIdpEndpoint: "us-west-2",
+      storage,
+    });
+    storage.setItem(TOMBSTONE_KEY, String(now() - 60_000));
+
+    const processed = await processTokens(
+      sessionTokens("fresh-signin-refresh-token")
+    );
+
+    expect(processed.refreshToken).toBe("fresh-signin-refresh-token");
+    expect(storage.getItem(TOMBSTONE_KEY)).toBeNull();
+    expect(storage.getItem(`${AMPLIFY_PREFIX}.${username}.refreshToken`)).toBe(
+      "fresh-signin-refresh-token"
+    );
+  });
 });

--- a/test/scheduleRefresh.test.ts
+++ b/test/scheduleRefresh.test.ts
@@ -36,44 +36,70 @@ describe("ScheduleRefresh Lock", () => {
     expect(duration).toBeLessThan(100);
   });
 
-  test("should return silently when lock is held by another process", async () => {
-    // First, store minimal user data so scheduleRefresh knows there's a user
-    const { storage } = configure();
-    const amplifyKeyPrefix = `CognitoIdentityServiceProvider.testClient`;
-    const customKeyPrefix = `Passwordless.testClient`;
+  test("should return silently when lock is held by another (renewing) tab", async () => {
+    // A lock held by a LIVE tab is renewed via heartbeat; scheduleRefresh
+    // waits out its acquisition timeout and then returns silently, assuming
+    // the other tab is handling the refresh. (A lock that is NOT renewed
+    // goes stale after 30s and is taken over instead — that liveness
+    // behavior is covered in lock-liveness.test.ts.)
+    jest.useFakeTimers();
+    try {
+      const { storage } = configure();
+      const amplifyKeyPrefix = `CognitoIdentityServiceProvider.testClient`;
+      const customKeyPrefix = `Passwordless.testClient`;
 
-    await storage.setItem(`${amplifyKeyPrefix}.LastAuthUser`, "testuser");
-    await storage.setItem(
-      `${amplifyKeyPrefix}.testuser.accessToken`,
-      createValidJWT()
-    );
-    await storage.setItem(
-      `${amplifyKeyPrefix}.testuser.refreshToken`,
-      "test-refresh-token"
-    );
-    await storage.setItem(
-      `${customKeyPrefix}.testuser.expireAt`,
-      new Date(Date.now() + 3600000).toISOString()
-    );
+      await storage.setItem(`${amplifyKeyPrefix}.LastAuthUser`, "testuser");
+      await storage.setItem(
+        `${amplifyKeyPrefix}.testuser.accessToken`,
+        createValidJWT()
+      );
+      await storage.setItem(
+        `${amplifyKeyPrefix}.testuser.refreshToken`,
+        "test-refresh-token"
+      );
+      await storage.setItem(
+        `${customKeyPrefix}.testuser.expireAt`,
+        new Date(Date.now() + 3600000).toISOString()
+      );
 
-    // Now block the lock with a non-stale lock to simulate another tab refreshing
-    const userKey = `Passwordless.testClient.testuser.refreshLock`;
-    const lockData = {
-      id: "test-lock-id",
-      timestamp: Date.now(), // Current timestamp so it's not stale
-    };
-    await storage.setItem(userKey, JSON.stringify(lockData));
+      const userKey = `Passwordless.testClient.testuser.refreshLock`;
+      await storage.setItem(
+        userKey,
+        JSON.stringify({ id: "other-tab-lock", timestamp: Date.now() })
+      );
+      // The other tab renews its heartbeat, so the lock never goes stale
+      const renewer = setInterval(() => {
+        void storage.setItem(
+          userKey,
+          JSON.stringify({ id: "other-tab-lock", timestamp: Date.now() })
+        );
+      }, 5_000);
 
-    // scheduleRefresh should wait for lock timeout (15s) then return silently
-    // This is the expected behavior - it assumes another tab is handling the refresh
-    const startTime = Date.now();
-    await expect(scheduleRefresh()).resolves.toBeUndefined();
-    const duration = Date.now() - startTime;
+      try {
+        const outcome: { done: boolean; error?: unknown } = { done: false };
+        scheduleRefresh().then(
+          () => {
+            outcome.done = true;
+          },
+          (error) => {
+            outcome.done = true;
+            outcome.error = error;
+          }
+        );
+        // Drive past the lock acquisition timeout (45s)
+        for (let i = 0; i < 90 && !outcome.done; i++) {
+          await jest.advanceTimersByTimeAsync(1000);
+        }
 
-    // Should have waited approximately 15 seconds before giving up
-    expect(duration).toBeGreaterThan(14000);
-    expect(duration).toBeLessThan(16000);
-  }, 20000); // Increase timeout to handle lock wait
+        expect(outcome.done).toBe(true);
+        expect(outcome.error).toBeUndefined();
+      } finally {
+        clearInterval(renewer);
+      }
+    } finally {
+      jest.useRealTimers();
+    }
+  });
 
   test("should honor the per-user lock when the access token is expired", async () => {
     // Regression: scheduleRefresh used to derive the lock user via

--- a/test/signOut.test.ts
+++ b/test/signOut.test.ts
@@ -128,7 +128,12 @@ describe("SignOut Lock", () => {
     const leftoverUserKeys = [...backing.keys()].filter((key) =>
       key.startsWith(`${customKeyPrefix}.testuser.`)
     );
-    expect(leftoverUserKeys).toEqual([]);
+    // The sign-out tombstone is the ONE deliberate survivor: an in-flight
+    // refresh checks it before/after writing tokens back, so a sign-out
+    // racing a refresh stays signed out. A fresh sign-in clears it.
+    expect(leftoverUserKeys).toEqual([
+      `${customKeyPrefix}.testuser.signedOutAt`,
+    ]);
     const leftoverAmplifyKeys = [...backing.keys()].filter((key) =>
       key.startsWith(amplifyKeyPrefix)
     );

--- a/test/signOut.test.ts
+++ b/test/signOut.test.ts
@@ -375,3 +375,103 @@ describe("SignOut revocation ordering", () => {
     expect(revokeCalls).toHaveLength(1);
   });
 });
+
+describe("SignOut lock-timeout fallback", () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test("signs out without the lock when another tab holds it past the timeout", async () => {
+    // Another tab's heartbeat-renewed refresh lock used to make signOut
+    // throw LockTimeoutError: tokens stayed, the click did nothing. Sign-out
+    // must eventually win - after the wait it proceeds without the lock.
+    jest.useFakeTimers();
+    const username = "testuser";
+    const refreshToken = "fallback-refresh-token";
+    const now = Date.now();
+
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({}),
+    });
+    configure({
+      clientId: "testClient",
+      cognitoIdpEndpoint: "us-west-2",
+      fetch: fetchMock,
+    });
+    const { storage } = configure();
+
+    await storeTokens({
+      accessToken: createJWT({
+        sub: "user123",
+        username,
+        scope: "openid",
+        exp: Math.floor((now + 3600_000) / 1000),
+        iat: Math.floor(now / 1000),
+      }),
+      idToken: createJWT({
+        sub: "user123",
+        "cognito:username": username,
+        exp: Math.floor((now + 3600_000) / 1000),
+        iat: Math.floor(now / 1000),
+      }),
+      refreshToken,
+      authMethod: "SRP",
+      expireAt: new Date(now + 3600_000),
+    });
+
+    // Simulate another tab holding the refresh lock and renewing its
+    // heartbeat: the lock never goes stale, so signOut cannot acquire it
+    const lockKey = `Passwordless.testClient.${username}.refreshLock`;
+    await storage.setItem(
+      lockKey,
+      JSON.stringify({ id: "other-tab-lock", timestamp: Date.now() })
+    );
+    const renewer = setInterval(() => {
+      void storage.setItem(
+        lockKey,
+        JSON.stringify({ id: "other-tab-lock", timestamp: Date.now() })
+      );
+    }, 5_000);
+
+    try {
+      const { signedOut } = signOut();
+      const outcome: { done: boolean; error?: unknown } = { done: false };
+      signedOut.then(
+        () => {
+          outcome.done = true;
+        },
+        (error) => {
+          outcome.done = true;
+          outcome.error = error;
+        }
+      );
+      // Drive past the lock acquisition timeout (45s) and the fallback
+      for (let i = 0; i < 90 && !outcome.done; i++) {
+        await jest.advanceTimersByTimeAsync(1000);
+      }
+
+      expect(outcome.done).toBe(true);
+      expect(outcome.error).toBeUndefined();
+
+      // Local session is gone despite the held lock
+      const amplifyKeyPrefix = `CognitoIdentityServiceProvider.testClient`;
+      expect(
+        await storage.getItem(`${amplifyKeyPrefix}.LastAuthUser`)
+      ).toBeNull();
+      expect(
+        await storage.getItem(`${amplifyKeyPrefix}.${username}.refreshToken`)
+      ).toBeNull();
+      // And the refresh token was still revoked server-side
+      const revokeCall = fetchMock.mock.calls.find(([, init]) =>
+        (init as { headers?: Record<string, string> })?.headers?.[
+          "x-amz-target"
+        ]?.endsWith("RevokeToken")
+      );
+      expect(revokeCall).toBeDefined();
+    } finally {
+      clearInterval(renewer);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Third PR of the sequential series — the sign-out/lock liveness cluster from the post-merge re-review. The recurring theme: the lock's *safety* (mutual exclusion) was solid after #54, but three *liveness* properties were missing, each ending in "the user can't sign out" or "auth operations fail for no good reason".

## Changes
1. **`signOut` proceeds without the lock on `LockTimeoutError`** (`common.ts`). Another tab's heartbeat-renewed refresh lock used to make sign-out throw — tokens stayed, the click silently did nothing, in every tab. Sign-out must eventually win; a concurrent refresh that loses this race will re-validate the session before acting (that invariant lands in the next PR of the series).
2. **Heartbeat renewals capped at 120s** (`lock.ts`). A hung critical section (refresh fetch stuck on a dead connection, suspended tab) used to renew the lock forever, making it unstealable. After the cap, renewals stop, the lock goes stale within 30s, and other tabs can take over. A legitimately-finishing section still releases normally (only removes the lock if still owned).
3. **Default acquisition timeout now exceeds the stale threshold** (45s > 30s; was 15s < 30s). A lock orphaned by an abruptly closed page keeps its last timestamp forever; a waiter that gives up before the orphan *can* go stale was guaranteed to fail — worst case the OAuth callback's token exchange after a redirect, when the one-time authorization code is already spent.

## Test plan
- New `test/lock-liveness.test.ts` (fake timers): waiter outlasts an orphaned lock; hung holder loses the lock to a takeover after the cap; sanity check that a healthy long section is still protected within the cap.
- New sign-out fallback test in `test/signOut.test.ts`: a perpetually-renewed foreign lock — sign-out still removes the session and revokes the refresh token.
- `test/scheduleRefresh.test.ts` contended-lock test rewritten for the new semantics: a *live renewing* holder (a static lock now correctly goes stale and is taken over rather than timing out), under fake timers — the suite no longer spends 15 real seconds sleeping.
- Bite-check: 3 of the new tests fail on unfixed main. Full suite: 426 passed / 0 failures, twice consecutively; tsc and eslint clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core session teardown, token persistence, and multi-tab locking; mistakes could leave users signed in when they intended to sign out or break OAuth/refresh flows.
> 
> **Overview**
> Fixes **multi-tab auth liveness** and **sign-out vs. in-flight refresh** races so users can sign out reliably and orphaned locks do not block auth forever.
> 
> **Lock behavior (`lock.ts`):** Default lock wait is **45s** (was 15s) so waiters can outlive a **30s stale** orphan from a killed tab. Heartbeat renewal stops after **120s** so a hung refresh cannot hold the lock indefinitely; the lock can then go stale and be taken over.
> 
> **Sign-out (`common.ts`):** On **`LockTimeoutError`**, sign-out **still runs** without the refresh lock instead of failing silently. Teardown writes a **`signedOutAt` tombstone first**, then clears session keys via shared **`removeSessionKeysFromStorage`** (device key kept).
> 
> **Refresh / token write (`common.ts`, `refresh.ts`):** After a refresh round-trip, the client re-checks that the session still exists. **`processTokens`** accepts **`sessionMustExistSince`** and validates tombstone + session **before and after** `storeTokens`, compensating by removing keys if sign-out won mid-write. Fresh sign-in clears a stale tombstone.
> 
> **Tests:** New coverage for lock liveness, tombstone protocol, refresh-after-unlocked-sign-out, and sign-out lock-timeout fallback; **`scheduleRefresh`** contended-lock test uses fake timers and a renewing holder.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a43e93f417191787ff10de8bab3a01c9f2d3729e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->