### PR TITLE
Rehydrate deviceKey from storage in the SRP and plaintext tokensCb

### DIFF
--- a/client/__tests__/react-devicekey-rehydrate.test.tsx
+++ b/client/__tests__/react-devicekey-rehydrate.test.tsx
@@ -181,4 +181,93 @@ describe("deviceKey rehydration in SRP / plaintext tokensCb", () => {
     });
     expect(result.current.deviceKey).toBeNull();
   });
+
+  it("does not let a stale rehydrate lookup overwrite a newer sign-in's deviceKey", async () => {
+    // The rehydrate awaits getRememberedDevice() after the session is already
+    // visible. If a newer sign-in (different user, carrying its own deviceKey)
+    // lands while user A's lookup is in flight, A's late resolution must NOT
+    // overwrite the newer user's deviceKey.
+    const tokensA: TokensFromSignIn = {
+      ...tokensWithoutDeviceKey,
+      username: "user-a",
+    };
+    const tokensB: TokensFromSignIn = {
+      ...tokensWithoutDeviceKey,
+      username: "user-b",
+      deviceKey: "us-west-2_device-key-user-b",
+    };
+
+    // A's remembered-device lookup is deferred so we can complete B's sign-in
+    // before it resolves.
+    let resolveLookupA!: (rec: {
+      deviceKey: string;
+      groupKey: string;
+      password: string;
+      remembered: boolean;
+    }) => void;
+    mockGetRememberedDevice.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveLookupA = resolve;
+        })
+    );
+
+    let capturedTokensCb:
+      | ((tokens: TokensFromSignIn) => void | Promise<void>)
+      | undefined;
+    mockAuthSRP.mockImplementation(((props: {
+      tokensCb?: typeof capturedTokensCb;
+    }) => {
+      capturedTokensCb = props?.tokensCb;
+      return {
+        signedIn: Promise.resolve(tokensA),
+        abort: jest.fn(),
+      };
+    }) as never);
+
+    const { result } = renderHook(() => usePasswordless(), {
+      wrapper: makeWrapper(),
+    });
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    act(() => {
+      result.current.authenticateWithSRP({
+        username: "user-a",
+        password: "pw",
+      });
+    });
+    expect(capturedTokensCb).toBeDefined();
+
+    // Drive user A's tokensCb but do NOT await it: it marks the session
+    // current (user-a), then suspends on the deferred lookup.
+    let tokensADone!: Promise<void>;
+    await act(async () => {
+      tokensADone = Promise.resolve(capturedTokensCb!(tokensA));
+      await Promise.resolve();
+    });
+    expect(mockGetRememberedDevice).toHaveBeenCalledWith("user-a");
+
+    // A newer sign-in for user B completes (it carries its own deviceKey, so
+    // it takes the synchronous path and overwrites the current-session marker).
+    await act(async () => {
+      await capturedTokensCb!(tokensB);
+    });
+    expect(result.current.deviceKey).toBe("us-west-2_device-key-user-b");
+
+    // A's lookup resolves too late: the current session is now user B, so the
+    // guard must skip A's SET_DEVICE_KEY and leave B's deviceKey untouched.
+    await act(async () => {
+      resolveLookupA({
+        deviceKey: "us-west-2_remembered-device-a",
+        groupKey: "grp",
+        password: "pw",
+        remembered: true,
+      });
+      await tokensADone;
+    });
+
+    expect(result.current.deviceKey).toBe("us-west-2_device-key-user-b");
+  });
 });

