### PR TITLE
Resolve CodeQL alerts: two polynomial-ReDoS regexes + workflow permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,11 @@ on:
     branches: [main]
   workflow_dispatch:
 
+# Minimal token permissions: the test job only reads the repo and uploads
+# coverage via a dedicated CODECOV_TOKEN secret (not GITHUB_TOKEN).
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/client/config.ts
+++ b/client/config.ts
@@ -368,7 +368,13 @@ function normalizeEndpoint(endpoint: string): string {
   const withProtocol = endpoint.startsWith("http")
     ? endpoint
     : `https://${endpoint}`;
-  return withProtocol.replace(/\/+$/, ""); // trim trailing slashes
+  // Trim trailing slashes with a linear scan rather than /\/+$/, whose
+  // backtracking is polynomial on long runs of "/" (CodeQL js/polynomial-redos)
+  let end = withProtocol.length;
+  while (end > 0 && withProtocol.charCodeAt(end - 1) === 47 /* "/" */) {
+    end--;
+  }
+  return withProtocol.slice(0, end);
 }
 
 /**

--- a/client/util.ts
+++ b/client/util.ts
@@ -26,9 +26,14 @@ export async function throwIfNot2xx(res: MinimalResponse) {
   const detail = (await res.json()) as { __type: string; message: string };
   let message = detail.message;
   if (detail.__type === "UserLambdaValidationException") {
-    const match = detail.message.match(/^.+failed with error (.+)$/);
-    if (match) {
-      message = match[1];
+    // Extract the text after the last "failed with error " without the
+    // backtracking regex /^.+failed with error (.+)$/, which is polynomial
+    // on crafted messages (CodeQL js/polynomial-redos). Mirrors the regex:
+    // a non-empty prefix (idx > 0) and a non-empty captured suffix.
+    const marker = "failed with error ";
+    const idx = detail.message.lastIndexOf(marker);
+    if (idx > 0 && idx + marker.length < detail.message.length) {
+      message = detail.message.slice(idx + marker.length);
     }
   }
 

--- a/client/util.ts
+++ b/client/util.ts
@@ -26,14 +26,20 @@ export async function throwIfNot2xx(res: MinimalResponse) {
   const detail = (await res.json()) as { __type: string; message: string };
   let message = detail.message;
   if (detail.__type === "UserLambdaValidationException") {
-    // Extract the text after the last "failed with error " without the
-    // backtracking regex /^.+failed with error (.+)$/, which is polynomial
-    // on crafted messages (CodeQL js/polynomial-redos). Mirrors the regex:
-    // a non-empty prefix (idx > 0) and a non-empty captured suffix.
+    // Replicate /^.+failed with error (.+)$/ without the backtracking regex,
+    // which is polynomial on crafted messages (CodeQL js/polynomial-redos).
+    // The greedy `^.+` makes the regex resolve to the RIGHTMOST "failed with
+    // error " that still has a non-empty suffix (it backtracks past a final
+    // marker that has no text after it), with a non-empty prefix.
     const marker = "failed with error ";
-    const idx = detail.message.lastIndexOf(marker);
-    if (idx > 0 && idx + marker.length < detail.message.length) {
-      message = detail.message.slice(idx + marker.length);
+    let pos = detail.message.lastIndexOf(marker);
+    while (pos > 0) {
+      if (pos + marker.length < detail.message.length) {
+        message = detail.message.slice(pos + marker.length);
+        break;
+      }
+      // This occurrence has no suffix; look for an earlier one.
+      pos = detail.message.lastIndexOf(marker, pos - 1);
     }
   }
 

--- a/test/redos-fixes.test.ts
+++ b/test/redos-fixes.test.ts
@@ -32,6 +32,14 @@ describe("throwIfNot2xx UserLambdaValidationException message extraction", () =>
     );
   });
 
+  test("uses an earlier marker when the rightmost one has no suffix (matches the greedy regex)", async () => {
+    // The greedy /^.+failed with error (.+)$/ backtracks past the final
+    // (suffix-less) marker to the previous one that does have text after it.
+    expect(
+      await extract("X failed with error Y failed with error ")
+    ).toBe("Y failed with error ");
+  });
+
   test("leaves the message unchanged when there is no prefix or no suffix", async () => {
     // No prefix (marker at start) → unchanged
     expect(await extract("failed with error X")).toBe("failed with error X");

--- a/test/redos-fixes.test.ts
+++ b/test/redos-fixes.test.ts
@@ -1,0 +1,86 @@
+import { configure } from "../client/config.js";
+import { throwIfNot2xx } from "../client/util.js";
+import { getAuthorizeEndpoint } from "../client/config.js";
+
+const errResponse = (type: string, message: string) => ({
+  ok: false,
+  status: 400,
+  json: () => Promise.resolve({ __type: type, message }),
+});
+
+describe("throwIfNot2xx UserLambdaValidationException message extraction", () => {
+  const extract = async (message: string): Promise<string> => {
+    try {
+      await throwIfNot2xx(
+        errResponse("UserLambdaValidationException", message) as never
+      );
+      throw new Error("should have thrown");
+    } catch (e) {
+      return (e as Error).message;
+    }
+  };
+
+  test("extracts the text after 'failed with error '", async () => {
+    expect(
+      await extract("PreSignUp failed with error Email domain not allowed.")
+    ).toBe("Email domain not allowed.");
+  });
+
+  test("leaves the message unchanged when the marker is absent", async () => {
+    expect(await extract("Some other validation message")).toBe(
+      "Some other validation message"
+    );
+  });
+
+  test("leaves the message unchanged when there is no prefix or no suffix", async () => {
+    // No prefix (marker at start) → unchanged
+    expect(await extract("failed with error X")).toBe("failed with error X");
+    // No suffix (marker at end) → unchanged
+    expect(await extract("Trigger failed with error ")).toBe(
+      "Trigger failed with error "
+    );
+  });
+
+  test("returns quickly (no ReDoS) on a pathological message", async () => {
+    // The old /^.+failed with error (.+)$/ backtracks polynomially on a long
+    // near-miss; this must complete well under any sane timeout.
+    const pathological = "a".repeat(200_000) + "failed with erro"; // near-miss
+    const start = Date.now();
+    const out = await extract(pathological);
+    expect(Date.now() - start).toBeLessThan(1000);
+    expect(out).toBe(pathological); // no marker match → unchanged
+  });
+});
+
+describe("endpoint trailing-slash normalization", () => {
+  test("trims trailing slashes from a custom https endpoint", () => {
+    configure({
+      clientId: "c",
+      cognitoIdpEndpoint: "https://auth.example.com///",
+      hostedUi: {
+        domain: "auth.example.com////",
+        redirectSignIn: "https://app.example.com/cb",
+      },
+    });
+    // getAuthorizeEndpoint builds on the normalized hostedUi domain
+    expect(getAuthorizeEndpoint()).toBe(
+      "https://auth.example.com/oauth2/authorize"
+    );
+  });
+
+  test("returns quickly (no ReDoS) on a long run of trailing slashes", () => {
+    const start = Date.now();
+    configure({
+      clientId: "c",
+      cognitoIdpEndpoint: "https://auth.example.com",
+      hostedUi: {
+        domain: "https://auth.example.com" + "/".repeat(200_000),
+        redirectSignIn: "https://app.example.com/cb",
+      },
+    });
+    expect(getAuthorizeEndpoint()).toBe(
+      "https://auth.example.com/oauth2/authorize"
+    );
+    expect(Date.now() - start).toBeLessThan(1000);
+  });
+});


### PR DESCRIPTION
## Summary
Addresses the open GitHub **code-scanning (CodeQL)** alerts found while auditing the repo's security tab.

| # | Severity | Location | Rule |
|---|----------|----------|------|
| 4 | HIGH | `client/config.ts` (trailing-slash trim) | `js/polynomial-redos` |
| 3 | HIGH | `client/util.ts` (Lambda error message) | `js/polynomial-redos` |
| 1 | MEDIUM | `.github/workflows/main.yml` | `actions/missing-workflow-permissions` |

## Fixes
- **`config.ts`** — `/\/+$/` backtracks polynomially on a long run of `/`. Replaced with a linear backward scan.
- **`util.ts`** — `/^.+failed with error (.+)$/` (run on a Cognito `UserLambdaValidationException` message) backtracks polynomially on a crafted near-miss. Replaced with `lastIndexOf`/`slice`, mirroring the regex's semantics (non-empty prefix and suffix) with no backtracking.
- **`main.yml`** — added an explicit minimal `permissions: contents: read`. The test job only reads the repo; coverage upload uses a dedicated `CODECOV_TOKEN` secret, not `GITHUB_TOKEN`.

## Test plan
- New `test/redos-fixes.test.ts`: message extraction unchanged (incl. no-marker / no-prefix / no-suffix cases); trailing-slash trim unchanged; both paths stay fast on pathological inputs.
- Full suite: 449 passed / 0 failures, twice; tsc and eslint clean.
- CodeQL re-scan on this PR should clear alerts #3 and #4 (the backtracking regexes are gone) and #1 (permissions block added).

## Note on the Dependabot alert
The one open Dependabot alert — esbuild `< 0.28.1` RCE — is already addressed by the in-flight bump [#90](https://github.com/joinmeow/amazon-cognito-passwordless-auth/pull/90). esbuild is a build-time tool in this repo (the `dist` script), and the advisory's Deno-module vector does not apply to this npm usage; the version bump is still the right remediation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving security hardening with targeted tests; CI only narrows default token scope to read-only repo access.
> 
> **Overview**
> Clears CodeQL **js/polynomial-redos** findings by replacing two backtracking regexes with linear string handling, and adds explicit minimal **`permissions: contents: read`** on the test workflow.
> 
> In **`client/config.ts`**, trailing-slash trimming on OAuth/Hosted UI base URLs no longer uses `/\/+$/`; it walks backward from the end of the string so long runs of `/` cannot trigger polynomial backtracking.
> 
> In **`client/util.ts`**, **`UserLambdaValidationException`** message parsing no longer uses `/^.+failed with error (.+)$/`. It uses **`lastIndexOf`** / **`slice`** to pick the rightmost `"failed with error "` with a non-empty prefix and suffix, matching the old greedy-regex behavior without ReDoS risk on crafted Cognito error text.
> 
> **`test/redos-fixes.test.ts`** locks in extraction edge cases, slash normalization, and timing checks on pathological inputs. The CI workflow comment documents that coverage upload uses **`CODECOV_TOKEN`**, not **`GITHUB_TOKEN`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49c9ab359eecae90cdb42a832b1141c5bb814560. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->