### PR TITLE
Fix React OAuth callback gate for errors and stuck busy status

### DIFF
--- a/client/__tests__/react-oauth-callback.test.tsx
+++ b/client/__tests__/react-oauth-callback.test.tsx
@@ -1,0 +1,145 @@
+/**
+ * Copyright Amazon.com, Inc. and its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You
+ * may not use this file except in compliance with the License. A copy of
+ * the License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+import React from "react";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import {
+  usePasswordless,
+  PasswordlessContextProvider,
+} from "../react/hooks.js";
+import { handleCognitoOAuthCallback } from "../hosted-oauth.js";
+import { configure } from "../config.js";
+import { retrieveTokens, onTokensStored } from "../storage.js";
+import type { ConfigWithDefaults } from "../config.js";
+
+jest.mock("../hosted-oauth");
+jest.mock("../config");
+jest.mock("../storage");
+
+const mockHandleCallback = handleCognitoOAuthCallback as jest.MockedFunction<
+  typeof handleCognitoOAuthCallback
+>;
+const mockConfigure = configure as jest.MockedFunction<typeof configure>;
+const mockRetrieveTokens = retrieveTokens as jest.MockedFunction<
+  typeof retrieveTokens
+>;
+const mockOnTokensStored = onTokensStored as jest.MockedFunction<
+  typeof onTokensStored
+>;
+
+// Point globalThis.location at a callback URL with the given query/hash.
+// jsdom's location is not configurable, but history.replaceState updates
+// location.search / location.hash / location.href in place.
+const setLocation = (search: string, hash = "") => {
+  globalThis.history.replaceState(
+    {},
+    "",
+    `/signin-redirect${search}${hash}`
+  );
+};
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <PasswordlessContextProvider>{children}</PasswordlessContextProvider>
+);
+
+describe("React OAuth callback handling", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockConfigure.mockReturnValue({
+      clientId: "test-client-id",
+      debug: jest.fn(),
+      storage: {
+        getItem: jest.fn(),
+        setItem: jest.fn(),
+        removeItem: jest.fn(),
+      },
+    } as unknown as ConfigWithDefaults);
+    mockRetrieveTokens.mockResolvedValue(undefined); // not signed in
+    mockOnTokensStored.mockReturnValue(() => {});
+  });
+
+  afterEach(() => {
+    setLocation(""); // reset to a non-callback URL
+  });
+
+  it("invokes the callback handler and surfaces the error for an error-only redirect", async () => {
+    // The user denied consent: the redirect carries ?error=access_denied with
+    // NO code and NO access_token. The handler (which surfaces provider
+    // errors) must still be invoked.
+    setLocation("?error=access_denied&error_description=User+denied&state=s");
+    mockHandleCallback.mockRejectedValue(new Error("User denied"));
+
+    const { result } = renderHook(() => usePasswordless(), { wrapper });
+
+    await waitFor(() => {
+      expect(mockHandleCallback).toHaveBeenCalledTimes(1);
+    });
+    await waitFor(() => {
+      expect(result.current.lastError?.message).toBe("User denied");
+    });
+    expect(result.current.signInStatus).toBe("NOT_SIGNED_IN");
+  });
+
+  it("does not stay stuck busy when the callback handler returns null", async () => {
+    // The gate fires (a code is present) but the handler returns null — e.g.
+    // it wasn't actually our in-progress redirect. The UI must resolve to the
+    // real (not-signed-in) state, not stay pinned at SIGNING_IN.
+    setLocation("?code=abc&state=s");
+    mockHandleCallback.mockResolvedValue(null);
+
+    const { result } = renderHook(() => usePasswordless(), { wrapper });
+
+    await waitFor(() => {
+      expect(mockHandleCallback).toHaveBeenCalledTimes(1);
+    });
+    await waitFor(() => {
+      expect(result.current.signInStatus).toBe("NOT_SIGNED_IN");
+    });
+    expect(result.current.signInStatus).not.toBe("SIGNING_IN");
+  });
+
+  it("reaches SIGNED_IN_WITH_REDIRECT when the handler returns tokens", async () => {
+    setLocation("?code=abc&state=s");
+    mockHandleCallback.mockResolvedValue({
+      accessToken: "a",
+      idToken: "i",
+      refreshToken: "r",
+      expireAt: new Date(Date.now() + 3600_000),
+      username: "user",
+      authMethod: "REDIRECT",
+    });
+
+    const { result } = renderHook(() => usePasswordless(), { wrapper });
+
+    await waitFor(() => {
+      expect(mockHandleCallback).toHaveBeenCalledTimes(1);
+    });
+    await waitFor(() => {
+      expect(result.current.signInStatus).toBe("SIGNED_IN");
+    });
+  });
+
+  it("does not invoke the callback handler on a plain (non-callback) URL", async () => {
+    setLocation("?foo=bar");
+    mockHandleCallback.mockResolvedValue(null);
+
+    renderHook(() => usePasswordless(), { wrapper });
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 50));
+    });
+
+    expect(mockHandleCallback).not.toHaveBeenCalled();
+  });
+});

--- a/client/react/hooks.tsx
+++ b/client/react/hooks.tsx
@@ -306,6 +306,7 @@ type PasswordlessAction =
   | { type: "SET_AUTH_METHOD"; payload: PasswordlessState["authMethod"] }
   | { type: "SET_TOTP_MFA_STATUS"; payload: PasswordlessState["totpMfaStatus"] }
   | { type: "SET_MFA_STATUS_READY"; payload: boolean }
+  | { type: "RESET_REDIRECT_SIGNIN_STATUS" }
   | { type: "SIGN_OUT" };
 
 // Initial state
@@ -331,6 +332,17 @@ function passwordlessReducer(
   switch (action.type) {
     case "SET_SIGNING_STATUS":
       return { ...state, signingInStatus: action.payload };
+
+    case "RESET_REDIRECT_SIGNIN_STATUS":
+      // Leave the optimistic busy state only if it's still ours: when the
+      // OAuth callback handler turns out to have nothing to process (not our
+      // redirect), the status must not stay stuck at the busy
+      // STARTING_SIGN_IN_WITH_REDIRECT. Guarded so it never clobbers a status
+      // that loadTokens (or anything else) set in the meantime.
+      if (state.signingInStatus === "STARTING_SIGN_IN_WITH_REDIRECT") {
+        return { ...state, signingInStatus: "SIGNED_OUT" };
+      }
+      return state;
 
     case "SET_INITIAL_LOADING":
       return { ...state, initiallyRetrievingTokensFromStorage: action.payload };
@@ -755,7 +767,18 @@ function _usePasswordless() {
         globalThis.location.hash.substring(1)
       );
 
-      if (urlParams.has("code") || hashParams.has("access_token")) {
+      // Fire for a successful redirect (code / implicit access_token) AND for
+      // an error redirect (e.g. the user denied consent), which carries
+      // neither but does carry `error` — in the query for the code flow, the
+      // fragment for the implicit flow. Without the error case,
+      // handleCognitoOAuthCallback (which surfaces provider errors) was never
+      // invoked, so a denied sign-in left the page silently stuck.
+      if (
+        urlParams.has("code") ||
+        hashParams.has("access_token") ||
+        urlParams.has("error") ||
+        hashParams.has("error")
+      ) {
         // Prevent multiple simultaneous OAuth callback processing
         if (oauthProcessingRef.current) {
           debug?.("OAuth callback already being processed, skipping...");
@@ -773,6 +796,14 @@ function _usePasswordless() {
             updateTokens(oauthTokens);
             setSigninInStatus("SIGNED_IN_WITH_REDIRECT");
             debug?.("OAuth callback processed successfully");
+          } else {
+            // Not our redirect / nothing to process: don't leave the UI
+            // stuck in the busy STARTING_SIGN_IN_WITH_REDIRECT state. The
+            // reset is guarded so it can't clobber a status loadTokens set.
+            debug?.(
+              "OAuth callback produced no tokens; clearing optimistic redirect status"
+            );
+            dispatch({ type: "RESET_REDIRECT_SIGNIN_STATUS" });
           }
         } catch (error) {
           debug?.("OAuth callback processing failed:", error);
@@ -780,6 +811,11 @@ function _usePasswordless() {
             error instanceof Error ? error : new Error(String(error))
           );
           setSigninInStatus("SIGNIN_WITH_REDIRECT_FAILED");
+        } finally {
+          // Allow a later callback in this mount to be processed (e.g. a
+          // retry after a transient failure); the in-progress storage flag
+          // and URL params still gate real work.
+          oauthProcessingRef.current = false;
         }
       }
     };


### PR DESCRIPTION
## Summary
Fifth PR of the sequential series. Two bugs in the React hook's OAuth-callback effect, from the post-merge re-review's "asymmetric hardening" cluster — #66 hardened the *core* error surfacing, but the React layer never reached it.

## Bugs fixed
1. **Error-only redirects never invoked the handler.** The gate fired only on `code` / `access_token`. When the user denies consent, the redirect carries `?error=access_denied` (query for the code flow, fragment for implicit) with **no** code or token — so `handleCognitoOAuthCallback` (which surfaces provider errors since #66) was never called. A denied sign-in left the page silently stuck with no error shown. The gate now also fires on an `error` param in either location.
2. **Null result pinned the UI at SIGNING_IN forever.** The effect optimistically set the busy `STARTING_SIGN_IN_WITH_REDIRECT` before calling the handler; when the handler returned `null` (not our redirect / nothing to process), nothing cleared it, so the derived `signInStatus` stayed `SIGNING_IN` indefinitely. The null branch now dispatches a new `RESET_REDIRECT_SIGNIN_STATUS` reducer action that clears the busy state **only if it is still STARTING** — race-safe against `loadTokens`, which runs in parallel.

Also: `oauthProcessingRef` was set `true` but never reset; now reset in a `finally` so a later callback in the same mount (e.g. a retry) isn't permanently skipped. The storage in-progress flag and URL params still gate real work.

## Test plan
- New `client/__tests__/react-oauth-callback.test.tsx`: error-only redirect surfaces `lastError` and resolves to `NOT_SIGNED_IN`; a `null` result resolves to `NOT_SIGNED_IN` (not stuck at `SIGNING_IN`); a token result reaches `SIGNED_IN`; a plain non-callback URL never invokes the handler.
- The two behavior-change tests fail on the previous hook; the two unchanged-behavior tests pass on both.
- Full suite: 435 passed / 0 failures, twice; tsc and eslint clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches sign-in state on the OAuth redirect path; behavior is narrow and guarded, but incorrect gating would affect all Hosted UI React consumers at callback time.
> 
> **Overview**
> Fixes two bugs in **`usePasswordless`**’s mount-time OAuth callback effect so React apps align with core OAuth error handling.
> 
> The callback **gate** now treats query or hash **`error`** (e.g. consent denied) like `code` / `access_token`, so **`handleCognitoOAuthCallback`** runs and **`lastError`** can surface instead of failing silently. When the handler returns **`null`**, a guarded **`RESET_REDIRECT_SIGNIN_STATUS`** action clears **`STARTING_SIGN_IN_WITH_REDIRECT`** so **`signInStatus`** is not stuck at **`SIGNING_IN`**. **`oauthProcessingRef`** is cleared in a **`finally`** block so retries on the same mount are not skipped forever.
> 
> Adds **`client/__tests__/react-oauth-callback.test.tsx`** covering error-only redirects, null handler results, successful tokens, and non-callback URLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f92eeb14cb77d0108c97cd5dcef388326265090. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->