### PR TITLE
Fix processTokens refresh-scheduling dedup and fresh-login deferral

### DIFF
--- a/client/common.ts
+++ b/client/common.ts
@@ -50,6 +50,9 @@ const activeRefreshSchedules = new Map<
     abortController: AbortController;
     refreshToken: string;
     accessToken: string;
+    /** Handle for the fresh-login deferral timer, so it can be cancelled if
+     * the schedule is replaced or the user signs out before it fires */
+    deferralTimer?: ReturnType<typeof setTimeout>;
   }
 >();
 
@@ -349,6 +352,11 @@ async function processTokensInternal(
       if (existingSchedule.abortController.signal !== abort) {
         existingSchedule.abortController.abort();
       }
+      // Cancel a still-pending fresh-login deferral so a replaced schedule's
+      // timer can't fire and schedule a refresh for stale tokens
+      if (existingSchedule.deferralTimer) {
+        clearTimeout(existingSchedule.deferralTimer);
+      }
       activeRefreshSchedules.delete(normalizedTokens.username);
     }
 
@@ -360,9 +368,16 @@ async function processTokensInternal(
         "abort",
         () => {
           scheduleAbort.abort();
-          // Clean up the schedule tracking when aborted
+          // Clean up the schedule tracking when aborted, but only if it is
+          // still OUR entry — a newer processTokens may have replaced it.
           if (normalizedTokens.username) {
-            activeRefreshSchedules.delete(normalizedTokens.username);
+            const current = activeRefreshSchedules.get(
+              normalizedTokens.username
+            );
+            if (current?.abortController === scheduleAbort) {
+              if (current.deferralTimer) clearTimeout(current.deferralTimer);
+              activeRefreshSchedules.delete(normalizedTokens.username);
+            }
           }
         },
         { once: true }
@@ -377,15 +392,26 @@ async function processTokensInternal(
       accessToken: normalizedTokens.accessToken,
     });
 
