### PR TITLE
Gate implicit-flow OAuth fragment errors to responseType "token"

### DIFF
--- a/client/__tests__/react-oauth-callback.test.tsx
+++ b/client/__tests__/react-oauth-callback.test.tsx
@@ -43,11 +43,7 @@ const mockOnTokensStored = onTokensStored as jest.MockedFunction<
 // jsdom's location is not configurable, but history.replaceState updates
 // location.search / location.hash / location.href in place.
 const setLocation = (search: string, hash = "") => {
-  globalThis.history.replaceState(
-    {},
-    "",
-    `/signin-redirect${search}${hash}`
-  );
+  globalThis.history.replaceState({}, "", `/signin-redirect${search}${hash}`);
 };
 
 const wrapper = ({ children }: { children: React.ReactNode }) => (
@@ -141,5 +137,54 @@ describe("React OAuth callback handling", () => {
     });
 
     expect(mockHandleCallback).not.toHaveBeenCalled();
+  });
+
+  it("ignores a fragment-only error in code flow (does not invoke the handler)", async () => {
+    // Code flow delivers errors in the query, never the fragment. A stray
+    // `#error=…` on the redirect path is not our callback — admitting it would
+    // drive the handler to validate state first, find none (code-flow state is
+    // in the query), and clear the shared OAuth state (PKCE / state /
+    // in-progress), which can abort a real code-flow redirect in another tab.
+    setLocation(
+      "",
+      "#error=access_denied&error_description=User+denied&state=s"
+    );
+    mockHandleCallback.mockResolvedValue(null);
+
+    renderHook(() => usePasswordless(), { wrapper });
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 50));
+    });
+
+    expect(mockHandleCallback).not.toHaveBeenCalled();
+  });
+
+  it("invokes the handler and surfaces a fragment error in implicit flow", async () => {
+    // Implicit flow (responseType "token") legitimately delivers errors in the
+    // fragment, so the gate must admit them and the handler must surface them.
+    mockConfigure.mockReturnValue({
+      clientId: "test-client-id",
+      debug: jest.fn(),
+      hostedUi: { responseType: "token" },
+      storage: {
+        getItem: jest.fn(),
+        setItem: jest.fn(),
+        removeItem: jest.fn(),
+      },
+    } as unknown as ConfigWithDefaults);
+    setLocation(
+      "",
+      "#error=access_denied&error_description=User+denied&state=s"
+    );
+    mockHandleCallback.mockRejectedValue(new Error("User denied"));
+
+    const { result } = renderHook(() => usePasswordless(), { wrapper });
+
+    await waitFor(() => {
+      expect(mockHandleCallback).toHaveBeenCalledTimes(1);
+    });
+    await waitFor(() => {
+      expect(result.current.lastError?.message).toBe("User denied");
+    });
   });
 });

--- a/client/react/hooks.tsx
+++ b/client/react/hooks.tsx
@@ -770,14 +770,22 @@ function _usePasswordless() {
       // Fire for a successful redirect (code / implicit access_token) AND for
       // an error redirect (e.g. the user denied consent), which carries
       // neither but does carry `error` — in the query for the code flow, the
-      // fragment for the implicit flow. Without the error case,
-      // handleCognitoOAuthCallback (which surfaces provider errors) was never
-      // invoked, so a denied sign-in left the page silently stuck.
+      // fragment for the implicit flow (RFC 6749 §4.1.2.1 / §4.2.2.1). Without
+      // the error case, handleCognitoOAuthCallback (which surfaces provider
+      // errors) was never invoked, so a denied sign-in left the page stuck.
+      //
+      // The fragment-error case is gated to the implicit flow: code flow never
+      // delivers errors in the fragment, so a stray `#error=…` on the redirect
+      // path is not our callback. Admitting it would drive the handler to
+      // validate state first, find none (code-flow state lives in the query),
+      // and clear the shared OAuth state (PKCE / state / in-progress) — which
+      // can abort a real code-flow redirect still in flight in another tab.
+      const responseType = configure().hostedUi?.responseType ?? "code";
       if (
         urlParams.has("code") ||
         hashParams.has("access_token") ||
         urlParams.has("error") ||
-        hashParams.has("error")
+        (responseType === "token" && hashParams.has("error"))
       ) {
         // Prevent multiple simultaneous OAuth callback processing
         if (oauthProcessingRef.current) {


### PR DESCRIPTION
### Context

Follow-up to #92, addressing a Codex review comment on that PR.

#92 widened the React OAuth-callback gate in `client/react/hooks.tsx` so it also fires on an `error` param (so a denied sign-in surfaces instead of hanging). It checks `error` in **both** the query and the URL fragment, unconditionally:

```ts
urlParams.has("code") ||
hashParams.has("access_token") ||
urlParams.has("error") ||
hashParams.has("error")   // ← fires regardless of flow
```

Per RFC 6749, response errors come back in the **query** for the code flow (§4.1.2.1) and in the **fragment** for the implicit flow (§4.2.2.1). In the default code flow Cognito never delivers a fragment error, so a stray `#error=…` on the redirect path is **not** our callback. Admitting it drives `handleCognitoOAuthCallback` to validate state first (code-flow state is in the query, so none is found), hit `"OAuth state mismatch"`, and call `clearInternal()` — which wipes the shared `cognito_oauth_pkce` / `cognito_oauth_state` / `cognito_oauth_in_progress` keys. That can abort a real code-flow redirect still in flight in another tab.

Severity is low (the trigger requires a fragment error on the redirect path, which Cognito doesn't produce in code flow), but the fix is cheap and makes the gate flow-correct.

### Changes

- `client/react/hooks.tsx`: gate the **fragment**-error branch to `responseType === "token"`. The implicit flow is the only flow that delivers fragment errors, and it only runs when `responseType` is `"token"`. Query errors (code flow) and fragment `access_token`s are unchanged. The handler already reads errors flow-aware and validates state first (added in #92), so this just stops the spurious entry at the gate.
- `client/__tests__/react-oauth-callback.test.tsx`: add two cases — a code-flow fragment error no longer invokes the handler; an implicit-flow fragment error still does and surfaces the provider message.

### Test

- `npx jest` — 437 passed, 18 skipped, 0 failed (incl. the 2 new cases + existing `hosted-oauth` fragment-error tests).
- `eslint` clean on changed files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow OAuth callback detection change with targeted tests; affects sign-in UX edge cases, not auth token validation itself.
> 
> **Overview**
> Follow-up to widening the React OAuth callback gate for query/fragment `error` params: **fragment** `#error=…` is now treated as a callback only when `hostedUi.responseType` is **`"token"`** (implicit flow). Default **code** flow still handles **`?error=…`** in the query; **`code`**, **`access_token`**, and query errors are unchanged.
> 
> This avoids spurious `handleCognitoOAuthCallback` runs on stray hash errors in code flow, which could fail state validation and **`clearInternal()`** shared PKCE/state keys and disrupt a real redirect in another tab.
> 
> Tests cover that code flow ignores fragment-only errors and implicit flow still invokes the handler and surfaces the provider message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 610e20622e8549b7e00e7ca009eeef9269f0dc38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->