### PR TITLE
Honor an explicit advancedSecurity.region as an allowlist override

### DIFF
--- a/client/__tests__/cognito-security.test.ts
+++ b/client/__tests__/cognito-security.test.ts
@@ -185,18 +185,81 @@ describe("CognitoSecurityProvider", () => {
       );
     });
 
-    it("does not inject when the configured advancedSecurity.region is not where the script is hosted", async () => {
+    it("trusts an explicit advancedSecurity.region outside the allowlist (operator opt-in)", async () => {
+      // The allowlist is a hardcoded, necessarily-incomplete list. An
+      // explicitly configured region is an opt-in and must be honoured even
+      // if it is not in the allowlist (the operator may know the region
+      // hosts the script, or be using a new region we haven't listed).
       const provider = loadProvider({
         clientId: "test-client-id",
-        userPoolId: "us-east-1_abc123",
-        cognitoIdpEndpoint: "https://auth-proxy.example.com",
+        userPoolId: "ap-southeast-1_abc123",
+        cognitoIdpEndpoint: "ap-southeast-1",
         advancedSecurity: { region: "ap-southeast-1" },
       });
 
-      const data = await provider.getSecurityData("alice");
+      await provider.getSecurityData("alice");
 
-      expect(data).toBeUndefined();
+      const scripts = injectedScripts();
+      expect(scripts).toHaveLength(1);
+      expect(scripts[0].src).toContain("amazon-cognito-assets.ap-southeast-1");
+    });
+
+    it("re-attempts injection after a reconfigure supplies a usable region", async () => {
+      // A pool in an unsupported region with no override is skipped, but not
+      // permanently latched: a later configure() that adds a usable
+      // advancedSecurity.region must re-attempt injection.
+      let provider: CognitoSecurityProvider | undefined;
+      let cfg: typeof configure | undefined;
+      jest.isolateModules(() => {
+        /* eslint-disable @typescript-eslint/no-var-requires, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call */
+        const configModule = require("../config.js");
+        const securityModule = require("../cognito-security.js");
+        cfg = configModule.configure;
+        configModule.configure({
+          clientId: "test-client-id",
+          userPoolId: "ap-southeast-1_abc123",
+          cognitoIdpEndpoint: "ap-southeast-1",
+        });
+        provider = securityModule.CognitoSecurityProvider.getInstance();
+        /* eslint-enable @typescript-eslint/no-var-requires, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call */
+      });
+      if (!provider || !cfg) throw new Error("failed to load provider");
+
+      // First call: unsupported region, nothing injected
+      await provider.getSecurityData("alice");
       expect(injectedScripts()).toHaveLength(0);
+
+      // Operator reconfigures with a usable region override
+      cfg({
+        clientId: "test-client-id",
+        userPoolId: "ap-southeast-1_abc123",
+        cognitoIdpEndpoint: "ap-southeast-1",
+        advancedSecurity: { region: "us-east-1" },
+      });
+
+      // Second call now injects (the skip was not permanently latched)
+      await provider.getSecurityData("alice");
+      const scripts = injectedScripts();
+      expect(scripts).toHaveLength(1);
+      expect(scripts[0].src).toContain("amazon-cognito-assets.us-east-1");
+    });
+
+    it("lets an unsupported-region pool opt in to the region-generic us-east-1 script", async () => {
+      // The headline use case the override exists for: a pool in a region
+      // that does not host the script points at us-east-1's region-generic
+      // script instead of silently sending no security data.
+      const provider = loadProvider({
+        clientId: "test-client-id",
+        userPoolId: "ap-southeast-1_abc123",
+        cognitoIdpEndpoint: "ap-southeast-1",
+        advancedSecurity: { region: "us-east-1" },
+      });
+
+      await provider.getSecurityData("alice");
+
+      const scripts = injectedScripts();
+      expect(scripts).toHaveLength(1);
+      expect(scripts[0].src).toContain("amazon-cognito-assets.us-east-1");
     });
   });
 