--- a/client/__tests__/react-devicekey-rehydrate.test.tsx
+++ b/client/__tests__/react-devicekey-rehydrate.test.tsx
@@ -1,0 +1,184 @@
+/**
+ * Copyright Amazon.com, Inc. and its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You
+ * may not use this file except in compliance with the License. A copy of
+ * the License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+import React from "react";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import {
+  PasswordlessContextProvider,
+  usePasswordless,
+} from "../react/hooks.js";
+import { configure } from "../config.js";
+import { retrieveTokens, getRememberedDevice } from "../storage.js";
+import { getUser } from "../cognito-api.js";
+import { authenticateWithSRP } from "../srp.js";
+import { authenticateWithPlaintextPassword } from "../plaintext.js";
+import type { TokensFromSignIn } from "../model.js";
+
+jest.mock("../config");
+jest.mock("../storage");
+jest.mock("../common");
+jest.mock("../cognito-api");
+jest.mock("../hosted-oauth");
+jest.mock("../srp");
+jest.mock("../plaintext");
+jest.mock("../fido2", () => {
+  const actual = jest.requireActual("../fido2");
+  return {
+    ...actual,
+    fido2ListCredentials: jest.fn(() =>
+      Promise.resolve({ authenticators: [] })
+    ),
+  };
+});
+
+const mockConfigure = configure as jest.MockedFunction<typeof configure>;
+const mockRetrieveTokens = retrieveTokens as jest.MockedFunction<
+  typeof retrieveTokens
+>;
+const mockGetRememberedDevice = getRememberedDevice as jest.MockedFunction<
+  typeof getRememberedDevice
+>;
+const mockGetUser = getUser as jest.MockedFunction<typeof getUser>;
+const mockAuthSRP = authenticateWithSRP as jest.MockedFunction<
+  typeof authenticateWithSRP
+>;
+const mockAuthPlaintext =
+  authenticateWithPlaintextPassword as jest.MockedFunction<
+    typeof authenticateWithPlaintextPassword
+  >;
+
+// Tokens that DO NOT carry a deviceKey (the common case the rehydrate covers)
+const tokensWithoutDeviceKey: TokensFromSignIn = {
+  accessToken: "mock-access-token", // parseable via parseJwtPayload mock in setup.ts
+  idToken: "mock-id-token",
+  refreshToken: "mock-refresh-token",
+  expireAt: new Date(Date.now() + 3600_000),
+  username: "user-a",
+  authMethod: "SRP",
+};
+
+const makeWrapper = () =>
+  function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <PasswordlessContextProvider>{children}</PasswordlessContextProvider>
+    );
+  };
+
+describe("deviceKey rehydration in SRP / plaintext tokensCb", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockConfigure.mockReturnValue({
+      clientId: "test-client-id",
+      debug: jest.fn(),
+      storage: {
+        getItem: jest.fn(),
+        setItem: jest.fn(),
+        removeItem: jest.fn(),
+      },
+    } as unknown as ReturnType<typeof configure>);
+    mockRetrieveTokens.mockResolvedValue(undefined);
+    mockGetUser.mockResolvedValue({
+      Username: "user-a",
+      UserAttributes: [],
+      UserMFASettingList: [],
+    } as unknown as Awaited<ReturnType<typeof getUser>>);
+    // A remembered device exists in storage for this user
+    mockGetRememberedDevice.mockResolvedValue({
+      deviceKey: "us-west-2_remembered-device",
+      groupKey: "grp",
+      password: "pw",
+      remembered: true,
+    });
+  });
+
+  const driveSignIn = async (
+    result: { current: ReturnType<typeof usePasswordless> },
+    method: "srp" | "plaintext"
+  ) => {
+    let capturedTokensCb:
+      | ((tokens: TokensFromSignIn) => void | Promise<void>)
+      | undefined;
+    const impl = (props: { tokensCb?: typeof capturedTokensCb }) => {
+      capturedTokensCb = props?.tokensCb;
+      return {
+        signedIn: Promise.resolve(tokensWithoutDeviceKey),
+        abort: jest.fn(),
+      };
+    };
+    if (method === "srp") {
+      mockAuthSRP.mockImplementation(impl as never);
+    } else {
+      mockAuthPlaintext.mockImplementation(impl as never);
+    }
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0));
+    });
+    act(() => {
+      if (method === "srp") {
+        result.current.authenticateWithSRP({
+          username: "user-a",
+          password: "pw",
+        });
+      } else {
+        result.current.authenticateWithPlaintextPassword({
+          username: "user-a",
+          password: "pw",
+        });
+      }
+    });
+    expect(capturedTokensCb).toBeDefined();
+    await act(async () => {
+      await capturedTokensCb!(tokensWithoutDeviceKey);
+    });
+  };
+
+  it("rehydrates deviceKey from the remembered device on SRP sign-in when tokens omit it", async () => {
+    const { result } = renderHook(() => usePasswordless(), {
+      wrapper: makeWrapper(),
+    });
+    await driveSignIn(result, "srp");
+
+    await waitFor(() => {
+      expect(result.current.deviceKey).toBe("us-west-2_remembered-device");
+    });
+    expect(mockGetRememberedDevice).toHaveBeenCalledWith("user-a");
+  });
+
+  it("rehydrates deviceKey from the remembered device on plaintext sign-in when tokens omit it", async () => {
+    const { result } = renderHook(() => usePasswordless(), {
+      wrapper: makeWrapper(),
+    });
+    await driveSignIn(result, "plaintext");
+
+    await waitFor(() => {
+      expect(result.current.deviceKey).toBe("us-west-2_remembered-device");
+    });
+    expect(mockGetRememberedDevice).toHaveBeenCalledWith("user-a");
+  });
+
+  it("does not rehydrate when no remembered device exists (SRP)", async () => {
+    mockGetRememberedDevice.mockResolvedValue(undefined);
+    const { result } = renderHook(() => usePasswordless(), {
+      wrapper: makeWrapper(),
+    });
+    await driveSignIn(result, "srp");
+
+    await waitFor(() => {
+      expect(result.current.signInStatus).toBe("SIGNED_IN");
+    });
+    expect(result.current.deviceKey).toBeNull();
+  });
+});

--- a/client/__tests__/react-devicekey-rehydrate.test.tsx
+++ b/client/__tests__/react-devicekey-rehydrate.test.tsx
@@ -270,4 +270,88 @@ describe("deviceKey rehydration in SRP / plaintext tokensCb", () => {
 
     expect(result.current.deviceKey).toBe("us-west-2_device-key-user-b");
   });
+
+  it("does not rehydrate deviceKey after a cross-tab sign-out clears the session mid-lookup", async () => {
+    // A cross-tab sign-out reaches THIS tab via a 'storage' event →
+    // loadTokens() → retrieveTokens() returns undefined → _setTokens(undefined),
+    // which moves the session marker to undefined. An in-flight rehydrate
+    // lookup must then skip its late SET_DEVICE_KEY. This teardown path does
+    // NOT go through the signOut callback, so it is only covered because the
+    // marker is maintained in _setTokens (not just the sign-in/sign-out cbs).
+    let resolveLookup!: (rec: {
+      deviceKey: string;
+      groupKey: string;
+      password: string;
+      remembered: boolean;
+    }) => void;
+    mockGetRememberedDevice.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveLookup = resolve;
+        })
+    );
+    // retrieveTokens() returns undefined (beforeEach), so the cross-tab reload
+    // sees a signed-out storage.
+
+    let capturedTokensCb:
+      | ((tokens: TokensFromSignIn) => void | Promise<void>)
+      | undefined;
+    mockAuthSRP.mockImplementation(((props: {
+      tokensCb?: typeof capturedTokensCb;
+    }) => {
+      capturedTokensCb = props?.tokensCb;
+      return {
+        signedIn: Promise.resolve(tokensWithoutDeviceKey),
+        abort: jest.fn(),
+      };
+    }) as never);
+
+    const { result } = renderHook(() => usePasswordless(), {
+      wrapper: makeWrapper(),
+    });
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    act(() => {
+      result.current.authenticateWithSRP({
+        username: "user-a",
+        password: "pw",
+      });
+    });
+    expect(capturedTokensCb).toBeDefined();
+
+    let tokensCbDone!: Promise<void>;
+    await act(async () => {
+      tokensCbDone = Promise.resolve(capturedTokensCb!(tokensWithoutDeviceKey));
+      await Promise.resolve();
+    });
+    expect(mockGetRememberedDevice).toHaveBeenCalledWith("user-a");
+
+    // Cross-tab sign-out: a token key changes in another tab → loadTokens()
+    // re-reads storage (now empty) and clears tokens via _setTokens(undefined).
+    await act(async () => {
+      globalThis.dispatchEvent(
+        new StorageEvent("storage", {
+          key: "CognitoIdentityServiceProvider.test-client-id.user-a.accessToken",
+          newValue: null,
+        })
+      );
+      // let the async loadTokens() run to _setTokens(undefined)
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    // The lookup resolves after the cross-tab teardown: the guard must skip it.
+    await act(async () => {
+      resolveLookup({
+        deviceKey: "us-west-2_remembered-device",
+        groupKey: "grp",
+        password: "pw",
+        remembered: true,
+      });
+      await tokensCbDone;
+    });
+
+    expect(result.current.deviceKey).toBeNull();
+  });
 });

--- a/client/react/hooks.tsx
+++ b/client/react/hooks.tsx
@@ -1798,9 +1798,25 @@ function _usePasswordless() {
           dispatch({ type: "SET_AUTH_METHOD", payload: "SRP" });
           // Don't clear credentials here - auth method controls visibility
 
-          // Ensure device key is updated if present
+          // Update the device key from the new tokens, or rehydrate it from
+          // the remembered-device record when the tokens don't carry one
+          // (e.g. a re-sign-in after the SIGN_OUT reset nulled
+          // state.deviceKey) — mirrors the FIDO2 tokensCb, so confirmDevice()
+          // and the device UI see the key.
           if (newTokens.deviceKey) {
             dispatch({ type: "SET_DEVICE_KEY", payload: newTokens.deviceKey });
+          } else {
+            try {
+              const existing = await getRememberedDevice(newTokens.username);
+              if (existing?.deviceKey) {
+                dispatch({
+                  type: "SET_DEVICE_KEY",
+                  payload: existing.deviceKey,
+                });
+              }
+            } catch {
+              // ignore
+            }
           }
 
           // Force sign-in status update after setting tokens
@@ -1895,6 +1911,27 @@ function _usePasswordless() {
         statusCb: setSigninInStatus,
         tokensCb: async (newTokens: TokensFromSignIn) => {
           updateTokens(newTokens);
+
+          // Update the device key from the new tokens, or rehydrate it from
+          // the remembered-device record when the tokens don't carry one
+          // (the plaintext tokensCb did not set deviceKey in state at all) —
+          // mirrors the FIDO2 tokensCb so confirmDevice() and the device UI
+          // see the key.
+          if (newTokens.deviceKey) {
+            dispatch({ type: "SET_DEVICE_KEY", payload: newTokens.deviceKey });
+          } else {
+            try {
+              const existing = await getRememberedDevice(newTokens.username);
+              if (existing?.deviceKey) {
+                dispatch({
+                  type: "SET_DEVICE_KEY",
+                  payload: existing.deviceKey,
+                });
+              }
+            } catch {
+              // ignore
+            }
+          }
 
           // If rememberDevice callback requested and Cognito needs confirmation
           if (

--- a/client/react/hooks.tsx
+++ b/client/react/hooks.tsx
@@ -663,6 +663,15 @@ function _usePasswordless() {
   const mfaRetryForTokenRef = useRef<string | undefined>();
   const MAX_MFA_FETCH_RETRIES = 3;
 
+  // Username of the sign-in that owns the current session, recorded
+  // synchronously when a sign-in's tokens are applied and cleared on sign-out.
+  // The deviceKey rehydrate (SRP / plaintext / FIDO2 tokensCb) awaits a
+  // getRememberedDevice() lookup after the session is already visible; this ref
+  // lets that async path detect a sign-out or a newer sign-in landing during
+  // the lookup and skip a late SET_DEVICE_KEY that would otherwise repopulate
+  // deviceKey for an ended or different session.
+  const currentSignInUserRef = useRef<string | undefined>();
+
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     // Don't run if we're currently handling incomplete tokens to avoid loops
@@ -1593,6 +1602,10 @@ function _usePasswordless() {
           // MFA status fetch must run immediately, not wait out a cooldown
           // started by the previous user
           lastMfaFetchTimeRef.current = 0;
+          // Invalidate the current-session marker so any in-flight deviceKey
+          // rehydrate lookup (SRP / plaintext / FIDO2 tokensCb) skips its late
+          // SET_DEVICE_KEY instead of repopulating the signed-out session.
+          currentSignInUserRef.current = undefined;
           dispatch({ type: "SIGN_OUT" });
         },
         currentStatus: signingInStatus,
@@ -1666,12 +1679,19 @@ function _usePasswordless() {
         tokensCb: async (newTokens) => {
           // 1) Update tokens in state and deviceKey
           updateTokens(newTokens);
+          // Mark this sign-in as the current session before any async yield.
+          currentSignInUserRef.current = newTokens.username;
           if (newTokens.deviceKey) {
             dispatch({ type: "SET_DEVICE_KEY", payload: newTokens.deviceKey });
           } else {
             try {
               const existing = await getRememberedDevice(newTokens.username);
-              if (existing?.deviceKey) {
+              // Skip a late dispatch if a sign-out (clears the ref) or a newer
+              // sign-in (overwrites it) happened while the lookup was in flight.
+              if (
+                existing?.deviceKey &&
+                currentSignInUserRef.current === newTokens.username
+              ) {
                 dispatch({
                   type: "SET_DEVICE_KEY",
                   payload: existing.deviceKey,
@@ -1803,12 +1823,18 @@ function _usePasswordless() {
           // (e.g. a re-sign-in after the SIGN_OUT reset nulled
           // state.deviceKey) — mirrors the FIDO2 tokensCb, so confirmDevice()
           // and the device UI see the key.
+          currentSignInUserRef.current = newTokens.username;
           if (newTokens.deviceKey) {
             dispatch({ type: "SET_DEVICE_KEY", payload: newTokens.deviceKey });
           } else {
             try {
               const existing = await getRememberedDevice(newTokens.username);
-              if (existing?.deviceKey) {
+              // Skip a late dispatch if a sign-out (clears the ref) or a newer
+              // sign-in (overwrites it) happened while the lookup was in flight.
+              if (
+                existing?.deviceKey &&
+                currentSignInUserRef.current === newTokens.username
+              ) {
                 dispatch({
                   type: "SET_DEVICE_KEY",
                   payload: existing.deviceKey,
@@ -1917,12 +1943,18 @@ function _usePasswordless() {
           // (the plaintext tokensCb did not set deviceKey in state at all) —
           // mirrors the FIDO2 tokensCb so confirmDevice() and the device UI
           // see the key.
+          currentSignInUserRef.current = newTokens.username;
           if (newTokens.deviceKey) {
             dispatch({ type: "SET_DEVICE_KEY", payload: newTokens.deviceKey });
           } else {
             try {
               const existing = await getRememberedDevice(newTokens.username);
-              if (existing?.deviceKey) {
+              // Skip a late dispatch if a sign-out (clears the ref) or a newer
+              // sign-in (overwrites it) happened while the lookup was in flight.
+              if (
+                existing?.deviceKey &&
+                currentSignInUserRef.current === newTokens.username
+              ) {
                 dispatch({
                   type: "SET_DEVICE_KEY",
                   payload: existing.deviceKey,
@@ -2108,6 +2140,9 @@ function _usePasswordless() {
           // status and the next user's fetch runs immediately
           lastFetchedMfaTokenRef.current = undefined;
           lastMfaFetchTimeRef.current = 0;
+          // Invalidate the current-session marker so an in-flight deviceKey
+          // rehydrate lookup skips its late SET_DEVICE_KEY (see signOut).
+          currentSignInUserRef.current = undefined;
           dispatch({ type: "SIGN_OUT" });
         },
         currentStatus: signingInStatus,

--- a/client/react/hooks.tsx
+++ b/client/react/hooks.tsx
@@ -462,7 +462,22 @@ function _usePasswordless() {
     dispatch({ type: "SET_ERROR", payload: error });
   }, []);
 
+  // Username of the sign-in that owns the current session, kept in lockstep
+  // with the tokens on EVERY write below (fresh sign-in, refresh, OAuth
+  // callback, cross-tab/page load, and sign-out → undefined). The deviceKey
+  // rehydrate awaits a getRememberedDevice() lookup after the session is
+  // already visible; reading this ref after the await lets that async path
+  // detect a sign-out or a different/newer sign-in that landed during the
+  // lookup and skip a late SET_DEVICE_KEY that would otherwise repopulate
+  // deviceKey for an ended or different session.
+  const currentSignInUserRef = useRef<string | undefined>();
+
   const _setTokens = useCallback((tokens: TokensFromStorage | undefined) => {
+    // _setTokens is the single sink for every token change, so updating the
+    // session marker here keeps it authoritative for all paths (not just the
+    // sign-in tokensCb): a cross-tab sign-out / OAuth callback / refresh that
+    // does not go through a tokensCb still moves the marker.
+    currentSignInUserRef.current = tokens?.username;
     dispatch({ type: "SET_TOKENS", payload: tokens });
   }, []);
 
@@ -662,15 +677,6 @@ function _usePasswordless() {
   const mfaRetryCountRef = useRef<number>(0);
   const mfaRetryForTokenRef = useRef<string | undefined>();
   const MAX_MFA_FETCH_RETRIES = 3;
-
-  // Username of the sign-in that owns the current session, recorded
-  // synchronously when a sign-in's tokens are applied and cleared on sign-out.
-  // The deviceKey rehydrate (SRP / plaintext / FIDO2 tokensCb) awaits a
-  // getRememberedDevice() lookup after the session is already visible; this ref
-  // lets that async path detect a sign-out or a newer sign-in landing during
-  // the lookup and skip a late SET_DEVICE_KEY that would otherwise repopulate
-  // deviceKey for an ended or different session.
-  const currentSignInUserRef = useRef<string | undefined>();
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
@@ -1296,6 +1302,38 @@ function _usePasswordless() {
     [tokens, parseAndSetTokens, _setTokens]
   );
 
+  // Apply the device key from a fresh sign-in: use the key the tokens carry,
+  // or rehydrate it from the remembered-device record when they don't (e.g. a
+  // re-sign-in after the SIGN_OUT reset nulled state.deviceKey, or the plaintext
+  // flow which never carries one). Shared by the FIDO2 / SRP / plaintext
+  // tokensCb so the three stay in lockstep — they diverged once, which is the
+  // bug this consolidates. Call AFTER updateTokens(newTokens) so the session
+  // marker (currentSignInUserRef, set in _setTokens) already reflects this
+  // sign-in before the async lookup below.
+  const rehydrateDeviceKey = useCallback(
+    async (newTokens: TokensFromSignIn) => {
+      if (newTokens.deviceKey) {
+        dispatch({ type: "SET_DEVICE_KEY", payload: newTokens.deviceKey });
+        return;
+      }
+      try {
+        const existing = await getRememberedDevice(newTokens.username);
+        // Skip a late dispatch if a sign-out (marker → undefined) or a
+        // different/newer sign-in (marker → other username) changed the current
+        // session while the lookup was in flight.
+        if (
+          existing?.deviceKey &&
+          currentSignInUserRef.current === newTokens.username
+        ) {
+          dispatch({ type: "SET_DEVICE_KEY", payload: existing.deviceKey });
+        }
+      } catch {
+        // ignore
+      }
+    },
+    []
+  );
+
   return {
     /** The (raw) tokens: ID token, Access token and Refresh Token */
     tokens,
