### PR TITLE
Misc safety: no authParameters mutation, reject http:// hostedUi.domain

### DIFF
--- a/client/__tests__/initiate-auth-no-mutation.test.ts
+++ b/client/__tests__/initiate-auth-no-mutation.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Copyright Amazon.com, Inc. and its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You
+ * may not use this file except in compliance with the License. A copy of
+ * the License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+import { configure } from "../config.js";
+import type { MinimalFetch } from "../config.js";
+import { initiateAuth } from "../cognito-api.js";
+
+describe("initiateAuth does not mutate the caller's authParameters", () => {
+  let fetchMock: jest.Mock;
+
+  beforeEach(() => {
+    fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ AuthenticationResult: {} }),
+    });
+    configure({
+      clientId: "test-client",
+      cognitoIdpEndpoint: "us-east-1",
+      fetch: fetchMock as unknown as MinimalFetch,
+    });
+  });
+
+  const sentDeviceKey = () => {
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body as string) as {
+      AuthParameters: Record<string, string>;
+    };
+    return body.AuthParameters.DEVICE_KEY;
+  };
+
+  it("sends DEVICE_KEY in the request without adding it to the caller's object", async () => {
+    const authParameters: Record<string, string> = {
+      USERNAME: "alice",
+      PASSWORD: "secret",
+    };
+
+    await initiateAuth({
+      authflow: "USER_PASSWORD_AUTH",
+      authParameters,
+      deviceKey: "us-east-1_device",
+    });
+
+    // The request carried the device key ...
+    expect(sentDeviceKey()).toBe("us-east-1_device");
+    // ... but the caller's object was NOT mutated
+    expect(authParameters).toEqual({ USERNAME: "alice", PASSWORD: "secret" });
+    expect("DEVICE_KEY" in authParameters).toBe(false);
+  });
+
+  it("reuses the same authParameters object across two calls without leaking DEVICE_KEY", async () => {
+    const authParameters: Record<string, string> = {
+      USERNAME: "alice",
+      PASSWORD: "secret",
+    };
+
+    // First attempt WITH a device key
+    await initiateAuth({
+      authflow: "USER_PASSWORD_AUTH",
+      authParameters,
+      deviceKey: "us-east-1_device",
+    });
+    // Second attempt WITHOUT a device key, reusing the same object: it must
+    // not still carry the first attempt's DEVICE_KEY (the previous mutation
+    // bug left it stuck on the object).
+    await initiateAuth({
+      authflow: "USER_PASSWORD_AUTH",
+      authParameters,
+    });
+
+    const secondBody = JSON.parse(
+      fetchMock.mock.calls[1][1].body as string
+    ) as { AuthParameters: Record<string, string> };
+    expect("DEVICE_KEY" in secondBody.AuthParameters).toBe(false);
+  });
+});

--- a/client/__tests__/oauth-endpoints.test.ts
+++ b/client/__tests__/oauth-endpoints.test.ts
@@ -35,6 +35,35 @@ describe("OAuth2 endpoints (Hosted UI domain)", () => {
       ).toThrow("hostedUi.domain is required");
     });
 
+    it("throws when hostedUi.domain uses plaintext http://", () => {
+      // The domain becomes the OAuth2 base that codes/tokens travel to, so
+      // it must be https:// (mirrors the cognitoIdpEndpoint http:// rejection)
+      expect(() =>
+        configure({
+          cognitoIdpEndpoint: "eu-west-1",
+          clientId: "test-client-id",
+          hostedUi: {
+            domain: "http://auth.example.com",
+            redirectSignIn,
+          },
+        })
+      ).toThrow("hostedUi.domain must not use plaintext http://");
+    });
+
+    it("accepts a bare hostedUi.domain (https:// is assumed)", () => {
+      configure({
+        cognitoIdpEndpoint: "eu-west-1",
+        clientId: "test-client-id",
+        hostedUi: {
+          domain: "example.auth.eu-west-1.amazoncognito.com",
+          redirectSignIn,
+        },
+      });
+      expect(getAuthorizeEndpoint()).toBe(
+        "https://example.auth.eu-west-1.amazoncognito.com/oauth2/authorize"
+      );
+    });
+
     it("throws when hostedUi is configured without domain and cognitoIdpEndpoint is an https:// prefixed region", () => {
       // https://eu-west-1 is not a usable OAuth2 origin: it is just the bare
       // AWS region with a scheme glued on, not a real custom URL

--- a/client/cognito-api.ts
+++ b/client/cognito-api.ts
@@ -276,18 +276,20 @@ export async function initiateAuth<
     }
   }
 
