### PR TITLE
Retry transient renewal initiate in conditional FIDO2 flow

### DIFF
--- a/client/__tests__/fido2-core.test.ts
+++ b/client/__tests__/fido2-core.test.ts
@@ -875,6 +875,75 @@ describe("FIDO2 Core Functionality", () => {
         expect(credentialGetter).toHaveBeenCalledTimes(1);
       });
 
+      it("ends the flow promptly when a modal takeover supersedes it during the renewal-initiate backoff", async () => {
+        // The harder supersede case: a modal "sign in with passkey" takeover
+        // marks the conditional flow superseded but does NOT abort the
+        // conditional caller's own signal (only a non-conditional request taking
+        // the credentials.get() lock sets activeConditionalFlow.superseded). The
+        // initiate-retry backoff therefore cannot rely on the caller signal — it
+        // must wake on the supersede itself and end the flow at once, instead of
+        // sleeping out the full backoff behind the now-foreground modal sign-in.
+        jest.useFakeTimers();
+        mockInitiateAuth
+          .mockResolvedValueOnce(challengeResponse(1)) // conditional first challenge
+          .mockRejectedValue(new Error("network blip")); // renewals keep failing
+
+        const credentialGetter = jest
+          .fn()
+          .mockImplementationOnce(pendingUntilAborted)
+          .mockResolvedValueOnce(parsedAssertion);
+
+        // The modal takeover goes through the REAL fido2getCredential, which
+        // takes the lock and marks the active conditional flow superseded. A
+        // direct challenge is supplied, so it issues navigator.credentials.get
+        // without an initiateAuth round-trip of its own.
+        const modalGet = jest.fn().mockResolvedValue(MOCK_ASSERTION_CREDENTIAL);
+        cleanup = setupWebAuthnMock({
+          customCredentials: { get: modalGet, create: jest.fn() } as never,
+        });
+
+        const prepared = prepareFido2SignIn({
+          username: "alice",
+          mediation: "conditional",
+          credentialGetter,
+        });
+        let settled: { value: unknown } | { error: unknown } | undefined;
+        void prepared.then(
+          (value) => (settled = { value }),
+          (error: unknown) => (settled = { error })
+        );
+
+        // Reach the renewal boundary: the first renewal initiate fails and the
+        // flow enters its (1s) backoff. It must NOT have ended yet.
+        await jest.advanceTimersByTimeAsync(
+          COGNITO_AUTH_SESSION_RENEWAL_INTERVAL_MS
+        );
+        expect(settled).toBeUndefined();
+
+        // Modal takeover mid-backoff: marks the conditional flow superseded.
+        const modal = fido2getCredential({
+          challenge: TEST_CHALLENGES.basic,
+        }).catch((err: unknown) => err);
+
+        // Flush microtasks ONLY — do NOT advance the 1s backoff. With the
+        // supersede-driven wake the flow has already ended; without it (the bug)
+        // it would still be sleeping and `settled` would remain undefined.
+        await jest.advanceTimersByTimeAsync(0);
+        await jest.advanceTimersByTimeAsync(0);
+
+        expect(settled).toBeDefined();
+        const { error } = settled as { error: unknown };
+        expect(error).toBeInstanceOf(Fido2AbortError);
+        expect((error as Fido2AbortError).superseded).toBe(true);
+
+        // The takeover itself proceeded, and the backoff was cut short: only the
+        // first challenge + the single failed renewal initiate ran (no further
+        // renewal attempts were consumed waiting out the backoff).
+        await modal;
+        expect(modalGet).toHaveBeenCalledTimes(1);
+        expect(mockInitiateAuth).toHaveBeenCalledTimes(2);
+      });
+
       it("does not renew when the credential resolves before the renewal interval", async () => {
         mockInitiateAuth.mockResolvedValueOnce(challengeResponse(1));
         const credentialGetter = jest.fn().mockResolvedValue(parsedAssertion);

--- a/client/__tests__/fido2-core.test.ts
+++ b/client/__tests__/fido2-core.test.ts
@@ -750,6 +750,131 @@ describe("FIDO2 Core Functionality", () => {
         expect(credentialGetter).toHaveBeenCalledTimes(3);
       });
 
+      it("rides out a transient renewal-initiate failure (retries then succeeds) without ending the flow", async () => {
+        // A network blip on the per-renewal initiateFido2Challenge() must not
+        // kill the still-pending autofill request: the renewal retries with
+        // backoff and the flow ultimately resolves with the assertion.
+        jest.useFakeTimers();
+        mockInitiateAuth
+          .mockResolvedValueOnce(challengeResponse(1)) // first challenge
+          .mockRejectedValueOnce(new Error("network blip 1")) // renewal try 1
+          .mockRejectedValueOnce(new Error("network blip 2")) // renewal try 2
+          .mockResolvedValueOnce(challengeResponse(2)); // renewal try 3 OK
+
+        const credentialGetter = jest
+          .fn()
+          .mockImplementationOnce(pendingUntilAborted)
+          .mockResolvedValueOnce(parsedAssertion);
+
+        const prepared = prepareFido2SignIn({
+          username: "alice",
+          mediation: "conditional",
+          credentialGetter,
+        });
+        const settled = prepared.then(
+          (value) => ({ value }),
+          (error: unknown) => ({ error })
+        );
+
+        // Reach the renewal boundary: the pending get() is aborted and the
+        // renewal initiate begins (and fails transiently).
+        await jest.advanceTimersByTimeAsync(
+          COGNITO_AUTH_SESSION_RENEWAL_INTERVAL_MS
+        );
+        // Advance through both retry backoffs (1s then 2s).
+        await jest.advanceTimersByTimeAsync(1000);
+        await jest.advanceTimersByTimeAsync(2000);
+
+        const outcome = await settled;
+        expect(outcome).toEqual({
+          value: {
+            username: "alice",
+            credential: parsedAssertion,
+            session: "session-2",
+            existingDeviceKey: undefined,
+          },
+        });
+        // 4 initiate calls: 1 first challenge + 3 renewal attempts (2 fail, 1 ok)
+        expect(mockInitiateAuth).toHaveBeenCalledTimes(4);
+        expect(credentialGetter).toHaveBeenCalledTimes(2);
+      });
+
+      it("ends the flow when renewal-initiate fails more than the retry budget", async () => {
+        // Retries are bounded: once the budget is exhausted the failure
+        // propagates and ends the prepared flow (it rejects), rather than
+        // retrying forever.
+        jest.useFakeTimers();
+        mockInitiateAuth
+          .mockResolvedValueOnce(challengeResponse(1)) // first challenge
+          .mockRejectedValue(new Error("persistent network failure")); // all renewals
+
+        const credentialGetter = jest
+          .fn()
+          .mockImplementationOnce(pendingUntilAborted)
+          .mockResolvedValueOnce(parsedAssertion);
+
+        const prepared = prepareFido2SignIn({
+          username: "alice",
+          mediation: "conditional",
+          credentialGetter,
+        });
+        const outcome = prepared.catch((err: unknown) => err);
+
+        await jest.advanceTimersByTimeAsync(
+          COGNITO_AUTH_SESSION_RENEWAL_INTERVAL_MS
+        );
+        // Exhaust both backoffs between the 3 attempts.
+        await jest.advanceTimersByTimeAsync(1000);
+        await jest.advanceTimersByTimeAsync(2000);
+
+        const err = await outcome;
+        expect(err).toBeInstanceOf(Error);
+        expect((err as Error).message).toBe("persistent network failure");
+        // 1 first challenge + exactly RENEWAL_INITIATE_MAX_ATTEMPTS (3) renewals
+        expect(mockInitiateAuth).toHaveBeenCalledTimes(4);
+        // The second get() never ran: the flow ended on exhausted retries
+        expect(credentialGetter).toHaveBeenCalledTimes(1);
+      });
+
+      it("ends the flow promptly on a caller abort during the renewal-initiate backoff", async () => {
+        // A supersede/abort during the retry backoff must end the flow
+        // immediately, not after the retry budget is exhausted.
+        jest.useFakeTimers();
+        mockInitiateAuth
+          .mockResolvedValueOnce(challengeResponse(1)) // first challenge
+          .mockRejectedValue(new Error("network blip")); // renewals keep failing
+
+        const credentialGetter = jest
+          .fn()
+          .mockImplementationOnce(pendingUntilAborted)
+          .mockResolvedValueOnce(parsedAssertion);
+        const abortController = new AbortController();
+
+        const prepared = prepareFido2SignIn({
+          username: "alice",
+          mediation: "conditional",
+          credentialGetter,
+          signal: abortController.signal,
+        });
+        const outcome = prepared.catch((err: unknown) => err);
+
+        // Reach the renewal boundary; the first renewal attempt fails and we
+        // enter the (1s) backoff.
+        await jest.advanceTimersByTimeAsync(
+          COGNITO_AUTH_SESSION_RENEWAL_INTERVAL_MS
+        );
+        // Abort mid-backoff (before the 1s elapses): the flow must end now,
+        // without consuming the remaining retry attempts.
+        abortController.abort();
+        await jest.advanceTimersByTimeAsync(0);
+
+        const err = await outcome;
+        expect(err).toBeInstanceOf(Fido2AbortError);
+        // 1 first challenge + only 1 renewal attempt before the abort ended it
+        expect(mockInitiateAuth).toHaveBeenCalledTimes(2);
+        expect(credentialGetter).toHaveBeenCalledTimes(1);
+      });
+
       it("does not renew when the credential resolves before the renewal interval", async () => {
         mockInitiateAuth.mockResolvedValueOnce(challengeResponse(1));
         const credentialGetter = jest.fn().mockResolvedValue(parsedAssertion);

--- a/client/fido2.ts
+++ b/client/fido2.ts
@@ -234,6 +234,30 @@ export interface PreparedFido2SignIn {
  */
 export const COGNITO_AUTH_SESSION_RENEWAL_INTERVAL_MS = 150_000; // 2.5 minutes
 
+/**
+ * How many times to attempt the per-iteration `initiateFido2Challenge()` call
+ * that refreshes the Cognito CUSTOM_AUTH session during a pending conditional
+ * (autofill) request, before giving up and ending the flow.
+ *
+ * A conditional request can stay pending for a long time, so a single
+ * transient network failure of the renewal initiate must not end passkey
+ * autofill — the pending request could keep waiting. Retrying a bounded number
+ * of times rides out brief blips; once the budget is exhausted the failure
+ * propagates and ends the flow, as before.
+ */
+export const RENEWAL_INITIATE_MAX_ATTEMPTS = 3;
+
+/**
+ * Base backoff between retries of a failed renewal `initiateFido2Challenge()`.
+ * Backoff grows linearly per attempt (1s, 2s, ...) and is capped by
+ * {@link RENEWAL_INITIATE_BACKOFF_CAP_MS}. A supersede/abort during the backoff
+ * ends the flow rather than waiting it out.
+ */
+export const RENEWAL_INITIATE_BACKOFF_BASE_MS = 1000;
+
+/** Upper bound on the per-retry renewal-initiate backoff. */
+export const RENEWAL_INITIATE_BACKOFF_CAP_MS = 4000;
+
 type AuthenticatorAttestationResponseWithOptionalMembers =
   AuthenticatorAttestationResponse & {
     getTransports?: () => "" | string[];
@@ -1250,13 +1274,58 @@ export async function prepareFido2SignIn({
         throw new Fido2AbortError();
       };
 
+      // Backoff that wakes promptly on a caller abort so a supersede/abort
+      // during the wait ends the flow instead of being waited out.
+      const backoffSleep = (ms: number) =>
+        new Promise<void>((resolve) => {
+          const onAbort = () => {
+            clearTimeout(timer);
+            resolve();
+          };
+          const timer = setTimeout(() => {
+            signal?.removeEventListener("abort", onAbort);
+            resolve();
+          }, ms);
+          signal?.addEventListener("abort", onAbort, { once: true });
+        });
+
+      // Refresh the Cognito CUSTOM_AUTH challenge for a renewal iteration,
+      // riding out transient failures of initiateFido2Challenge(): a single
+      // network blip must not end an otherwise-pending autofill request. A
+      // supersede/abort is never retried — it ends the flow promptly.
+      const initiateRenewalChallenge = async () => {
+        for (let attempt = 1; ; attempt++) {
+          // A takeover/abort that landed before (or while) initiating must end
+          // the flow, not be swallowed as a transient failure and retried.
+          if (flow.superseded || signal?.aborted) abortFlow();
+          try {
+            return await initiateFido2Challenge();
+          } catch (err) {
+            // Supersede/abort wins over any retry: end the flow now.
+            if (flow.superseded || signal?.aborted) abortFlow();
+            if (attempt >= RENEWAL_INITIATE_MAX_ATTEMPTS) {
+              // Budget exhausted: propagate, ending the flow as before.
+              throw err;
+            }
+            const backoff = Math.min(
+              RENEWAL_INITIATE_BACKOFF_BASE_MS * attempt,
+              RENEWAL_INITIATE_BACKOFF_CAP_MS
+            );
+            debug?.(
+              `⚠️ Renewal initiateFido2Challenge() failed (attempt ${attempt}/${RENEWAL_INITIATE_MAX_ATTEMPTS}) - retrying in ${backoff}ms`
+            );
+            await backoffSleep(backoff);
+          }
+        }
+      };
+
       try {
         for (;;) {
           // A modal takeover may have superseded this flow during the previous
           // iteration's renewal gap, including while awaiting initiate below.
           if (flow.superseded || signal?.aborted) abortFlow();
 
-          const challenge = await initiateFido2Challenge();
+          const challenge = await initiateRenewalChallenge();
 
           // Re-check: a takeover could have landed during the (awaited)
           // initiate call — exactly the window pendingConditionalGet misses.

--- a/client/fido2.ts
+++ b/client/fido2.ts
@@ -728,16 +728,41 @@ let pendingConditionalGet:
   | undefined = undefined;
 
 /**
- * Marks a conditional (autofill) sign-in flow as active for its ENTIRE
- * lifetime — including the gaps between renewal iterations, when the previous
+ * A conditional (autofill) sign-in flow, tracked for its ENTIRE lifetime —
+ * including the gaps between renewal iterations, when the previous
  * navigator.credentials.get() has been aborted and the next one has not yet
  * been issued (e.g. while initiating a fresh Cognito challenge). A modal
- * takeover sets `superseded` here even when no get() is pending, so the
+ * takeover marks `superseded` here even when no get() is pending, so the
  * renewal loop stops re-arming instead of running invisibly behind the modal
  * sign-in forever. `pendingConditionalGet` only covers the narrower window
  * while a get() is actually pending.
  */
-let activeConditionalFlow: { superseded: boolean } | undefined = undefined;
+type ActiveConditionalFlow = {
+  superseded: boolean;
+  /**
+   * Aborted in lockstep with `superseded` (see {@link supersedeConditionalFlow})
+   * so code blocked on an AbortSignal between renewal iterations — the
+   * initiate-retry backoff — wakes immediately on a takeover instead of waiting
+   * out the full backoff. A modal takeover marks the flow superseded but does
+   * NOT abort the caller's own signal, so the boolean alone is invisible to
+   * anything sleeping on a signal.
+   */
+  supersededAbort: AbortController;
+};
+
+let activeConditionalFlow: ActiveConditionalFlow | undefined = undefined;
+
+/**
+ * Supersede a conditional flow: mark it AND wake anything waiting on it. The
+ * `superseded` boolean is polled at renewal-loop boundaries, but the
+ * initiate-retry backoff blocks on an AbortSignal — and a takeover never aborts
+ * the caller's signal — so without this the backoff is waited out in full (up
+ * to {@link RENEWAL_INITIATE_BACKOFF_CAP_MS}) before the flow notices.
+ */
+function supersedeConditionalFlow(flow: ActiveConditionalFlow): void {
+  flow.superseded = true;
+  flow.supersededAbort.abort();
+}
 
 /**
  * Serializes the issuance of navigator.credentials.get() requests.
@@ -891,7 +916,7 @@ export async function fido2getCredential({
     // momentarily undefined). The flow's own conditional renewal re-arm is
     // mediation === "conditional" and must NOT self-supersede here.
     if (mediation !== "conditional" && activeConditionalFlow) {
-      activeConditionalFlow.superseded = true;
+      supersedeConditionalFlow(activeConditionalFlow);
     }
 
     // If a conditional (autofill) request is still pending, abort it first so
@@ -1257,8 +1282,18 @@ export async function prepareFido2SignIn({
 
       // Mark this conditional flow active for its whole lifetime so a modal
       // takeover can stop it even during the renewal gap (no get() pending).
-      const flow = { superseded: false };
+      const flow: ActiveConditionalFlow = {
+        superseded: false,
+        supersededAbort: new AbortController(),
+      };
       const previousFlow = activeConditionalFlow;
+      // A newer conditional flow taking over supersedes any still-active older
+      // one, so an older flow paused in its initiate-retry backoff ends promptly
+      // instead of waking later to re-arm and abort this newer flow's get(). A
+      // pending older get() is already aborted via pendingConditionalGet; this
+      // covers the renewal gap, where none is pending and the takeover path's
+      // `mediation !== "conditional"` guard would otherwise skip it.
+      if (previousFlow) supersedeConditionalFlow(previousFlow);
       activeConditionalFlow = flow;
 
       // Throw the abort that ends the flow: superseded by a takeover, or a
@@ -1274,19 +1309,26 @@ export async function prepareFido2SignIn({
         throw new Fido2AbortError();
       };
 
-      // Backoff that wakes promptly on a caller abort so a supersede/abort
-      // during the wait ends the flow instead of being waited out.
+      // Backoff that wakes promptly on either a caller abort OR a takeover
+      // (which marks flow.superseded and aborts flow.supersededAbort but never
+      // the caller's signal), so a supersede/abort during the wait ends the
+      // flow immediately instead of being waited out for the full backoff.
       const backoffSleep = (ms: number) =>
         new Promise<void>((resolve) => {
-          const onAbort = () => {
+          const supersededSignal = flow.supersededAbort.signal;
+          if (signal?.aborted || supersededSignal.aborted) {
+            resolve();
+            return;
+          }
+          const done = () => {
             clearTimeout(timer);
+            signal?.removeEventListener("abort", done);
+            supersededSignal.removeEventListener("abort", done);
             resolve();
           };
-          const timer = setTimeout(() => {
-            signal?.removeEventListener("abort", onAbort);
-            resolve();
-          }, ms);
-          signal?.addEventListener("abort", onAbort, { once: true });
+          const timer = setTimeout(done, ms);
+          signal?.addEventListener("abort", done, { once: true });
+          supersededSignal.addEventListener("abort", done, { once: true });
         });
 
       // Refresh the Cognito CUSTOM_AUTH challenge for a renewal iteration,

--- a/client/fido2.ts
+++ b/client/fido2.ts
@@ -1465,7 +1465,12 @@ export async function prepareFido2SignIn({
         }
       } finally {
         if (activeConditionalFlow === flow) {
-          activeConditionalFlow = previousFlow;
+          // This flow superseded previousFlow at setup, so by here previousFlow
+          // is dead; restoring it would leave activeConditionalFlow pointing at
+          // a superseded flow instead of "no live conditional flow". Restore
+          // only a still-live previous flow, else clear to undefined.
+          activeConditionalFlow =
+            previousFlow && !previousFlow.superseded ? previousFlow : undefined;
         }
       }
     } else {


### PR DESCRIPTION
## Summary

A conditional-mediation (passkey autofill) sign-in stays pending until the user picks a suggestion, which can outlive the Cognito `AuthSessionValidity` window. The renewal loop in `prepareFido2SignIn` therefore re-initiates a fresh `CUSTOM_AUTH` challenge at the top of each iteration via `initiateFido2Challenge()`.

A **transient network failure** of that renewal `initiateFido2Challenge()` call threw and killed the entire conditional-autofill flow — so a single network blip ended passkey autofill, even though the pending `navigator.credentials.get()` could have kept waiting. The React hook maps the thrown error to `lastError` / `FIDO2_SIGNIN_FAILED`, surfacing a spurious failure for an otherwise-recoverable hiccup.

## Fix

Wrap the **per-renewal-iteration** initiate in a small bounded retry with linear backoff:

- `RENEWAL_INITIATE_MAX_ATTEMPTS = 3` attempts.
- Linear backoff `RENEWAL_INITIATE_BACKOFF_BASE_MS = 1000` × attempt (1s, 2s, …), capped at `RENEWAL_INITIATE_BACKOFF_CAP_MS = 4000`.
- Each attempt re-checks `flow.superseded` and the caller `signal` **before** retrying, and bails via `abortFlow()` if either is set — a supersede/abort is **never** retried; it ends the flow promptly.
- The backoff wait wakes promptly on a caller abort, so a takeover/abort during the backoff ends the flow immediately rather than waiting out the retry budget.
- On a transient throw, debug-logs and retries; only **after** exhausting the budget does the error propagate and end the flow, exactly as before (no behavior change for a genuinely-failing initiate).

The non-conditional path (`else` branch) is untouched. The conditional path's first initiate is now also covered by the same bounded retry (it runs through the loop's first iteration), which is a strict improvement and does not affect non-conditional sign-in.

## Test plan

Added three tests to the `conditional mediation session renewal` harness in `client/__tests__/fido2-core.test.ts` (fake timers + `advanceTimersByTimeAsync`):

1. **Rides out a transient failure** — renewal initiate fails twice then succeeds → the flow continues and resolves with the assertion (`session-2`); no rejection, 4 initiate calls (1 first + 3 renewal), 2 `get()` calls.
2. **Bounded, not infinite** — renewal initiate fails more than the budget → the prepared promise rejects with the underlying error; exactly `RENEWAL_INITIATE_MAX_ATTEMPTS` renewal attempts, second `get()` never runs.
3. **Prompt abort during backoff** — caller aborts mid-backoff → flow ends immediately with `Fido2AbortError` after only one renewal attempt, without consuming the remaining retries.

New tests run 5× — deterministic. Gates:

- `npx tsc --project client/tsconfig.json --noEmit` — clean.
- `npx eslint client/fido2.ts client/__tests__/fido2-core.test.ts` — clean.
- Full `npx jest` — 53 suites passed (1 skipped), 458 passed / 18 skipped, 0 failures.
- `client/__tests__/{fido2-core,mediation-integration,mediation}.test.ts` — 73 passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes conditional FIDO2 sign-in renewal and supersede coordination in `prepareFido2SignIn`; bounded retries and abort handling limit blast radius, but this is still authentication-critical client logic.
> 
> **Overview**
> Fixes **conditional passkey autofill** ending on a single transient failure when the renewal loop calls `initiateFido2Challenge()` to refresh the Cognito `CUSTOM_AUTH` session.
> 
> The conditional path now wraps each renewal initiate in **`initiateRenewalChallenge`**: up to **3 attempts** with **linear backoff** (1s, 2s, capped at 4s). After the budget is exhausted, behavior is unchanged—the error still ends the flow. **Caller abort** and **modal supersede** are never retried; `backoffSleep` wakes on both the caller `signal` and a new **`supersededAbort`** on `ActiveConditionalFlow`, so takeover during retry backoff ends immediately instead of waiting out the timer.
> 
> Also **supersedes any prior active conditional flow** when a new one starts, routes modal takeover through **`supersedeConditionalFlow`**, and fixes **`activeConditionalFlow` teardown** so a superseded previous flow is not restored on exit.
> 
> Tests cover retry-then-success, exhausted budget, abort during backoff, and modal supersede during backoff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7fedc172bb145fa3e58a69d27dcc801c51ba812. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->