### PR TITLE
Cap the MFA-status fetch retry so a failing getUser can't poll forever

### DIFF
--- a/client/__tests__/react-mfa-status-cooldown.test.tsx
+++ b/client/__tests__/react-mfa-status-cooldown.test.tsx
@@ -158,4 +158,49 @@ describe("MFA status fetch cooldown", () => {
     });
     expect(mockGetUser).toHaveBeenCalledTimes(2);
   });
+
+  it("stops retrying MFA status fetch after the cap when getUser keeps failing", async () => {
+    mockRetrieveTokens.mockResolvedValue(makeTokens("initial"));
+    // getUser fails every time (e.g. a network outage or a backend erroring)
+    mockGetUser.mockRejectedValue(new Error("network down"));
+
+    const wrapper = makeWrapper();
+    const { result } = renderHook(() => usePasswordless(), { wrapper });
+
+    // Initial attempt
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(0);
+    });
+    expect(mockGetUser).toHaveBeenCalledTimes(1);
+    // Even on failure the UI is unblocked (last-known status retained)
+    expect(result.current.mfaStatusReady).toBe(true);
+
+    // Drive well past many retry windows (each retry is 6–8s jittered).
+    // The cap is 3 retries, so a total of 1 initial + 3 retries = 4 fetches,
+    // after which it must stop — not poll forever.
+    for (let i = 0; i < 12; i++) {
+      await act(async () => {
+        await jest.advanceTimersByTimeAsync(8_000);
+      });
+    }
+
+    expect(mockGetUser).toHaveBeenCalledTimes(4);
+
+    // A genuinely new token resets the budget and fetches again
+    mockGetUser.mockClear();
+    mockGetUser.mockRejectedValue(new Error("still down"));
+    const rotated = makeTokens("rotated") as TokensFromRefresh;
+    mockRefreshTokens.mockImplementation(async (args) => {
+      await args?.tokensCb?.(rotated);
+      return rotated;
+    });
+    await act(async () => {
+      await result.current.refreshTokens();
+    });
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(0);
+    });
+    // The new token gets its own first fetch (budget reset)
+    expect(mockGetUser).toHaveBeenCalled();
+  });
 });

--- a/client/react/hooks.tsx
+++ b/client/react/hooks.tsx
@@ -654,6 +654,14 @@ function _usePasswordless() {
   const mfaRetryTimeoutRef = useRef<
     ReturnType<typeof setTimeout> | undefined
   >();
+  // How many silent MFA-fetch retries have been scheduled for the CURRENT
+  // access token, so a persistently failing getUser stops retrying instead
+  // of polling every ~7s forever. The retry path clears
+  // lastFetchedMfaTokenRef (to force a re-fetch of the same token), so the
+  // budget is tracked against its own token ref rather than that one.
+  const mfaRetryCountRef = useRef<number>(0);
+  const mfaRetryForTokenRef = useRef<string | undefined>();
+  const MAX_MFA_FETCH_RETRIES = 3;
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
@@ -1111,6 +1119,14 @@ function _usePasswordless() {
       };
     }
 
+    // A genuinely new access token resets the retry budget (a fresh session
+    // deserves a fresh set of retries). A retry of the SAME token does not
+    // (the retry path cleared lastFetchedMfaTokenRef, so that ref can't be
+    // used to tell the two apart).
+    if (tokens.accessToken !== mfaRetryForTokenRef.current) {
+      mfaRetryCountRef.current = 0;
+      mfaRetryForTokenRef.current = tokens.accessToken;
+    }
     lastFetchedMfaTokenRef.current = tokens.accessToken;
     lastMfaFetchTimeRef.current = now;
 
@@ -1146,11 +1162,13 @@ function _usePasswordless() {
             },
           });
           dispatch({ type: "SET_MFA_STATUS_READY", payload: true });
-          // Successful fetch – cancel any scheduled retry
+          // Successful fetch – cancel any scheduled retry and reset the
+          // per-token retry budget
           if (mfaRetryTimeoutRef.current) {
             clearTimeout(mfaRetryTimeoutRef.current);
             mfaRetryTimeoutRef.current = undefined;
           }
