### PR TITLE
Reset per-user state on a cross-tab sign-out

### DIFF
--- a/client/__tests__/react-cross-tab-signout-reset.test.tsx
+++ b/client/__tests__/react-cross-tab-signout-reset.test.tsx
@@ -1,0 +1,253 @@
+/**
+ * Copyright Amazon.com, Inc. and its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You
+ * may not use this file except in compliance with the License. A copy of
+ * the License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+import React from "react";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import {
+  PasswordlessContextProvider,
+  usePasswordless,
+} from "../react/hooks.js";
+import { configure } from "../config.js";
+import { retrieveTokens } from "../storage.js";
+import { signOut as signOutCore } from "../common.js";
+import { getUser } from "../cognito-api.js";
+import { authenticateWithFido2 as authenticateWithFido2Core } from "../fido2.js";
+import type { TokensFromSignIn } from "../model.js";
+
+// Mocks
+jest.mock("../config");
+jest.mock("../storage");
+jest.mock("../common");
+jest.mock("../cognito-api");
+jest.mock("../hosted-oauth");
+jest.mock("../fido2", () => {
+  const actual = jest.requireActual("../fido2");
+  return {
+    ...actual,
+    authenticateWithFido2: jest.fn(),
+  };
+});
+
+const CLIENT_ID = "test-client-id";
+const ACCESS_TOKEN_KEY = `CognitoIdentityServiceProvider.${CLIENT_ID}.user-a.accessToken`;
+const LAST_AUTH_USER_KEY = `CognitoIdentityServiceProvider.${CLIENT_ID}.LastAuthUser`;
+
+const mockConfigure = configure as jest.MockedFunction<typeof configure>;
+const mockRetrieveTokens = retrieveTokens as jest.MockedFunction<
+  typeof retrieveTokens
+>;
+const mockSignOutCore = signOutCore as jest.MockedFunction<typeof signOutCore>;
+const mockGetUser = getUser as jest.MockedFunction<typeof getUser>;
+const mockAuthenticateWithFido2 =
+  authenticateWithFido2Core as jest.MockedFunction<
+    typeof authenticateWithFido2Core
+  >;
+
+const makeWrapper = () =>
+  function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <PasswordlessContextProvider>{children}</PasswordlessContextProvider>
+    );
+  };
+
+const signInTokens: TokensFromSignIn = {
+  accessToken: "mock-access-token", // parseable via parseJwtPayload mock in setup.ts
+  idToken: "mock-id-token",
+  refreshToken: "mock-refresh-token",
+  expireAt: new Date(Date.now() + 3600_000),
+  username: "user-a",
+  authMethod: "FIDO2",
+  deviceKey: "us-west-2_device-key-user-a",
+};
+
+// Sign the hook's user A in and wait for per-user state to populate.
+async function signInUserA(result: {
+  current: ReturnType<typeof usePasswordless>;
+}) {
+  let capturedTokensCb:
+    | ((tokens: TokensFromSignIn) => void | Promise<void>)
+    | undefined;
+  mockAuthenticateWithFido2.mockImplementation((props) => {
+    capturedTokensCb = props?.tokensCb;
+    return {
+      signedIn: Promise.resolve(signInTokens),
+      abort: jest.fn(),
+    };
+  });
+
+  await act(async () => {
+    await new Promise((r) => setTimeout(r, 0));
+  });
+
+  act(() => {
+    result.current.authenticateWithFido2({ username: "user-a" });
+  });
+  expect(capturedTokensCb).toBeDefined();
+  await act(async () => {
+    await capturedTokensCb!(signInTokens);
+  });
+
+  await waitFor(() => {
+    expect(result.current.signInStatus).toBe("SIGNED_IN");
+    expect(result.current.deviceKey).toBe("us-west-2_device-key-user-a");
+    expect(result.current.totpMfaStatus).toEqual({
+      enabled: true,
+      preferred: true,
+      availableMfaTypes: ["SOFTWARE_TOKEN_MFA"],
+    });
+    expect(result.current.mfaStatusReady).toBe(true);
+  });
+}
+
+describe("cross-tab sign-out resets per-user state", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockConfigure.mockReturnValue({
+      clientId: CLIENT_ID,
+      debug: jest.fn(),
+      storage: {
+        getItem: jest.fn(),
+        setItem: jest.fn(),
+        removeItem: jest.fn(),
+      },
+    } as unknown as ReturnType<typeof configure>);
+
+    // After a cross-tab sign-out the local store has no tokens, so the hook's
+    // loadTokens (retrieveTokens) resolves undefined.
+    mockRetrieveTokens.mockResolvedValue(undefined);
+
+    mockGetUser.mockResolvedValue({
+      Username: "user-a",
+      UserAttributes: [],
+      MFAOptions: [],
+      UserMFASettingList: ["SOFTWARE_TOKEN_MFA"],
+      PreferredMfaSetting: "SOFTWARE_TOKEN_MFA",
+    });
+
+    mockSignOutCore.mockImplementation((props) => {
+      props?.statusCb?.("SIGNING_OUT");
+      props?.tokensRemovedLocallyCb?.();
+      props?.statusCb?.("SIGNED_OUT");
+      return {
+        signedOut: Promise.resolve(),
+        abort: jest.fn(),
+      } as unknown as ReturnType<typeof signOutCore>;
+    });
+  });
+
+  it("resets deviceKey, totpMfaStatus and mfaStatusReady when a token key is removed in another tab", async () => {
+    const wrapper = makeWrapper();
+    const { result } = renderHook(() => usePasswordless(), { wrapper });
+
+    await signInUserA(result);
+
+    // Another tab signs out: it removes the accessToken key, which fires a
+    // `storage` event in THIS tab with newValue === null.
+    await act(async () => {
+      globalThis.dispatchEvent(
+        new StorageEvent("storage", {
+          key: ACCESS_TOKEN_KEY,
+          oldValue: "some-old-access-token",
+          newValue: null,
+        })
+      );
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    // The SIGN_OUT reducer must have run: all per-user state reset.
+    await waitFor(() => {
+      expect(result.current.tokens).toBeUndefined();
+      expect(result.current.tokensParsed).toBeUndefined();
+      expect(result.current.deviceKey).toBeNull();
+      expect(result.current.totpMfaStatus).toEqual({
+        enabled: false,
+        preferred: false,
+        availableMfaTypes: [],
+      });
+      expect(result.current.mfaStatusReady).toBe(false);
+    });
+  });
+
+  it("resets per-user state when the LastAuthUser key is removed in another tab", async () => {
+    const wrapper = makeWrapper();
+    const { result } = renderHook(() => usePasswordless(), { wrapper });
+
+    await signInUserA(result);
+
+    await act(async () => {
+      globalThis.dispatchEvent(
+        new StorageEvent("storage", {
+          key: LAST_AUTH_USER_KEY,
+          oldValue: "user-a",
+          newValue: null,
+        })
+      );
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    await waitFor(() => {
+      expect(result.current.deviceKey).toBeNull();
+      expect(result.current.mfaStatusReady).toBe(false);
+      expect(result.current.totpMfaStatus).toEqual({
+        enabled: false,
+        preferred: false,
+        availableMfaTypes: [],
+      });
+    });
+  });
+
+  it("does NOT reset per-user state when a token is merely CHANGED (refreshed) in another tab", async () => {
+    const wrapper = makeWrapper();
+    const { result } = renderHook(() => usePasswordless(), { wrapper });
+
+    await signInUserA(result);
+
+    // After a refresh in another tab, this tab's loadTokens re-reads storage
+    // and finds the (rotated) tokens — so the user stays signed in.
+    mockRetrieveTokens.mockResolvedValue({
+      accessToken: "mock-access-token",
+      idToken: "mock-id-token",
+      refreshToken: "mock-refresh-token",
+      expireAt: new Date(Date.now() + 3600_000),
+      username: "user-a",
+      authMethod: "FIDO2",
+    } as unknown as Awaited<ReturnType<typeof retrieveTokens>>);
+
+    // A token refresh in another tab fires a `storage` event with a NEW
+    // (non-null) value. This must only reload tokens, never sign out.
+    await act(async () => {
+      globalThis.dispatchEvent(
+        new StorageEvent("storage", {
+          key: ACCESS_TOKEN_KEY,
+          oldValue: "some-old-access-token",
+          newValue: "some-rotated-access-token",
+        })
+      );
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    // Per-user state survives a refresh: still signed in, deviceKey intact,
+    // MFA status preserved.
+    expect(result.current.signInStatus).toBe("SIGNED_IN");
+    expect(result.current.deviceKey).toBe("us-west-2_device-key-user-a");
+    expect(result.current.mfaStatusReady).toBe(true);
+    expect(result.current.totpMfaStatus).toEqual({
+      enabled: true,
+      preferred: true,
+      availableMfaTypes: ["SOFTWARE_TOKEN_MFA"],
+    });
+  });
+});

--- a/client/react/hooks.tsx
+++ b/client/react/hooks.tsx
@@ -858,14 +858,35 @@ function _usePasswordless() {
         clientId &&
         e.key.includes(`CognitoIdentityServiceProvider.${clientId}`)
       ) {
-        // Check if it's a token key (accessToken, idToken, or refreshToken)
-        if (
+        const isTokenKey =
           e.key.includes(".accessToken") ||
           e.key.includes(".idToken") ||
-          e.key.includes(".refreshToken")
-        ) {
+          e.key.includes(".refreshToken");
+        const isLastAuthUserKey = e.key.includes(".LastAuthUser");
+
+        // A removal (newValue === null) of a token key or the LastAuthUser key
+        // means another tab signed the user out. A change (newValue present)
+        // — e.g. a token refresh in another tab — must NOT trigger a sign-out,
+        // only a token reload to pick up the rotated values.
+        const isSessionRemoved =
+          (isTokenKey || isLastAuthUserKey) && e.newValue == null;
+
+        if (isSessionRemoved) {
+          debug?.(`Detected cross-tab sign-out in storage for key: ${e.key}`);
+          // Mirror the same-tab signOut reset: clear all per-user React state
+          // via the SIGN_OUT reducer action and reset the per-user refs so a
+          // stale getUser response or fetch cooldown cannot bleed across into
+          // the next user's session (the same class of bug PR #64 fixed for
+          // the same tab). The reducer is idempotent, so receiving this for
+          // each removed key (separate storage events) is harmless.
+          lastActivityAtRef.current = Date.now();
+          lastFetchedMfaTokenRef.current = undefined;
+          lastMfaFetchTimeRef.current = 0;
+          dispatch({ type: "SIGN_OUT" });
+          void loadTokens();
+        } else if (isTokenKey) {
+          // Token CHANGED in another tab (e.g. a refresh) — reload tokens.
           debug?.(`Detected token change in storage for key: ${e.key}`);
-          // Reload tokens from storage
           void loadTokens();
         }
       }


### PR DESCRIPTION
## Summary
Follow-up split from the React-hook cleanups. The cross-tab counterpart of #64's same-tab fix.

## Bug
When another tab signs out, it removes the Cognito token keys from storage, firing a `storage` event in this tab. The handler only called `loadTokens` (which nulls the tokens) but never dispatched `SIGN_OUT`, so per-user React state (`totpMfaStatus`, `mfaStatusReady`, `deviceKey`, `authMethod`, …) survived until the next sign-in — and could render for the **wrong user** on a shared browser.

## Fix
On a `storage` event that **removes** a token key or `LastAuthUser` (`newValue == null`), dispatch `SIGN_OUT` (the full per-user reset) and reset the same per-user refs the same-tab `signOut` callback resets (`lastActivityAtRef`, `lastFetchedMfaTokenRef`, `lastMfaFetchTimeRef`) so a stale `getUser` response or fetch cooldown can't bleed across. A token **change** (`newValue` present, e.g. a refresh in another tab) still only reloads tokens — it must not sign the user out.

## Test plan
- New `client/__tests__/react-cross-tab-signout-reset.test.tsx`: a token-key removal and a `LastAuthUser` removal each reset `deviceKey`/`totpMfaStatus`/`mfaStatusReady`; a token **change** (refresh) keeps the user signed in with state intact. The two removal tests fail on the previous code.
- Full suite: 458 passed / 0 failures; tsc and eslint clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auth session sync across tabs and MFA/device UI state; behavior is well-scoped to storage removals vs updates and covered by new tests.
> 
> **Overview**
> Fixes a bug where **another tab signing out** only triggered `loadTokens` on `storage` events, leaving per-user React state (`deviceKey`, `totpMfaStatus`, `mfaStatusReady`, etc.) stale—similar to the same-tab issue addressed in PR #64.
> 
> The **`usePasswordless` storage listener** now treats removal of a Cognito token key or **`LastAuthUser`** (`newValue == null`) as cross-tab sign-out: it dispatches **`SIGN_OUT`**, resets the same per-user refs as same-tab `signOut` (`lastActivityAtRef`, `lastFetchedMfaTokenRef`, `lastMfaFetchTimeRef`), then reloads tokens. A **non-null** token update (e.g. refresh in another tab) still **only** calls `loadTokens` so the session stays signed in.
> 
> Adds **`react-cross-tab-signout-reset.test.tsx`** covering removal vs refresh behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c125bbd99ef4637375c4171f6f5fda3978852261. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->