### PR TITLE
Close FIDO2 conditional renewal/takeover seam during the initiate window

### DIFF
--- a/client/__tests__/fido2-core.test.ts
+++ b/client/__tests__/fido2-core.test.ts
@@ -813,6 +813,38 @@ describe("FIDO2 Core Functionality", () => {
         expect(credentialGetter).toHaveBeenCalledTimes(1);
       });
 
+      it("does not complete a superseded flow when the conditional credential resolves in the same tick as a takeover", async () => {
+        // Race: a modal takeover marks the flow superseded (via the lock) at
+        // the same time the conditional getter resolves with a valid
+        // credential — e.g. an injected getter the takeover's abort never
+        // reaches. The success branch must honour the superseded marker and
+        // end the flow, not complete the (superseded) conditional sign-in.
+        jest.useFakeTimers();
+        cleanup = setupWebAuthnMock({ credential: MOCK_ASSERTION_CREDENTIAL });
+
+        mockInitiateAuth.mockResolvedValueOnce(challengeResponse(1));
+
+        // The conditional getter performs a modal takeover and THEN resolves
+        // with a credential, in that order, without ever observing its abort
+        // signal — exactly the same-tick success-vs-supersede race.
+        const credentialGetter = jest.fn().mockImplementationOnce(async () => {
+          await fido2getCredential({ challenge: TEST_CHALLENGES.basic });
+          return parsedAssertion;
+        });
+
+        const prepared = prepareFido2SignIn({
+          username: "alice",
+          mediation: "conditional",
+          credentialGetter,
+        });
+        const outcome = prepared.catch((err: unknown) => err);
+        await jest.advanceTimersByTimeAsync(0);
+
+        const err = await outcome;
+        expect(err).toBeInstanceOf(Fido2AbortError);
+        expect((err as Fido2AbortError).superseded).toBe(true);
+      });
+
       it("ends the flow instead of renewing when the conditional request was superseded by a newer request", async () => {
         // Belt-and-suspenders: even relying only on the per-get error's
         // superseded flag (the flow-lifetime marker aside), a superseded

--- a/client/__tests__/fido2-core.test.ts
+++ b/client/__tests__/fido2-core.test.ts
@@ -765,9 +765,59 @@ describe("FIDO2 Core Functionality", () => {
         expect(credentialGetter).toHaveBeenCalledTimes(1);
       });
 
+      it("ends the flow when a modal takeover lands during the renewal initiate-challenge window (no get pending)", async () => {
+        // Gap the per-get supersede tracker misses: between renewal
+        // iterations, the previous get() has been aborted and the next has
+        // not been issued (e.g. while initiating a fresh challenge), so
+        // pendingConditionalGet is momentarily undefined. A modal takeover in
+        // that window must still end the conditional flow via the
+        // flow-lifetime marker, instead of the autofill re-arming forever
+        // behind the modal sign-in.
+        jest.useFakeTimers();
+        // Real navigator mock so the modal fido2getCredential can succeed
+        cleanup = setupWebAuthnMock({ credential: MOCK_ASSERTION_CREDENTIAL });
+
+        let modalCompleted = false;
+        mockInitiateAuth
+          .mockResolvedValueOnce(challengeResponse(1))
+          .mockImplementationOnce(async () => {
+            // A modal passkey sign-in completes WHILE we are initiating the
+            // renewal challenge — exactly the no-get-pending window. It must
+            // supersede the active conditional flow.
+            await fido2getCredential({ challenge: TEST_CHALLENGES.basic });
+            modalCompleted = true;
+            return challengeResponse(2);
+          });
+
+        const credentialGetter = jest
+          .fn()
+          .mockImplementationOnce(pendingUntilAborted);
+
+        const prepared = prepareFido2SignIn({
+          username: "alice",
+          mediation: "conditional",
+          credentialGetter,
+        });
+        const outcome = prepared.catch((err: unknown) => err);
+
+        await jest.advanceTimersByTimeAsync(
+          COGNITO_AUTH_SESSION_RENEWAL_INTERVAL_MS
+        );
+
+        const err = await outcome;
+        expect(err).toBeInstanceOf(Fido2AbortError);
+        expect((err as Fido2AbortError).superseded).toBe(true);
+        expect(modalCompleted).toBe(true);
+        // The autofill flow did NOT re-arm behind the modal: its credential
+        // getter ran exactly once (the first, aborted iteration).
+        expect(credentialGetter).toHaveBeenCalledTimes(1);
+      });
+
       it("ends the flow instead of renewing when the conditional request was superseded by a newer request", async () => {
-        // Regression: a modal passkey sign-in taking over the pending
-        // conditional request rejects it with a superseded Fido2AbortError.
+        // Belt-and-suspenders: even relying only on the per-get error's
+        // superseded flag (the flow-lifetime marker aside), a superseded
+        // abort landing at the renewal boundary must end the flow, not
+        // restart it.
         // If that rejection lands at the renewal boundary (after the renewal
         // timer aborts the pending get()), the renewal loop must NOT treat it
         // as its own renewal abort and restart the autofill flow behind the

--- a/client/fido2.ts
+++ b/client/fido2.ts
@@ -1285,6 +1285,12 @@ export async function prepareFido2SignIn({
               }),
             ]);
             if (raceOutcome !== RENEW_SESSION) {
+              // A modal takeover may have set flow.superseded in the same
+              // tick the credential resolved (or for an injected getter the
+              // takeover's abort never reached it): a superseded flow must
+              // not complete with an assertion — the modal flow owns the
+              // sign-in now.
+              if (flow.superseded) abortFlow();
               assertion = raceOutcome;
               session = challenge.session;
               break;
@@ -1316,6 +1322,9 @@ export async function prepareFido2SignIn({
                 );
                 continue;
               }
+              // As above: a takeover during the settle wait wins over a
+              // late-resolving credential.
+              if (flow.superseded) abortFlow();
               assertion = settled;
               session = challenge.session;
               break;

--- a/client/fido2.ts
+++ b/client/fido2.ts
@@ -704,6 +704,18 @@ let pendingConditionalGet:
   | undefined = undefined;
 
 /**
+ * Marks a conditional (autofill) sign-in flow as active for its ENTIRE
+ * lifetime — including the gaps between renewal iterations, when the previous
+ * navigator.credentials.get() has been aborted and the next one has not yet
+ * been issued (e.g. while initiating a fresh Cognito challenge). A modal
+ * takeover sets `superseded` here even when no get() is pending, so the
+ * renewal loop stops re-arming instead of running invisibly behind the modal
+ * sign-in forever. `pendingConditionalGet` only covers the narrower window
+ * while a get() is actually pending.
+ */
+let activeConditionalFlow: { superseded: boolean } | undefined = undefined;
+
+/**
  * Serializes the issuance of navigator.credentials.get() requests.
  *
  * Concurrent fido2getCredential calls must not issue overlapping
@@ -848,6 +860,16 @@ export async function fido2getCredential({
   const releaseLock = await acquireCredentialsGetLock();
   let credential;
   try {
+    // A non-conditional (modal / immediate / default) request taking the lock
+    // is a takeover of any active conditional autofill flow: mark that flow
+    // superseded so its renewal loop stops re-arming — even if this lands in
+    // the renewal gap where no get() is pending (so pendingConditionalGet is
+    // momentarily undefined). The flow's own conditional renewal re-arm is
+    // mediation === "conditional" and must NOT self-supersede here.
+    if (mediation !== "conditional" && activeConditionalFlow) {
+      activeConditionalFlow.superseded = true;
+    }
+
     // If a conditional (autofill) request is still pending, abort it first so
     // the browser accepts this new request instead of rejecting it
     if (pendingConditionalGet) {
@@ -1207,59 +1229,123 @@ export async function prepareFido2SignIn({
       // request and restarting it with the fresh challenge. Pending
       // conditional requests show no UI, so renewal is invisible to the user.
       const RENEW_SESSION = Symbol("renew-session");
-      for (;;) {
-        const challenge = await initiateFido2Challenge();
-        const renewalAbort = new AbortController();
-        const forwardAbort = () => renewalAbort.abort();
-        if (signal?.aborted) {
-          renewalAbort.abort();
-        } else {
-          signal?.addEventListener("abort", forwardAbort, { once: true });
-        }
-        let renewalTimer: ReturnType<typeof setTimeout> | undefined;
-        const credentialPromise = getCredentialForChallenge(
-          challenge.fido2options,
-          renewalAbort.signal
-        );
-        try {
-          const raceOutcome = await Promise.race([
-            credentialPromise,
-            new Promise<typeof RENEW_SESSION>((resolve) => {
-              renewalTimer = setTimeout(
-                () => resolve(RENEW_SESSION),
-                COGNITO_AUTH_SESSION_RENEWAL_INTERVAL_MS
-              );
-            }),
-          ]);
-          if (raceOutcome !== RENEW_SESSION) {
-            assertion = raceOutcome;
-            session = challenge.session;
-            break;
-          }
-          debug?.(
-            "🔄 Cognito auth session nearing expiry while conditional request pending - renewing challenge"
+      const SETTLE_TIMEOUT = Symbol("settle-timeout");
+
+      // Mark this conditional flow active for its whole lifetime so a modal
+      // takeover can stop it even during the renewal gap (no get() pending).
+      const flow = { superseded: false };
+      const previousFlow = activeConditionalFlow;
+      activeConditionalFlow = flow;
+
+      // Throw the abort that ends the flow: superseded by a takeover, or a
+      // plain cancellation by the caller's own signal.
+      const abortFlow = (): never => {
+        if (flow.superseded) {
+          throw new Fido2AbortError(
+            "WebAuthn operation was aborted: superseded by a newer credential request",
+            "Passkey verification was cancelled",
+            { superseded: true }
           );
-          renewalAbort.abort();
-          try {
-            // The user may have picked a credential just as the renewal timer
-            // fired - if so, the current session is still valid, use it
-            assertion = await credentialPromise;
-            session = challenge.session;
-            break;
-          } catch (err) {
-            if (!isFido2AbortError(err) || signal?.aborted || err.superseded) {
-              // Not our renewal abort: rethrow. In particular, a superseded
-              // abort means a newer credential request (e.g. a modal passkey
-              // sign-in) took over the pending conditional request — the
-              // autofill flow must end here, not restart with a fresh
-              // challenge behind the newer request's back
-              throw err;
-            }
-            // Aborted by us for renewal - loop around for a fresh challenge
+        }
+        throw new Fido2AbortError();
+      };
+
+      try {
+        for (;;) {
+          // A modal takeover may have superseded this flow during the previous
+          // iteration's renewal gap, including while awaiting initiate below.
+          if (flow.superseded || signal?.aborted) abortFlow();
+
+          const challenge = await initiateFido2Challenge();
+
+          // Re-check: a takeover could have landed during the (awaited)
+          // initiate call — exactly the window pendingConditionalGet misses.
+          if (flow.superseded || signal?.aborted) abortFlow();
+
+          const renewalAbort = new AbortController();
+          const forwardAbort = () => renewalAbort.abort();
+          if (signal?.aborted) {
+            renewalAbort.abort();
+          } else {
+            signal?.addEventListener("abort", forwardAbort, { once: true });
           }
-        } finally {
-          clearTimeout(renewalTimer);
-          signal?.removeEventListener("abort", forwardAbort);
+          let renewalTimer: ReturnType<typeof setTimeout> | undefined;
+          const credentialPromise = getCredentialForChallenge(
+            challenge.fido2options,
+            renewalAbort.signal
+          );
+          try {
+            const raceOutcome = await Promise.race([
+              credentialPromise,
+              new Promise<typeof RENEW_SESSION>((resolve) => {
+                renewalTimer = setTimeout(
+                  () => resolve(RENEW_SESSION),
+                  COGNITO_AUTH_SESSION_RENEWAL_INTERVAL_MS
+                );
+              }),
+            ]);
+            if (raceOutcome !== RENEW_SESSION) {
+              assertion = raceOutcome;
+              session = challenge.session;
+              break;
+            }
+            debug?.(
+              "🔄 Cognito auth session nearing expiry while conditional request pending - renewing challenge"
+            );
+            renewalAbort.abort();
+            // A takeover that landed during this iteration ends the flow.
+            if (flow.superseded) abortFlow();
+            let settleTimer: ReturnType<typeof setTimeout> | undefined;
+            try {
+              // The user may have picked a credential just as the renewal
+              // timer fired - if so, the current session is still valid, use
+              // it. Bound the wait: a non-conforming get() may ignore the
+              // abort and never settle, and the renewal loop must not hang.
+              const settled = await Promise.race([
+                credentialPromise,
+                new Promise<typeof SETTLE_TIMEOUT>((resolve) => {
+                  settleTimer = setTimeout(
+                    () => resolve(SETTLE_TIMEOUT),
+                    SUPERSEDED_SETTLEMENT_TIMEOUT_MS
+                  );
+                }),
+              ]);
+              if (settled === SETTLE_TIMEOUT) {
+                debug?.(
+                  `⚠️ Aborted conditional get() did not settle within ${SUPERSEDED_SETTLEMENT_TIMEOUT_MS}ms during renewal - re-arming with a fresh challenge`
+                );
+                continue;
+              }
+              assertion = settled;
+              session = challenge.session;
+              break;
+            } catch (err) {
+              // A takeover wins over a plain renewal abort regardless of how
+              // the per-get classifier labelled this error (the same-tick
+              // renewal-abort + supersede race can mislabel it).
+              if (flow.superseded) abortFlow();
+              if (
+                !isFido2AbortError(err) ||
+                signal?.aborted ||
+                err.superseded
+              ) {
+                // Not our renewal abort: rethrow. A superseded abort means a
+                // newer credential request took over — end here rather than
+                // restart behind it.
+                throw err;
+              }
+              // Aborted by us for renewal - loop around for a fresh challenge
+            } finally {
+              clearTimeout(settleTimer);
+            }
+          } finally {
+            clearTimeout(renewalTimer);
+            signal?.removeEventListener("abort", forwardAbort);
+          }
+        }
+      } finally {
+        if (activeConditionalFlow === flow) {
+          activeConditionalFlow = previousFlow;
         }
       }
     } else {


### PR DESCRIPTION
## Summary
Sixth PR of the sequential series — the FIDO2 renewal/takeover seam from the post-merge re-review (the new defect introduced when #53's renewal loop and #76's takeover tracker were composed).

## Bug
The conditional-autofill renewal loop tracked takeovers only via `pendingConditionalGet`, which exists **only while a `navigator.credentials.get()` is pending**. Between renewal iterations — after the previous get() is aborted and before the next is issued (e.g. while initiating a fresh Cognito challenge) — no get() is pending, so a modal passkey sign-in starting in that window superseded nothing. The autofill flow then re-armed and ran invisibly behind the modal sign-in, hitting Cognito every ~2.5 minutes **forever**.

## Fix
- **Flow-lifetime marker** (`activeConditionalFlow`) spanning the whole conditional flow, including the renewal gaps. A non-conditional (modal/immediate/default) request taking the credentials lock marks it superseded — even when no get() is pending — and the renewal loop checks it **before and after each initiate**, ending the flow instead of re-arming. The loop's own conditional re-arm is `mediation === "conditional"` and does not self-supersede.
- **Same-tick classification race fixed**: the loop now consults the flow marker directly rather than relying solely on the per-get error's `superseded` flag, which the renewal-abort + supersede race could mislabel. The per-get flag check is kept as belt-and-suspenders.
- **Bounded settle wait** on the post-renewal-abort `await` (`SUPERSEDED_SETTLEMENT_TIMEOUT_MS`): a non-conforming get() that ignores the abort can no longer hang the renewal loop; it re-arms with a fresh challenge instead.

## Test plan
- New test: a modal takeover performed during the renewal's `initiate` call (the no-get-pending window) ends the flow with `superseded=true` and the autofill getter runs exactly once (no re-arm). Fails on the previous code (re-armed forever).
- Existing renewal/takeover/boundary tests all still pass (69 fido2 tests).
- Full suite: 436 passed / 0 failures, twice; tsc and eslint clean.

## Scope note
One item from the renewal-seam review is **deferred**: retry/backoff for a transient `initiateAuth` failure during renewal (a network blip currently kills the autofill flow). It's a distinct resilience concern from the takeover seam; splitting it keeps this PR focused and is filed as a follow-up.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches concurrent WebAuthn sign-in coordination and renewal timing; incorrect supersede logic could break autofill or modal flows, but scope is limited to FIDO2 client code with targeted regression tests.
> 
> **Overview**
> Fixes a seam where **conditional (autofill) passkey sign-in** could keep renewing Cognito challenges in the background after the user started a **modal** passkey flow. Takeovers were only tracked while `navigator.credentials.get()` was pending; between renewal iterations (after aborting the old get and before the next challenge/initiate), nothing was superseded, so autofill could re-arm indefinitely.
> 
> Introduces **`activeConditionalFlow`**, a flow-lifetime supersede marker set when a non-conditional `fido2getCredential` takes the credentials lock, and checked throughout the conditional renewal loop (before/after each `initiateAuth`, on credential success, and after renewal abort). The loop ends with a **`superseded` `Fido2AbortError`** instead of completing or re-arming. **Same-tick races** (credential resolves as a takeover marks the flow superseded) are handled via the flow marker, not only the per-get abort `superseded` flag. **Post-renewal-abort settle** is bounded with `SUPERSEDED_SETTLEMENT_TIMEOUT_MS` so a get that ignores abort cannot hang renewal.
> 
> Adds tests for takeover during the initiate window (getter runs once) and for resolving a credential in the same tick as takeover (flow must not complete).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28a88af7d1081002a71f51f9eeaabcea77349686. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->