+          mfaRetryCountRef.current = 0;
         } else {
           // Default to no MFA
           dispatch({
@@ -1166,6 +1184,7 @@ function _usePasswordless() {
             clearTimeout(mfaRetryTimeoutRef.current);
             mfaRetryTimeoutRef.current = undefined;
           }
+          mfaRetryCountRef.current = 0;
         }
       })
       .catch(() => {
@@ -1177,11 +1196,22 @@ function _usePasswordless() {
         debug?.("getUser failed; retaining previous TOTP MFA status");
         // Ensure UI never hangs behind a loader due to a transient failure
         dispatch({ type: "SET_MFA_STATUS_READY", payload: true });
-        // Schedule a simple early silent retry with jitter (6–8s)
+        // Schedule a simple early silent retry with jitter (6–8s), but cap
+        // the number of retries per token so a persistently failing getUser
+        // (e.g. a network outage, or a backend that keeps erroring) does not
+        // poll forever. mfaStatusReady is already true, so the UI is not
+        // blocked while we stop retrying.
         if (mfaRetryTimeoutRef.current) {
           clearTimeout(mfaRetryTimeoutRef.current);
           mfaRetryTimeoutRef.current = undefined;
         }
+        if (mfaRetryCountRef.current >= MAX_MFA_FETCH_RETRIES) {
+          debug?.(
+            `getUser failed ${mfaRetryCountRef.current} times for this token; giving up MFA-status retries until the next sign-in / token refresh`
+          );
+          return;
+        }
+        mfaRetryCountRef.current += 1;
         const jitterMs = 6000 + Math.floor(Math.random() * 2000);
         mfaRetryTimeoutRef.current = setTimeout(() => {
           // Clear token guard so the effect can try again


### PR DESCRIPTION
## Summary
Eighth PR of the sequential series. From the post-merge re-review's React-hook cleanups: the MFA-status fetch retry had no cap.

## Bug
On a `getUser` error the hook retained the last-known MFA status, marked `mfaStatusReady` true, and scheduled a silent retry every ~7s by clearing the token guard and nudging a re-run. With **no cap**, a persistent failure (network outage, or a backend that keeps erroring) retried forever.

## Fix
Cap retries at 3 per access token. The budget is tracked against its own token ref (`mfaRetryForTokenRef`) because the retry path clears `lastFetchedMfaTokenRef` to force a re-fetch of the *same* token — so that ref can't tell a retry apart from a new token (using it would zero the budget on every retry and re-create the loop). A genuinely new token (sign-in / refresh) resets the budget; a successful fetch resets it too. `mfaStatusReady` is already true, so the UI is never blocked while retries stop.

## Test plan
- `getUser` failing every time yields exactly 1 initial + 3 retries = 4 fetches, then stops (the previous code kept polling — 13+ and climbing in the test window); a token rotation resets the budget and fetches again.
- Full suite: 443 passed / 0 failures, twice; tsc and eslint clean.

## Scope note
"PR H" in my plan also bucketed three more independent React-hook cleanups — cross-tab `SIGN_OUT` on another tab's sign-out, `deviceKey` rehydration in the SRP/plaintext `tokensCb`, and scheduling a refresh on page reload. Each is an independent state-machine change with its own test surface, so they're split into focused follow-ups rather than bundled here (this PR is the substantive infinite-loop fix).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to MFA status fetch retry logic in the React hook; reduces API load and avoids unbounded polling without blocking the UI on failure.
> 
> **Overview**
> Fixes an **infinite retry loop** when Cognito `getUser` keeps failing during MFA status loading: the hook still sets `mfaStatusReady` and keeps last-known MFA state, but silent ~6–8s retries are now **limited to 3 per access token** (`MAX_MFA_FETCH_RETRIES`).
> 
> Retry counting uses **`mfaRetryForTokenRef`** (not `lastFetchedMfaTokenRef`, which retries clear to re-fetch the same token). A **new access token** or a **successful fetch** resets the budget. After the cap, retries stop until sign-in or token refresh.
> 
> Adds a test that persistent `getUser` failures yield **1 initial + 3 retries = 4 calls**, then silence, and that **token rotation** triggers a fresh fetch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3e1756ee40ebbb75e6105a61951821be3e205b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->