### PR TITLE
Route forceRefreshTokens through the per-user refresh lock

### DIFF
--- a/client/refresh.ts
+++ b/client/refresh.ts
@@ -325,7 +325,7 @@ async function scheduleRefreshUnlocked({
       );
 
       try {
-        await refreshTokens({
+        await performRefresh({
           abort,
           tokensCb,
           isRefreshingCb,
@@ -584,17 +584,8 @@ async function refreshTokensViaOAuth({
   }
 }
 
-/**
- * Refresh tokens using the refresh token
- */
-export async function refreshTokens({
-  abort,
-  tokensCb,
-  isRefreshingCb,
-  tokens,
-  force = false,
-  skipLock = false,
-}: {
+/** Public options for {@link refreshTokens}. */
+export interface RefreshTokensOptions {
   abort?: AbortSignal;
   tokensCb?: (res: TokensFromRefresh) => void | Promise<void>;
   isRefreshingCb?: (isRefreshing: boolean) => unknown;
@@ -607,12 +598,35 @@ export async function refreshTokens({
    * sign-out and any in-flight scheduled refresh.
    */
   force?: boolean;
-  /**
-   * INTERNAL: the caller already holds the per-user refresh lock, so don't
-   * re-acquire it (storage locks are not reentrant — re-acquiring the same
-   * key from the same tab would self-deadlock until the wait times out).
-   * Only the in-lock immediate-refresh path sets this.
-   */
+}
+
+/**
+ * Refresh tokens using the refresh token. Always goes through the per-user
+ * refresh lock, so it serializes with sign-out and any in-flight refresh.
+ */
+export async function refreshTokens(
+  args: RefreshTokensOptions = {}
+): Promise<TokensFromRefresh> {
+  // skipLock is INTERNAL and deliberately not part of the public options:
+  // exposing it would let a consumer bypass the per-user lock and recreate
+  // the sign-out/refresh resurrection race this path guards against.
+  return performRefresh(args);
+}
+
+/**
+ * Internal refresh implementation. `skipLock` is private to this module: the
+ * in-lock immediate-refresh path already holds the per-user refresh lock on
+ * the same key, so re-acquiring would self-deadlock (storage locks are not
+ * reentrant). No other caller may bypass the lock.
+ */
+async function performRefresh({
+  abort,
+  tokensCb,
+  isRefreshingCb,
+  tokens,
+  force = false,
+  skipLock = false,
+}: RefreshTokensOptions & {
   skipLock?: boolean;
 } = {}): Promise<TokensFromRefresh> {
   const { clientId } = configure();
@@ -984,7 +998,7 @@ export async function refreshTokens({
  * Force an immediate token refresh
  */
 export async function forceRefreshTokens(
-  args?: Omit<Parameters<typeof refreshTokens>[0], "force" | "skipLock">
+  args?: Omit<RefreshTokensOptions, "force">
 ): Promise<TokensFromRefresh> {
   logDebug("Forcing immediate token refresh");
 
@@ -1009,7 +1023,12 @@ export async function forceRefreshTokens(
     force: true,
   });
 
-  void scheduleRefresh({ ...args });
+  // scheduleRefresh's tokensCb is nullable (scheduling can yield null tokens)
+  // while the forced-refresh tokensCb is not; the spread is behaviourally the
+  // same as before, the cast just bridges that variance difference
+  void scheduleRefresh(
+    { ...args } as Parameters<typeof scheduleRefresh>[0]
+  );
 
   return refreshed;
 }

--- a/client/refresh.ts
+++ b/client/refresh.ts
@@ -331,6 +331,9 @@ async function scheduleRefreshUnlocked({
           isRefreshingCb,
           tokens,
           force: true,
+          // This path runs inside scheduleRefresh's per-user refresh lock
+          // (same lock key), so re-acquiring would self-deadlock
+          skipLock: true,
         });
 
         // Mark as completed
@@ -590,12 +593,27 @@ export async function refreshTokens({
   isRefreshingCb,
   tokens,
   force = false,
+  skipLock = false,
 }: {
   abort?: AbortSignal;
   tokensCb?: (res: TokensFromRefresh) => void | Promise<void>;
   isRefreshingCb?: (isRefreshing: boolean) => unknown;
   tokens?: TokenPayload;
+  /**
+   * Skip the cross-tab `shouldAttemptRefresh()` coordination/dedup check and
+   * the in-process `isRefreshing` guard: the caller wants a refresh NOW
+   * (e.g. after a 401), regardless of the 5s dedup window. Does NOT bypass
+   * the per-user refresh lock — a forced refresh still serializes with
+   * sign-out and any in-flight scheduled refresh.
+   */
   force?: boolean;
+  /**
+   * INTERNAL: the caller already holds the per-user refresh lock, so don't
+   * re-acquire it (storage locks are not reentrant — re-acquiring the same
+   * key from the same tab would self-deadlock until the wait times out).
+   * Only the in-lock immediate-refresh path sets this.
+   */
+  skipLock?: boolean;
 } = {}): Promise<TokensFromRefresh> {
   const { clientId } = configure();
   let userIdentifier: string | undefined = tokens?.username;
@@ -851,8 +869,11 @@ export async function refreshTokens({
   };
 
   const { debug } = configure();
-  if (force) {
-    debug?.("refreshTokens: force=true, bypassing lock", lockKey);
+  if (skipLock) {
+    debug?.(
+      "refreshTokens: skipLock=true, caller already holds the lock",
+      lockKey
+    );
     return doRefresh();
   }
   debug?.("refreshTokens: waiting for lock", lockKey);
@@ -963,7 +984,7 @@ export async function refreshTokens({
  * Force an immediate token refresh
  */
 export async function forceRefreshTokens(
-  args?: Omit<Parameters<typeof refreshTokens>[0], "force">
+  args?: Omit<Parameters<typeof refreshTokens>[0], "force" | "skipLock">
 ): Promise<TokensFromRefresh> {
   logDebug("Forcing immediate token refresh");
 
@@ -978,6 +999,11 @@ export async function forceRefreshTokens(
     state.refreshTimer = undefined;
   }
 
+  // force: true skips the dedup/coordination check, but the refresh still
+  // goes through the per-user lock (no skipLock) so it serializes with
+  // sign-out and any in-flight scheduled refresh — a forced refresh that
+  // wrote tokens back without the lock could resurrect a session a
+  // concurrent sign-out just removed
   const refreshed = await refreshTokens({
     ...(args ?? {}),
     force: true,

--- a/test/force-refresh-lock.test.ts
+++ b/test/force-refresh-lock.test.ts
@@ -1,0 +1,166 @@
+import { configure } from "../client/config.js";
+import {
+  forceRefreshTokens,
+  cleanupUserRefreshState,
+} from "../client/refresh.js";
+import { storeTokens } from "../client/storage.js";
+
+const createJWT = (claims: Record<string, unknown>) => {
+  const enc = (o: unknown) =>
+    btoa(JSON.stringify(o))
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+  return `${enc({ alg: "HS256", typ: "JWT" })}.${enc(claims)}.sig`;
+};
+
+function createMemoryStorage() {
+  const store = new Map<string, string>();
+  return {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      store.set(key, value);
+    },
+    removeItem: (key: string) => {
+      store.delete(key);
+    },
+    _store: store,
+  };
+}
+
+const seed = async (username: string, refreshToken: string) => {
+  const now = Date.now();
+  await storeTokens({
+    accessToken: createJWT({
+      sub: "u",
+      username,
+      exp: Math.floor((now + 3600_000) / 1000),
+      iat: Math.floor(now / 1000),
+    }),
+    idToken: createJWT({
+      sub: "u",
+      "cognito:username": username,
+      exp: Math.floor((now + 3600_000) / 1000),
+      iat: Math.floor(now / 1000),
+    }),
+    refreshToken,
+    authMethod: "SRP",
+    expireAt: new Date(now + 3600_000),
+  });
+};
+
+const refreshOk = (username: string, newRefresh: string) => {
+  const now = Date.now();
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({
+      AuthenticationResult: {
+        AccessToken: createJWT({
+          sub: "u",
+          username,
+          exp: Math.floor((now + 7200_000) / 1000),
+          iat: Math.floor(now / 1000),
+        }),
+        IdToken: createJWT({
+          sub: "u",
+          "cognito:username": username,
+          exp: Math.floor((now + 7200_000) / 1000),
+          iat: Math.floor(now / 1000),
+        }),
+        RefreshToken: newRefresh,
+        ExpiresIn: 3600,
+        TokenType: "Bearer",
+      },
+    }),
+  };
+};
+
+afterEach(() => {
+  jest.useRealTimers();
+  cleanupUserRefreshState("testuser");
+});
+
+describe("forceRefreshTokens goes through the per-user lock", () => {
+  test("waits for a held lock rather than bypassing it", async () => {
+    jest.useFakeTimers();
+    const username = "testuser";
+    const storage = createMemoryStorage();
+    const fetchMock = jest.fn((url: unknown, init?: { headers?: Record<string, string> }) => {
+      const target = init?.headers?.["x-amz-target"] ?? "";
+      if (
+        target.endsWith("GetTokensFromRefreshToken") ||
+        target.endsWith("InitiateAuth")
+      ) {
+        return Promise.resolve(refreshOk(username, "rotated-by-force"));
+      }
+      return Promise.resolve({ ok: true, status: 200, json: async () => ({}) });
+    });
+    configure({
+      clientId: "testClient",
+      cognitoIdpEndpoint: "us-west-2",
+      storage,
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    await seed(username, "original-refresh");
+
+    // Another tab holds the refresh lock and keeps renewing it for a while
+    const lockKey = `Passwordless.testClient.${username}.refreshLock`;
+    storage.setItem(
+      lockKey,
+      JSON.stringify({ id: "other-tab", timestamp: Date.now() })
+    );
+    let renews = 6;
+    const renewer = setInterval(() => {
+      if (renews-- > 0) {
+        storage.setItem(
+          lockKey,
+          JSON.stringify({ id: "other-tab", timestamp: Date.now() })
+        );
+      }
+    }, 5_000);
+
+    try {
+      const outcome: { done: boolean; value?: unknown; error?: unknown } = {
+        done: false,
+      };
+      forceRefreshTokens().then(
+        (v) => {
+          outcome.done = true;
+          outcome.value = v;
+        },
+        (e) => {
+          outcome.done = true;
+          outcome.error = e;
+        }
+      );
+
+      // While the foreign lock is held & renewed, the force refresh must NOT
+      // have hit the token endpoint yet (it's waiting for the lock, not
+      // bypassing it)
+      await jest.advanceTimersByTimeAsync(8_000);
+      expect(
+        fetchMock.mock.calls.some(([, init]) =>
+          (init as { headers?: Record<string, string> })?.headers?.[
+            "x-amz-target"
+          ]?.endsWith("GetTokensFromRefreshToken")
+        )
+      ).toBe(false);
+      expect(outcome.done).toBe(false);
+
+      // Once the other tab stops renewing, the lock goes stale and the force
+      // refresh takes it over and completes
+      clearInterval(renewer);
+      for (let i = 0; i < 90 && !outcome.done; i++) {
+        await jest.advanceTimersByTimeAsync(1000);
+      }
+      expect(outcome.done).toBe(true);
+      expect(outcome.error).toBeUndefined();
+      expect(
+        (outcome.value as { refreshToken?: string }).refreshToken
+      ).toBe("rotated-by-force");
+    } finally {
+      clearInterval(renewer);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Fourth PR of the sequential series. `forceRefreshTokens` (exposed by the React hook, typically called when the app gets a 401) bypassed the per-user refresh lock, so a forced refresh could race a concurrent sign-out and write tokens back **after** the session was torn down — a zombie session, made visible in the UI by #52's same-tab `onTokensStored` notification.

Root cause: the `force` flag did double duty — "skip the cross-tab dedup/coordination check" **and** "bypass the lock". Those are separate concerns.

## Change
- Decouple them with a new internal `skipLock` flag. `force` keeps its dedup-skip meaning (the caller wants a refresh **now**, ignoring the 5s window); `skipLock` controls lock bypass.
- Only the in-lock immediate-refresh path sets `skipLock: true` — it already runs inside `scheduleRefresh`'s lock on the same key, so re-acquiring would self-deadlock (storage locks aren't reentrant).
- `forceRefreshTokens` now passes `force: true` **without** `skipLock`, so it goes through `withStorageLock` and serializes with sign-out and any in-flight scheduled refresh.

This removes the race at the source; the #89 sign-out tombstone remains the backstop for the unlocked-fallback path.

## Test plan
- New `test/force-refresh-lock.test.ts`: a forced refresh waits out a held-and-renewed foreign lock (does **not** hit the token endpoint while held), then takes over once the lock goes stale and completes. Fails on unfixed main (force hit the endpoint immediately while the lock was held).
- Full suite: 431 passed / 0 failures, twice; tsc and eslint clean.

## Scope note
Two LOW-severity refresh cleanups originally bundled here — tracking the failure-backoff retry timer for cancellation, and making the consecutive-failure counter per-user — are **deferred**. Reaching the retry path requires driving the live scheduling machinery under fake timers, which hangs `advanceTimersByTimeAsync` (the same timer-machinery fragility PR #87 addressed). They'll land in a later PR with a test approach that doesn't fight the scheduler, rather than ship a flaky test here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core token refresh and session teardown serialization; behavior on 401/forced refresh and multi-tab locks is security-relevant but narrowly scoped with a targeted regression test.
> 
> **Overview**
> **Fixes a race where `forceRefreshTokens` (e.g. on 401) could write tokens after sign-out** by no longer treating `force` as “bypass the per-user refresh lock.”
> 
> Refresh logic is refactored so **`force` only skips cross-tab dedup / in-process guards**, while a new **internal `skipLock`** is the sole way to skip `withStorageLock`. Only the immediate refresh inside `scheduleRefresh` sets `skipLock: true`, because that path already holds the same lock and re-acquiring would deadlock. **`forceRefreshTokens` now acquires the lock** like other refreshes, serializing with sign-out and scheduled refresh. Public **`RefreshTokensOptions`** documents this; `performRefresh` stays module-private.
> 
> Adds **`test/force-refresh-lock.test.ts`**: with another tab holding and renewing the refresh lock, a forced refresh must not call the token endpoint until the lock is stale, then completes successfully.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc17ab8917a1c24770412ba6741f5bbac998c629. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->