--- a/client/__tests__/cognito-security.test.ts
+++ b/client/__tests__/cognito-security.test.ts
@@ -204,6 +204,24 @@ describe("CognitoSecurityProvider", () => {
       expect(scripts[0].src).toContain("amazon-cognito-assets.ap-southeast-1");
     });
 
+    it("rejects a malformed explicit region to prevent script-host injection", async () => {
+      // An explicit region is interpolated into the script host. A value
+      // like "us-east-1.evil.com/x" (e.g. from deployment/tenant data) must
+      // not be trusted just because it bypasses the allowlist — it would
+      // load the script from amazon-cognito-assets.us-east-1.evil.com.
+      const provider = loadProvider({
+        clientId: "test-client-id",
+        userPoolId: "us-east-1_abc123",
+        cognitoIdpEndpoint: "us-east-1",
+        advancedSecurity: { region: "us-east-1.evil.com/x" },
+      });
+
+      const data = await provider.getSecurityData("alice");
+
+      expect(data).toBeUndefined();
+      expect(injectedScripts()).toHaveLength(0);
+    });
+
     it("re-attempts injection after a reconfigure supplies a usable region", async () => {
       // A pool in an unsupported region with no override is skipped, but not
       // permanently latched: a later configure() that adds a usable

--- a/client/cognito-security.ts
+++ b/client/cognito-security.ts
@@ -46,6 +46,14 @@ const SUPPORTED_SCRIPT_REGIONS = [
   "eu-central-1",
 ];
 
+// A well-formed AWS region identifier, covering partitioned/multi-segment
+// regions (us-gov-west-1, eusc-de-east-1). Two alternatives instead of a
+// nested quantifier to satisfy the security/detect-unsafe-regex lint rule.
+// Crucially this contains no "." or "/", so it cannot express a host other
+// than amazon-cognito-assets.<region>.amazoncognito.com when interpolated
+// into the script URL — a value like "us-east-1.evil.com/x" is rejected.
+const AWS_REGION_FORMAT = /^[a-z]{2,4}-[a-z]+-\d$|^[a-z]{2,4}-[a-z]+-[a-z]+-\d$/;
+
 /**
  * Manages the Amazon Cognito Advanced Security data collection
  */
@@ -122,16 +130,34 @@ export class CognitoSecurityProvider {
     // Prefer the explicitly configured script region (e.g. for custom proxy
     // endpoints), and only fall back to parsing the Cognito IDP endpoint.
     const explicitRegion = advancedSecurity?.region;
+
+    // An explicit region is interpolated into the script host. It must be a
+    // well-formed region token, NOT just any non-empty string: otherwise a
+    // value sourced from deployment/tenant data like "us-east-1.evil.com/x"
+    // would load the script from an attacker-controlled host. Reject a
+    // malformed explicit region outright rather than fall through to the
+    // endpoint-derived region (which would mask the misconfiguration).
+    if (explicitRegion && !AWS_REGION_FORMAT.test(explicitRegion)) {
+      const skipKey = `invalid:${explicitRegion}`;
+      if (this.skippedForRegion !== skipKey) {
+        this.skippedForRegion = skipKey;
+        debug?.(
+          `CognitoSecurityProvider: advancedSecurity.region "${explicitRegion}" is not a valid AWS region identifier, skipping script injection`
+        );
+      }
+      return;
+    }
+
     const region =
       explicitRegion ?? this.resolveScriptRegion(cognitoIdpEndpoint);
 
-    // An explicitly configured advancedSecurity.region is an operator opt-in
-    // and is trusted even if it is not in the (hardcoded, necessarily
-    // incomplete) allowlist — e.g. pointing a pool whose own region does not
-    // host the script at a region that does (us-east-1's script is
-    // region-generic). The allowlist only filters the AUTO-RESOLVED region,
-    // to avoid a guaranteed 404 from loading the script for a region known
-    // not to host it.
+    // A well-formed, explicitly configured advancedSecurity.region is an
+    // operator opt-in and is trusted even if it is not in the (hardcoded,
+    // necessarily incomplete) allowlist — e.g. pointing a pool whose own
+    // region does not host the script at a region that does (us-east-1's
+    // script is region-generic). The allowlist only filters the
+    // AUTO-RESOLVED region, to avoid a guaranteed 404 from loading the
+    // script for a region known not to host it.
     const usable =
       !!region &&
       (!!explicitRegion || SUPPORTED_SCRIPT_REGIONS.includes(region));

--- a/client/cognito-security.ts
+++ b/client/cognito-security.ts
@@ -52,6 +52,11 @@ const SUPPORTED_SCRIPT_REGIONS = [
 export class CognitoSecurityProvider {
   private static instance: CognitoSecurityProvider;
   private scriptInjectionAttempted = false;
+  // The region we last declined to inject for (unsupported / undetermined).
+  // Tracked so a later configure() that supplies a usable region re-attempts
+  // injection instead of being permanently latched, while repeated auth
+  // calls for the same skipped region don't re-log.
+  private skippedForRegion: string | undefined;
 
   // Private constructor for singleton
   private constructor() {}
@@ -115,19 +120,39 @@ export class CognitoSecurityProvider {
     }
 
     // Prefer the explicitly configured script region (e.g. for custom proxy
-    // endpoints), and only fall back to parsing the Cognito IDP endpoint
+    // endpoints), and only fall back to parsing the Cognito IDP endpoint.
+    const explicitRegion = advancedSecurity?.region;
     const region =
-      advancedSecurity?.region ?? this.resolveScriptRegion(cognitoIdpEndpoint);
-    if (!region || !SUPPORTED_SCRIPT_REGIONS.includes(region)) {
-      // Final for this page load: don't reattempt on later calls
-      this.scriptInjectionAttempted = true;
-      debug?.(
-        region
-          ? `CognitoSecurityProvider: Security script not hosted in region ${region}, skipping script injection`
-          : `CognitoSecurityProvider: Cannot determine security script region for endpoint ${cognitoIdpEndpoint}, skipping script injection`
-      );
+      explicitRegion ?? this.resolveScriptRegion(cognitoIdpEndpoint);
+
+    // An explicitly configured advancedSecurity.region is an operator opt-in
+    // and is trusted even if it is not in the (hardcoded, necessarily
+    // incomplete) allowlist — e.g. pointing a pool whose own region does not
+    // host the script at a region that does (us-east-1's script is
+    // region-generic). The allowlist only filters the AUTO-RESOLVED region,
+    // to avoid a guaranteed 404 from loading the script for a region known
+    // not to host it.
+    const usable =
+      !!region &&
+      (!!explicitRegion || SUPPORTED_SCRIPT_REGIONS.includes(region));
+
+    if (!usable) {
+      // Do NOT permanently latch scriptInjectionAttempted here: a later
+      // configure() that supplies a usable advancedSecurity.region must be
+      // able to re-attempt injection. Dedupe the log per distinct skipped
+      // region so repeated auth calls don't spam it.
+      const skipKey = region ?? "<undetermined>";
+      if (this.skippedForRegion !== skipKey) {
+        this.skippedForRegion = skipKey;
+        debug?.(
+          region
+            ? `CognitoSecurityProvider: Security script not hosted in region ${region} and no advancedSecurity.region override set, skipping script injection`
+            : `CognitoSecurityProvider: Cannot determine security script region for endpoint ${cognitoIdpEndpoint} (set advancedSecurity.region to override), skipping script injection`
+        );
+      }
       return;
     }
+    this.skippedForRegion = undefined;
 
     const doc = getDocument();
     if (!doc) {

--- a/client/config.ts
+++ b/client/config.ts
@@ -140,6 +140,10 @@ export interface Config {
      * pool). Make sure the value is a region that actually serves
      * `amazon-cognito-assets.<region>.amazoncognito.com`, otherwise the
      * script 404s and security data is silently omitted.
+     *
+     * Must be a valid AWS region identifier (e.g. `us-east-1`). It is
+     * interpolated into the script host, so a malformed value is rejected
+     * to prevent loading the script from an unexpected host.
      */
     region?: string;
   };

--- a/client/config.ts
+++ b/client/config.ts
@@ -129,7 +129,18 @@ export interface Config {
     };
     /** Automatically inject the Amazon Cognito Advanced Security script if not already present */
     autoInject?: boolean;
-    /** Custom region for the security script (defaults to the region from cognitoIdpEndpoint) */
+    /**
+     * Region to load the Advanced Security script from. Defaults to the
+     * region parsed from `cognitoIdpEndpoint`.
+     *
+     * Setting this is an explicit opt-in that BYPASSES the built-in
+     * allowlist of regions known to host the script: use it for a user pool
+     * whose own region does not host the script by pointing at one that
+     * does (the `us-east-1` script is region-generic and works for any
+     * pool). Make sure the value is a region that actually serves
+     * `amazon-cognito-assets.<region>.amazoncognito.com`, otherwise the
+     * script 404s and security data is silently omitted.
+     */
     region?: string;
   };
   /**


### PR DESCRIPTION
## Summary
Seventh PR of the sequential series. From the post-merge re-review: #70's region allowlist also gated an **explicitly configured** `advancedSecurity.region`, removing the operator's only escape hatch for pools in unlisted regions.

## Bug
#70 added a hardcoded allowlist of regions known to host the Advanced Security script and stopped defaulting unknown regions to `us-east-1`. But it gated an explicitly configured `advancedSecurity.region` behind that same allowlist — so an operator could not point a pool in an unlisted region (e.g. `ap-southeast-1`) at a region that does host the script. The override that existed precisely for that case was itself filtered out, and the pool silently sent no `UserContextData` (only a debug log), degrading adaptive-auth signal.

## Fix
- An explicit `advancedSecurity.region` is now **trusted** and bypasses the (necessarily incomplete, hardcoded) allowlist. The allowlist only filters the **auto-resolved** region, to avoid a guaranteed 404 from a region known not to host the script. Config JSDoc documents the override and that the value must actually host the script (the `us-east-1` script is region-generic).
- **Un-latch the skip**: an unsupported/undetermined region no longer permanently sets `scriptInjectionAttempted`, so a later `configure()` that supplies a usable region re-attempts injection. The skip log is deduped per distinct region so repeated auth calls don't spam it.

## Test plan
- New tests: an explicit region outside the allowlist injects (operator opt-in); a pool in an unsupported region opts in to the `us-east-1` region-generic script; a reconfigure to a usable region re-attempts after an initial skip. The two behavior-change tests fail on the previous code; the headline-scenario test passes on both (us-east-1 was already allowlisted).
- Full suite: 437 passed / 0 failures, twice; tsc and eslint clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes script injection URL construction and when security data is sent—security-sensitive—but scope is limited to Advanced Security auto-inject with added validation and clearer operator opt-in.
> 
> **Overview**
> Restores **operator control** over which AWS region hosts the Cognito Advanced Security script: an explicit `advancedSecurity.region` now **bypasses** the hardcoded hosting allowlist (still applied only to the auto-resolved region from `cognitoIdpEndpoint`), so pools in unlisted regions can opt in—e.g. point at the region-generic **`us-east-1`** script instead of silently omitting `UserContextData`.
> 
> Adds **`AWS_REGION_FORMAT`** validation on explicit regions before they are interpolated into `amazon-cognito-assets.<region>.amazoncognito.com`, rejecting values like `us-east-1.evil.com/x` instead of falling back to endpoint parsing. Skipping injection for unsupported/undetermined regions **no longer permanently latches** `scriptInjectionAttempted`; **`skippedForRegion`** dedupes debug logs and a later `configure()` with a usable region can **re-attempt** injection. Config JSDoc documents the override semantics and validation expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fee39adfbd65bff198023f6987291fc8a6514a8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->