-  // Add device key to auth parameters if provided and it's a valid authentication flow for device
-  if (
-    deviceKey &&
+  // Add device key to auth parameters if provided and it's a valid
+  // authentication flow for device. Do NOT mutate the caller's
+  // authParameters object — callers reuse it across retry attempts, so it is
+  // merged into the request body below instead.
+  const includeDeviceKey =
+    !!deviceKey &&
     (authflow === "REFRESH_TOKEN" ||
       authflow === "USER_PASSWORD_AUTH" ||
       authflow === "USER_SRP_AUTH" ||
-      authflow === "CUSTOM_AUTH")
-  ) {
+      authflow === "CUSTOM_AUTH");
+  if (includeDeviceKey) {
     debug?.(
       `Including device key ${redactSecret(deviceKey)} in ${authflow} flow`
     );
-    authParameters.DEVICE_KEY = deviceKey;
   }
 
   return fetch(
@@ -307,6 +309,7 @@ export async function initiateAuth<
         ClientId: clientId,
         AuthParameters: {
           ...authParameters,
+          ...(includeDeviceKey && { DEVICE_KEY: deviceKey }),
           ...(clientSecret && {
             SECRET_HASH: await calculateSecretHash(authParameters.USERNAME),
           }),

--- a/client/config.ts
+++ b/client/config.ts
@@ -286,6 +286,15 @@ export function configure(config?: ConfigInput) {
         "Invalid configuration: hostedUi.domain is required. Amazon Cognito serves the OAuth2 endpoints (/oauth2/authorize, /oauth2/token) only on your user pool domain, e.g. example.auth.eu-west-1.amazoncognito.com or a custom domain. It may only be omitted if cognitoIdpEndpoint is a full https:// URL (e.g. a proxy you control) that also serves the OAuth2 endpoints — an AWS region (e.g. eu-west-1) is not such a URL, and plaintext http:// is not allowed because OAuth2 authorization codes and tokens travel to that origin"
       );
     }
+    // Reject a plaintext http:// hostedUi.domain: it becomes the OAuth2 base
+    // (where authorization codes and tokens travel), so it must be https://.
+    // A bare domain is fine (https:// is assumed by normalizeEndpoint). This
+    // mirrors the http:// rejection already applied to cognitoIdpEndpoint.
+    if (config.hostedUi?.domain?.startsWith("http://")) {
+      throw new Error(
+        "Invalid configuration: hostedUi.domain must not use plaintext http:// — it is the OAuth2 base that authorization codes and tokens travel to. Use https:// or a bare domain (https:// is assumed)."
+      );
+    }
 
     // Wrap the user-provided or default fetch in retry logic (pass debug callback)
     const baseFetch = (config.fetch ?? Defaults.fetch).bind(globalThis);

--- a/client/react/hooks.tsx
+++ b/client/react/hooks.tsx
@@ -777,7 +777,17 @@ function _usePasswordless() {
     // expired-but-refreshable session via retrieveTokensForRefresh),
     // self-gates to a no-op when there is no session, and dedups against any
     // in-memory schedule, so it is idempotent with the sign-in path.
-    void scheduleRefresh({ abort: abortController.signal });
+    // Promise.resolve wrap: fire-and-forget, and resilient if scheduleRefresh
+    // is stubbed to a non-promise in tests.
+    void Promise.resolve(
+      scheduleRefresh({ abort: abortController.signal })
+    ).catch((err) => {
+      // An abort (the component unmounted mid-acquisition) is expected and
+      // must not surface as an unhandled rejection. Log anything else.
+      if (!abortController.signal.aborted) {
+        debug?.("Failed to schedule refresh on mount:", err);
+      }
+    });
 
     // Check for OAuth callback
     const checkOAuthCallback = async () => {

--- a/client/storage.ts
+++ b/client/storage.ts
@@ -297,11 +297,15 @@ export async function storeTokens(tokens: TokensToStore) {
 }
 
 /**
- * The username of the user that last signed in on this device (tracked under
- * the Amplify-compatible LastAuthUser storage key). This is the CANONICAL
- * user id (not an alias), so it can be used to locate per-user records (e.g.
- * remembered devices) before authentication, when the user may have entered
- * an alias (e-mail, phone number).
+ * The username of the user that last signed in on this device (the
+ * Amplify-compatible LastAuthUser storage key) — the canonical user id, e.g.
+ * to pre-fill a sign-in form.
+ *
+ * Do NOT use this to attribute per-user records (remembered devices, etc.)
+ * to a user BEFORE authentication: on a shared browser LastAuthUser may
+ * belong to a different user, so a record keyed by it could be
+ * mis-attributed (the plaintext device-key flow deliberately keys by the
+ * username as entered for exactly this reason).
  */
 export async function getLastAuthUsername(): Promise<string | undefined> {
   const { clientId, storage } = configure();


### PR DESCRIPTION
## Summary
The trivia split out of the "core cleanups" bucket — three small independent hardening fixes, plus a hardening of the page-reload scheduling added in #99.

## Fixes
1. **`initiateAuth` no longer mutates the caller's `authParameters`.** It set `authParameters.DEVICE_KEY = deviceKey` on the passed object, which stuck on an object reused across retry attempts (the plaintext/SRP flows worked around this by rebuilding the object each attempt). The device key is now merged into the request body instead.
2. **Reject a plaintext `http://` `hostedUi.domain`** at `configure()` time. The domain becomes the OAuth2 base that authorization codes and tokens travel to, so it must be `https://` (a bare domain still defaults to `https://`). Mirrors the existing `http://` rejection for `cognitoIdpEndpoint` (#56).
3. **Corrected the misleading `getLastAuthUsername` doc** — it no longer suggests using `LastAuthUser` to attribute per-user records *before* auth (unsafe on a shared browser; the plaintext device-key flow keys by the entered username for exactly that reason). The export is kept: it is public API (re-exported from the entry point) and a harmless utility, so removal would be a **breaking change** — happy to do that as a separate deliberate major-bump if you want it.

## Also
Hardened the page-reload `scheduleRefresh()` from #99: wrapped in `Promise.resolve(...).catch(...)` so an abort on unmount can't surface as an unhandled rejection, and a non-promise test stub (some suites auto-mock `../refresh`) can't crash the mount effect. This was surfacing as an intermittent cross-test failure.

## Test plan
- New `initiate-auth-no-mutation.test.ts`: `initiateAuth` sends `DEVICE_KEY` in the body without mutating the caller's object (incl. reuse across two calls). New `oauth-endpoints` cases: `http://` `hostedUi.domain` throws; a bare domain is accepted. The behavior-change tests fail on the previous code.
- Full suite: 459 passed / 0 failures, three consecutive runs; tsc and eslint clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted fixes in auth request shaping and config validation; behavior change fixes a retry bug rather than widening attack surface.
> 
> **Overview**
> **`initiateAuth`** no longer writes `DEVICE_KEY` onto the caller’s `authParameters` object. The device key is merged only into the InitiateAuth request body, so reused parameter objects across retries do not keep a stale `DEVICE_KEY` on a later attempt without a device key.
> 
> **`configure()`** now rejects a plaintext `http://` **`hostedUi.domain`**, matching the existing rule for OAuth traffic that must use HTTPS. Bare domains still work with `https://` assumed.
> 
> The **`getLastAuthUsername`** JSDoc is updated to warn against using `LastAuthUser` to attribute per-user records (e.g. remembered devices) before authentication on shared browsers; the API is unchanged.
> 
> The React provider’s mount-time **`scheduleRefresh`** call is wrapped in **`Promise.resolve(...).catch(...)`** so unmount aborts do not become unhandled rejections and non-promise test stubs do not break the effect.
> 
> New tests cover auth-parameter non-mutation and Hosted UI domain validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20089c32abfbbdcf0e002c7954a8f92a6d3c2bc8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->