@@ -1602,10 +1640,6 @@ function _usePasswordless() {
           // MFA status fetch must run immediately, not wait out a cooldown
           // started by the previous user
           lastMfaFetchTimeRef.current = 0;
-          // Invalidate the current-session marker so any in-flight deviceKey
-          // rehydrate lookup (SRP / plaintext / FIDO2 tokensCb) skips its late
-          // SET_DEVICE_KEY instead of repopulating the signed-out session.
-          currentSignInUserRef.current = undefined;
           dispatch({ type: "SIGN_OUT" });
         },
         currentStatus: signingInStatus,
@@ -1679,28 +1713,7 @@ function _usePasswordless() {
         tokensCb: async (newTokens) => {
           // 1) Update tokens in state and deviceKey
           updateTokens(newTokens);
-          // Mark this sign-in as the current session before any async yield.
-          currentSignInUserRef.current = newTokens.username;
-          if (newTokens.deviceKey) {
-            dispatch({ type: "SET_DEVICE_KEY", payload: newTokens.deviceKey });
-          } else {
-            try {
-              const existing = await getRememberedDevice(newTokens.username);
-              // Skip a late dispatch if a sign-out (clears the ref) or a newer
-              // sign-in (overwrites it) happened while the lookup was in flight.
-              if (
-                existing?.deviceKey &&
-                currentSignInUserRef.current === newTokens.username
-              ) {
-                dispatch({
-                  type: "SET_DEVICE_KEY",
-                  payload: existing.deviceKey,
-                });
-              }
-            } catch {
-              // ignore
-            }
-          }
+          await rehydrateDeviceKey(newTokens);
           // 2) If a rememberDevice callback is provided and user confirmation is needed, prompt
           if (newTokens.userConfirmationNecessary) {
             try {
@@ -1819,31 +1832,8 @@ function _usePasswordless() {
           // Don't clear credentials here - auth method controls visibility
 
           // Update the device key from the new tokens, or rehydrate it from
-          // the remembered-device record when the tokens don't carry one
-          // (e.g. a re-sign-in after the SIGN_OUT reset nulled
-          // state.deviceKey) — mirrors the FIDO2 tokensCb, so confirmDevice()
-          // and the device UI see the key.
-          currentSignInUserRef.current = newTokens.username;
-          if (newTokens.deviceKey) {
-            dispatch({ type: "SET_DEVICE_KEY", payload: newTokens.deviceKey });
-          } else {
-            try {
-              const existing = await getRememberedDevice(newTokens.username);
-              // Skip a late dispatch if a sign-out (clears the ref) or a newer
-              // sign-in (overwrites it) happened while the lookup was in flight.
-              if (
-                existing?.deviceKey &&
-                currentSignInUserRef.current === newTokens.username
-              ) {
-                dispatch({
-                  type: "SET_DEVICE_KEY",
-                  payload: existing.deviceKey,
-                });
-              }
-            } catch {
-              // ignore
-            }
-          }
+          // the remembered-device record when the tokens don't carry one.
+          await rehydrateDeviceKey(newTokens);
 
           // Force sign-in status update after setting tokens
           // For SRP auth, always use "SRP" to maintain consistency
@@ -1939,31 +1929,9 @@ function _usePasswordless() {
           updateTokens(newTokens);
 
           // Update the device key from the new tokens, or rehydrate it from
-          // the remembered-device record when the tokens don't carry one
-          // (the plaintext tokensCb did not set deviceKey in state at all) —
-          // mirrors the FIDO2 tokensCb so confirmDevice() and the device UI
-          // see the key.
-          currentSignInUserRef.current = newTokens.username;
-          if (newTokens.deviceKey) {
-            dispatch({ type: "SET_DEVICE_KEY", payload: newTokens.deviceKey });
-          } else {
-            try {
-              const existing = await getRememberedDevice(newTokens.username);
-              // Skip a late dispatch if a sign-out (clears the ref) or a newer
-              // sign-in (overwrites it) happened while the lookup was in flight.
-              if (
-                existing?.deviceKey &&
-                currentSignInUserRef.current === newTokens.username
-              ) {
-                dispatch({
-                  type: "SET_DEVICE_KEY",
-                  payload: existing.deviceKey,
-                });
-              }
-            } catch {
-              // ignore
-            }
-          }
+          // the remembered-device record when the tokens don't carry one (the
+          // plaintext flow never carries one).
+          await rehydrateDeviceKey(newTokens);
 
           // If rememberDevice callback requested and Cognito needs confirmation
           if (
@@ -2140,9 +2108,6 @@ function _usePasswordless() {
           // status and the next user's fetch runs immediately
           lastFetchedMfaTokenRef.current = undefined;
           lastMfaFetchTimeRef.current = 0;
-          // Invalidate the current-session marker so an in-flight deviceKey
-          // rehydrate lookup skips its late SET_DEVICE_KEY (see signOut).
-          currentSignInUserRef.current = undefined;
           dispatch({ type: "SIGN_OUT" });
         },
         currentStatus: signingInStatus,


### PR DESCRIPTION
## Summary
Last of the follow-up split from the React-hook cleanups.

## Bug
The FIDO2 sign-in `tokensCb` rehydrates the device key from the remembered-device record when the tokens don't carry one (since #64), but the SRP and plaintext `tokensCb` did not: SRP only set `deviceKey` when present, and plaintext never dispatched `SET_DEVICE_KEY` at all. After #64's `SIGN_OUT` reset nulls `state.deviceKey`, a same-mount SRP/plaintext re-sign-in therefore left `state.deviceKey` null even though a confirmed device exists in storage — so `confirmDevice()` and the device UI saw no device key.

## Fix
Give both flows the same rehydration the FIDO2 `tokensCb` already does: set `deviceKey` from the new tokens, else look it up via `getRememberedDevice(username)`.

## Test plan
- New `client/__tests__/react-devicekey-rehydrate.test.tsx`: an SRP and a plaintext sign-in whose tokens omit `deviceKey` rehydrate it from the remembered device; with no remembered device, `deviceKey` stays null. The two rehydrate tests fail on the previous code.
- Full suite: 458 passed / 0 failures, twice; tsc and eslint clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches sign-in session state and async device-key updates; guards reduce race risk but behavior affects `confirmDevice` and device UI after auth.
> 
> **Overview**
> Fixes **`state.deviceKey` staying null** after SRP or plaintext re-sign-in when tokens omit `deviceKey` but a remembered device exists in storage (e.g. after `SIGN_OUT` cleared hook state). FIDO2 already rehydrated; SRP only set the key when present and plaintext never did.
> 
> Introduces shared **`rehydrateDeviceKey`** for FIDO2, SRP, and plaintext `tokensCb` paths: use `deviceKey` from tokens, otherwise **`getRememberedDevice(username)`**. **`currentSignInUserRef`** is kept in sync with every token write via **`_setTokens`** so late async lookups skip `SET_DEVICE_KEY` after sign-out, a newer sign-in, or cross-tab token clear.
> 
> Adds **`react-devicekey-rehydrate.test.tsx`** for happy path, missing remembered device, stale lookup vs newer user, and mid-lookup cross-tab sign-out.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6575e7cc6709273695efe4aac11becedfbf622ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->