+    // Delete the schedule entry only if it is still the one this scheduleFn
+    // registered. A completed refresh runs its nested processTokens (which
+    // registers the NEXT schedule for the new tokens) BEFORE this tokensCb
+    // fires, so an unconditional delete would wipe the replacement entry —
+    // leaving the dedup map empty while a timer is armed, and making
+    // signOut's targeted abort a no-op for it.
+    const clearOwnSchedule = () => {
+      if (!normalizedTokens.username) return;
+      const current = activeRefreshSchedules.get(normalizedTokens.username);
+      if (current?.abortController === scheduleAbort) {
+        activeRefreshSchedules.delete(normalizedTokens.username);
+      }
+    };
+
     const scheduleFn = () => {
       debug?.("🔄 [Process Tokens] Scheduling token refresh");
       scheduleRefresh({
         abort: scheduleAbort.signal,
         tokensCb: (newTokens) => {
-          // Always clear the schedule tracking when refresh completes (success or no tokens)
-          if (normalizedTokens.username) {
-            activeRefreshSchedules.delete(normalizedTokens.username);
-          }
+          clearOwnSchedule();
           if (!newTokens) return;
           // We don't need to store tokens here because processTokens will be called
           // for the refresh tokens too, and it will store them.
@@ -393,22 +419,33 @@ async function processTokensInternal(
         },
       }).catch((err) => {
         debug?.("❌ [Process Tokens] Failed to schedule token refresh:", err);
-        // Clear the schedule tracking on error
-        if (normalizedTokens.username) {
-          activeRefreshSchedules.delete(normalizedTokens.username);
-        }
+        clearOwnSchedule();
       });
     };
 
-    if (!("newDeviceMetadata" in normalizedTokens)) {
-      // Not a fresh login, schedule immediately
+    // Defer scheduling only for a genuine fresh login WITH a new device
+    // (newDeviceMetadata carrying a deviceKey). The previous `"key" in obj`
+    // check was true whenever the property merely existed — including the
+    // FIDO2 / hosted-OAuth token objects that set newDeviceMetadata to
+    // undefined — so every flow got the 2-minute deferral.
+    const freshDeviceKey =
+      "newDeviceMetadata" in normalizedTokens
+        ? normalizedTokens.newDeviceMetadata?.deviceKey
+        : undefined;
+    if (!freshDeviceKey) {
+      // Not a fresh login with a new device, schedule immediately
       scheduleFn();
     } else {
-      // Fresh login, delay by 2 minutes
+      // Fresh login with a new device, delay by 2 minutes. Track the timer
+      // so a sign-out / replacement within the window can cancel it.
       debug?.(
         "🔄 [Process Tokens] Fresh login detected, deferring token refresh scheduling"
       );
-      setTimeout(scheduleFn, FRESH_LOGIN_REFRESH_DELAY_MS);
+      const deferralTimer = setTimeout(scheduleFn, FRESH_LOGIN_REFRESH_DELAY_MS);
+      const entry = activeRefreshSchedules.get(normalizedTokens.username);
+      if (entry?.abortController === scheduleAbort) {
+        entry.deferralTimer = deferralTimer;
+      }
     }
   } else {
     debug?.(
@@ -552,6 +589,11 @@ export const signOut = (props?: {
           if (activeSchedule) {
             debug?.("signOut: cancelling active refresh schedule for user");
             activeSchedule.abortController.abort();
+            // Also cancel a pending fresh-login deferral so it can't fire
+            // and schedule a refresh for the session we are signing out of
+            if (activeSchedule.deferralTimer) {
+              clearTimeout(activeSchedule.deferralTimer);
+            }
             activeRefreshSchedules.delete(userIdentifier);
           }
 

--- a/test/process-tokens-scheduling.test.ts
+++ b/test/process-tokens-scheduling.test.ts
@@ -1,0 +1,167 @@
+// Per-test module isolation: processTokens launches fire-and-forget
+// scheduleRefresh chains that can outlive the test that started them; a
+// fresh module graph per test keeps stragglers bound to the previous test's
+// storage so they can't touch the running one (see refresh-bugs.test.ts).
+let configure: typeof import("../client/config.js").configure;
+let processTokens: typeof import("../client/common.js").processTokens;
+let signOut: typeof import("../client/common.js").signOut;
+let cleanupUserRefreshState: typeof import("../client/refresh.js").cleanupUserRefreshState;
+
+const createJWT = (claims: Record<string, unknown>) => {
+  const enc = (o: unknown) =>
+    btoa(JSON.stringify(o))
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+  return `${enc({ alg: "HS256", typ: "JWT" })}.${enc(claims)}.sig`;
+};
+
+function createMemoryStorage() {
+  const store = new Map<string, string>();
+  return {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      store.set(key, value);
+    },
+    removeItem: (key: string) => {
+      store.delete(key);
+    },
+  };
+}
+
+const USERNAME = "testuser";
+let debugLogs: string[];
+
+// processTokens takes the auth lock (jittered sleeps) under fake timers, so
+// awaiting it directly would hang. Advance fake time in small steps until
+// the promise settles.
+async function settle<T>(p: Promise<T>): Promise<T> {
+  let done = false;
+  const wrapped = p.finally(() => {
+    done = true;
+  });
+  for (let i = 0; i < 100 && !done; i++) {
+    await jest.advanceTimersByTimeAsync(50);
+  }
+  return wrapped;
+}
+
+const baseTokens = () => {
+  const now = Date.now();
+  return {
+    accessToken: createJWT({
+      sub: "u",
+      username: USERNAME,
+      exp: Math.floor((now + 3600_000) / 1000),
+      iat: Math.floor(now / 1000),
+    }),
+    idToken: createJWT({
+      sub: "u",
+      "cognito:username": USERNAME,
+      exp: Math.floor((now + 3600_000) / 1000),
+      iat: Math.floor(now / 1000),
+    }),
+    refreshToken: "refresh-token",
+    expireAt: new Date(now + 3600_000),
+    username: USERNAME,
+    authMethod: "SRP" as const,
+  };
+};
+
+beforeEach(async () => {
+  jest.resetModules();
+  jest.useFakeTimers();
+  ({ configure } = await import("../client/config.js"));
+  ({ processTokens, signOut } = await import("../client/common.js"));
+  ({ cleanupUserRefreshState } = await import("../client/refresh.js"));
+
+  debugLogs = [];
+  configure({
+    clientId: "testClient",
+    cognitoIdpEndpoint: "us-west-2",
+    // Refreshes never actually fire in these tests (we assert on the
+    // scheduling debug logs, not on refresh results); a rejecting fetch
+    // keeps any stray scheduled refresh from doing real work.
+    fetch: jest.fn(() =>
+      Promise.reject(new Error("no network in test"))
+    ) as unknown as typeof fetch,
+    storage: createMemoryStorage(),
+    debug: (...args: unknown[]) => debugLogs.push(args.map(String).join(" ")),
+  });
+});
+
+afterEach(async () => {
+  cleanupUserRefreshState(USERNAME);
+  await jest.advanceTimersByTimeAsync(0);
+  jest.useRealTimers();
+});
+
+describe("processTokens fresh-login deferral", () => {
+  test("schedules immediately when newDeviceMetadata is present but undefined (FIDO2/OAuth)", async () => {
+    // The FIDO2 / hosted-OAuth token objects set newDeviceMetadata to
+    // undefined; the old `"key" in obj` check treated that as a fresh login
+    // and deferred scheduling for every such flow.
+    await settle(
+      processTokens({ ...baseTokens(), newDeviceMetadata: undefined })
+    );
+
+    expect(debugLogs.some((l) => l.includes("Fresh login detected"))).toBe(
+      false
+    );
+    expect(
+      debugLogs.some((l) => l.includes("Scheduling token refresh"))
+    ).toBe(true);
+  });
+
+  test("defers scheduling only for a genuine fresh login with a new device key", async () => {
+    await settle(
+      processTokens({
+        ...baseTokens(),
+        newDeviceMetadata: {
+          deviceKey: "us-west-2_dev",
+          deviceGroupKey: "grp",
+        },
+      })
+    );
+
+    // Deferred: not scheduled yet
+    expect(debugLogs.some((l) => l.includes("Fresh login detected"))).toBe(
+      true
+    );
+    expect(
+      debugLogs.some((l) => l.includes("Scheduling token refresh"))
+    ).toBe(false);
+
+    // Fires after the 2-minute deferral
+    debugLogs.length = 0;
+    await jest.advanceTimersByTimeAsync(120_000);
+    expect(
+      debugLogs.some((l) => l.includes("Scheduling token refresh"))
+    ).toBe(true);
+  });
+
+  test("cancels a pending fresh-login deferral on sign-out", async () => {
+    await settle(
+      processTokens({
+        ...baseTokens(),
+        newDeviceMetadata: {
+          deviceKey: "us-west-2_dev",
+          deviceGroupKey: "grp",
+        },
+      })
+    );
+    expect(debugLogs.some((l) => l.includes("Fresh login detected"))).toBe(
+      true
+    );
+
+    // Sign out before the 2-minute deferral fires
+    await settle(signOut().signedOut);
+
+    // Advance past the deferral window: the cancelled timer must NOT schedule
+    debugLogs.length = 0;
+    await jest.advanceTimersByTimeAsync(180_000);
+    expect(
+      debugLogs.some((l) => l.includes("Scheduling token refresh"))
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
Ninth PR of the sequential series. Three related warts in the `processTokens` refresh-scheduling machinery (the cohesive `common.ts` subset of the re-review's "core cleanups").

## Fixes
1. **Identity-checked schedule deletion.** A completed refresh runs its nested `processTokens` (which registers the **next** schedule for the new tokens) *before* the old schedule's `tokensCb` fires. That `tokensCb` deleted the user's `activeRefreshSchedules` entry unconditionally — wiping the replacement entry, leaving the dedup map empty while a timer was armed, so `signOut`'s targeted abort became a no-op for it and a duplicate `processTokens` wouldn't dedupe. Now deletes only when the entry is still the one this `scheduleFn` registered (the same identity check the adjacent abort listener already uses).
2. **Fresh-login detection.** `"newDeviceMetadata" in tokens` was true whenever the property merely *existed* — including FIDO2 / hosted-OAuth token objects that set it to `undefined` — so **every** flow got the 2-minute scheduling deferral. Now defers only for a genuine fresh login carrying a new device key (`newDeviceMetadata?.deviceKey`).
3. **Cancellable deferral timer.** The 2-minute deferral `setTimeout` handle was discarded, so a sign-out or schedule replacement within the window couldn't cancel it — it would schedule a refresh for a torn-down / stale session. Now tracked on the schedule entry and cleared on replacement, abort, and `signOut`.

## Test plan
- New `test/process-tokens-scheduling.test.ts`: `newDeviceMetadata=undefined` schedules immediately (no deferral); a real new device key defers 2 minutes; sign-out cancels a pending deferral. The two behavior-change tests fail on the previous code.
- Full suite: 446 passed / 0 failures, twice; tsc and eslint clean.

## Scope note
"PR I" in my plan also bucketed three unrelated trivia — `initiateAuth` mutating the caller's `authParameters`, a dead `getLastAuthUsername` export, and rejecting `http://` supplied via `hostedUi.domain`. Those are independent one-liners in different files; they're split into a follow-up rather than bundled with this scheduling-machinery change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core session lifecycle (token refresh scheduling and sign-out teardown); fixes are localized but incorrect behavior could affect refresh timing or post-sign-out token activity.
> 
> **Overview**
> Fixes three race and mis-detection bugs in **`processTokens`** refresh scheduling in `common.ts`.
> 
> **Schedule map cleanup** now uses identity checks (`clearOwnSchedule` and the abort listener) so a finished refresh does not delete the *next* schedule entry that nested `processTokens` already registered—avoiding an empty dedup map with an armed timer and making `signOut` abort ineffective.
> 
> **Fresh-login deferral** applies only when `newDeviceMetadata?.deviceKey` is set, not merely when the property exists (FIDO2/hosted OAuth pass `newDeviceMetadata: undefined`), so those flows schedule refresh immediately instead of waiting two minutes.
> 
> The **2-minute deferral timer** is stored on the schedule entry and cleared on schedule replacement, external abort, and **`signOut`**, so a deferred refresh cannot run after the session is torn down.
> 
> Adds **`test/process-tokens-scheduling.test.ts`** covering immediate scheduling for undefined metadata, deferral with a real device key, and deferral cancellation on sign-out.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91861cc050f459291631754614e509cd17e46e84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->