### PR TITLE
feat(client): add WebAuthn Signal API wrappers

### DIFF
--- a/client/__tests__/signal-api.test.ts
+++ b/client/__tests__/signal-api.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Copyright Amazon.com, Inc. and its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You
+ * may not use this file except in compliance with the License. A copy of
+ * the License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+import { configure } from "../config.js";
+import { retrieveTokens } from "../storage.js";
+import { bufferToBase64Url } from "../util.js";
+import {
+  signalAllAcceptedCredentials,
+  signalUnknownCredential,
+  signalCurrentUserDetails,
+} from "../fido2.js";
+
+jest.mock("../config");
+jest.mock("../storage");
+
+const mockConfigure = configure as jest.MockedFunction<typeof configure>;
+const mockRetrieveTokens = retrieveTokens as jest.MockedFunction<
+  typeof retrieveTokens
+>;
+
+const RP_ID = "meow.com";
+const SUB = "user-sub-abc";
+// The Signal API userId must equal base64url(UTF-8 bytes of the raw Cognito sub),
+// i.e. the exact handle encodeUserHandle produces at registration.
+const EXPECTED_USER_ID = bufferToBase64Url(
+  new TextEncoder().encode(SUB).buffer as ArrayBuffer
+);
+
+function base64urlSegment(obj: object): string {
+  return bufferToBase64Url(
+    new TextEncoder().encode(JSON.stringify(obj)).buffer as ArrayBuffer
+  );
+}
+
+function makeIdToken(sub: string): string {
+  return `${base64urlSegment({ alg: "RS256" })}.${base64urlSegment({ sub })}.sig`;
+}
+
+const ALL_SUPPORTED = {
+  signalAllAcceptedCredentials: true,
+  signalUnknownCredential: true,
+  signalCurrentUserDetails: true,
+};
+
+describe("WebAuthn Signal API wrappers", () => {
+  let signalAllSpy: jest.Mock;
+  let signalUnknownSpy: jest.Mock;
+  let signalUserDetailsSpy: jest.Mock;
+  let originalPublicKeyCredential: unknown;
+
+  function armPublicKeyCredential(capabilities: Record<string, boolean>) {
+    signalAllSpy = jest.fn().mockResolvedValue(undefined);
+    signalUnknownSpy = jest.fn().mockResolvedValue(undefined);
+    signalUserDetailsSpy = jest.fn().mockResolvedValue(undefined);
+    (
+      global as unknown as { PublicKeyCredential: unknown }
+    ).PublicKeyCredential = {
+      getClientCapabilities: jest.fn().mockResolvedValue(capabilities),
+      signalAllAcceptedCredentials: signalAllSpy,
+      signalUnknownCredential: signalUnknownSpy,
+      signalCurrentUserDetails: signalUserDetailsSpy,
+    };
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    originalPublicKeyCredential = (
+      global as unknown as { PublicKeyCredential: unknown }
+    ).PublicKeyCredential;
+    mockConfigure.mockReturnValue({
+      debug: jest.fn(),
+      fetch: jest.fn(),
+      location: { hostname: "localhost", href: "https://localhost/" },
+      fido2: { rp: { id: RP_ID } },
+    } as unknown as ReturnType<typeof configure>);
+    mockRetrieveTokens.mockResolvedValue({
+      idToken: makeIdToken(SUB),
+    } as Awaited<ReturnType<typeof retrieveTokens>>);
+  });
+
+  afterEach(() => {
+    (
+      global as unknown as { PublicKeyCredential: unknown }
+    ).PublicKeyCredential = originalPublicKeyCredential;
+  });
+
+  it("signalAllAcceptedCredentials sends the encoded handle, rpId and credential ids", async () => {
+    armPublicKeyCredential(ALL_SUPPORTED);
+
+    await signalAllAcceptedCredentials({
+      allAcceptedCredentialIds: ["credA", "credB"],
+    });
+
+    expect(signalAllSpy).toHaveBeenCalledWith({
+      rpId: RP_ID,
+      userId: EXPECTED_USER_ID,
+      allAcceptedCredentialIds: ["credA", "credB"],
+    });
+  });
+
+  it("signalUnknownCredential sends rpId and credentialId without a user handle", async () => {
+    armPublicKeyCredential(ALL_SUPPORTED);
+
+    await signalUnknownCredential({ credentialId: "credX" });
+
+    expect(signalUnknownSpy).toHaveBeenCalledWith({
+      rpId: RP_ID,
+      credentialId: "credX",
+    });
+  });
+
+  it("signalCurrentUserDetails sends the encoded handle, name and display name", async () => {
+    armPublicKeyCredential(ALL_SUPPORTED);
+
+    await signalCurrentUserDetails({
+      name: "user@meow.com",
+      displayName: "User",
+    });
+
+    expect(signalUserDetailsSpy).toHaveBeenCalledWith({
+      rpId: RP_ID,
+      userId: EXPECTED_USER_ID,
+      name: "user@meow.com",
+      displayName: "User",
+    });
+  });
+
+  it("honours an explicit rpId override", async () => {
+    armPublicKeyCredential(ALL_SUPPORTED);
+
+    await signalUnknownCredential({ credentialId: "credX", rpId: "other.com" });
+
+    expect(signalUnknownSpy).toHaveBeenCalledWith({
+      rpId: "other.com",
+      credentialId: "credX",
+    });
+  });
+
+  it("no-ops when the browser does not support the capability", async () => {
+    armPublicKeyCredential({
+      signalAllAcceptedCredentials: false,
+      signalUnknownCredential: false,
+      signalCurrentUserDetails: false,
+    });
+
+    await signalAllAcceptedCredentials({ allAcceptedCredentialIds: ["c"] });
+    await signalUnknownCredential({ credentialId: "c" });
+    await signalCurrentUserDetails({ name: "n", displayName: "d" });
+
+    expect(signalAllSpy).not.toHaveBeenCalled();
+    expect(signalUnknownSpy).not.toHaveBeenCalled();
+    expect(signalUserDetailsSpy).not.toHaveBeenCalled();
+  });
+
+  it("no-ops the user-scoped signals when no one is signed in", async () => {
+    armPublicKeyCredential(ALL_SUPPORTED);
+    mockRetrieveTokens.mockResolvedValue(undefined);
+
+    await signalAllAcceptedCredentials({ allAcceptedCredentialIds: ["c"] });
+    await signalCurrentUserDetails({ name: "n", displayName: "d" });
+
+    expect(signalAllSpy).not.toHaveBeenCalled();
+    expect(signalUserDetailsSpy).not.toHaveBeenCalled();
+  });
+});

--- a/client/__tests__/signal-api.test.ts
+++ b/client/__tests__/signal-api.test.ts
@@ -14,7 +14,6 @@
  */
 
 import { configure } from "../config.js";
-import { retrieveTokens } from "../storage.js";
 import { bufferToBase64Url } from "../util.js";
 import {
   signalAllAcceptedCredentials,
@@ -23,30 +22,18 @@ import {
 } from "../fido2.js";
 
 jest.mock("../config");
-jest.mock("../storage");
 
 const mockConfigure = configure as jest.MockedFunction<typeof configure>;
-const mockRetrieveTokens = retrieveTokens as jest.MockedFunction<
-  typeof retrieveTokens
->;
 
 const RP_ID = "meow.com";
-const SUB = "user-sub-abc";
-// The Signal API userId must equal base64url(UTF-8 bytes of the raw Cognito sub),
-// i.e. the exact handle encodeUserHandle produces at registration.
+// The caller passes the relying party's user handle (the server's user.id); for
+// Cognito with a raw-sub handle that is the user's sub.
+const USER_HANDLE = "user-sub-abc";
+// The Signal API userId must equal base64url(UTF-8 bytes of the user handle) —
+// the exact value encodeUserHandle produces at registration.
 const EXPECTED_USER_ID = bufferToBase64Url(
-  new TextEncoder().encode(SUB).buffer as ArrayBuffer
+  new TextEncoder().encode(USER_HANDLE).buffer as ArrayBuffer
 );
-
-function base64urlSegment(obj: object): string {
-  return bufferToBase64Url(
-    new TextEncoder().encode(JSON.stringify(obj)).buffer as ArrayBuffer
-  );
-}
-
-function makeIdToken(sub: string): string {
-  return `${base64urlSegment({ alg: "RS256" })}.${base64urlSegment({ sub })}.sig`;
-}
 
 const ALL_SUPPORTED = {
   signalAllAcceptedCredentials: true,
@@ -85,9 +72,6 @@ describe("WebAuthn Signal API wrappers", () => {
       location: { hostname: "localhost", href: "https://localhost/" },
       fido2: { rp: { id: RP_ID } },
     } as unknown as ReturnType<typeof configure>);
-    mockRetrieveTokens.mockResolvedValue({
-      idToken: makeIdToken(SUB),
-    } as Awaited<ReturnType<typeof retrieveTokens>>);
   });
 
   afterEach(() => {
@@ -96,11 +80,12 @@ describe("WebAuthn Signal API wrappers", () => {
     ).PublicKeyCredential = originalPublicKeyCredential;
   });
 
-  it("signalAllAcceptedCredentials sends the encoded handle, rpId and credential ids", async () => {
+  it("signalAllAcceptedCredentials encodes the handle the same way registration does", async () => {
     armPublicKeyCredential(ALL_SUPPORTED);
 
     await signalAllAcceptedCredentials({
       allAcceptedCredentialIds: ["credA", "credB"],
+      userId: USER_HANDLE,
     });
 
     expect(signalAllSpy).toHaveBeenCalledWith({
@@ -127,6 +112,7 @@ describe("WebAuthn Signal API wrappers", () => {
     await signalCurrentUserDetails({
       name: "user@meow.com",
       displayName: "User",
+      userId: USER_HANDLE,
     });
 
     expect(signalUserDetailsSpy).toHaveBeenCalledWith({
@@ -155,23 +141,19 @@ describe("WebAuthn Signal API wrappers", () => {
       signalCurrentUserDetails: false,
     });
 
-    await signalAllAcceptedCredentials({ allAcceptedCredentialIds: ["c"] });
+    await signalAllAcceptedCredentials({
+      allAcceptedCredentialIds: ["c"],
+      userId: USER_HANDLE,
+    });
     await signalUnknownCredential({ credentialId: "c" });
-    await signalCurrentUserDetails({ name: "n", displayName: "d" });
+    await signalCurrentUserDetails({
+      name: "n",
+      displayName: "d",
+      userId: USER_HANDLE,
+    });
 
     expect(signalAllSpy).not.toHaveBeenCalled();
     expect(signalUnknownSpy).not.toHaveBeenCalled();
-    expect(signalUserDetailsSpy).not.toHaveBeenCalled();
-  });
-
-  it("no-ops the user-scoped signals when no one is signed in", async () => {
-    armPublicKeyCredential(ALL_SUPPORTED);
-    mockRetrieveTokens.mockResolvedValue(undefined);
-
-    await signalAllAcceptedCredentials({ allAcceptedCredentialIds: ["c"] });
-    await signalCurrentUserDetails({ name: "n", displayName: "d" });
-
-    expect(signalAllSpy).not.toHaveBeenCalled();
     expect(signalUserDetailsSpy).not.toHaveBeenCalled();
   });
 });

--- a/client/__tests__/signal-api.test.ts
+++ b/client/__tests__/signal-api.test.ts
@@ -156,4 +156,29 @@ describe("WebAuthn Signal API wrappers", () => {
     expect(signalUnknownSpy).not.toHaveBeenCalled();
     expect(signalUserDetailsSpy).not.toHaveBeenCalled();
   });
+
+  it("no-ops when no rpId is configured or passed (never guesses from hostname)", async () => {
+    armPublicKeyCredential(ALL_SUPPORTED);
+    mockConfigure.mockReturnValue({
+      debug: jest.fn(),
+      fetch: jest.fn(),
+      location: { hostname: "localhost", href: "https://localhost/" },
+      fido2: {},
+    } as unknown as ReturnType<typeof configure>);
+
+    await signalAllAcceptedCredentials({
+      allAcceptedCredentialIds: ["c"],
+      userId: USER_HANDLE,
+    });
+    await signalUnknownCredential({ credentialId: "c" });
+    await signalCurrentUserDetails({
+      name: "n",
+      displayName: "d",
+      userId: USER_HANDLE,
+    });
+
+    expect(signalAllSpy).not.toHaveBeenCalled();
+    expect(signalUnknownSpy).not.toHaveBeenCalled();
+    expect(signalUserDetailsSpy).not.toHaveBeenCalled();
+  });
 });

--- a/client/fido2.ts
+++ b/client/fido2.ts
@@ -661,20 +661,15 @@ function getSignalRpId(rpId?: string): string {
 }
 
 /**
- * Resolve the WebAuthn user handle (base64url) for the signed-in user. The
- * handle is the raw Cognito user id encoded exactly as at registration via
- * encodeUserHandle, so the browser matches it against stored passkeys.
+ * Encode a relying-party WebAuthn user handle to the base64url form the Signal
+ * API expects. The caller passes the same handle the server used as `user.id`
+ * in the start-registration response; we run it through the same encodeUserHandle
+ * the library applies at registration so the value matches stored passkeys
+ * byte-for-byte. We intentionally do not assume the handle equals the Cognito
+ * `sub` — that only holds when the backend uses the raw sub as the handle.
  */
-async function getSignalUserId(): Promise<string | null> {
-  const { idToken } = (await retrieveTokens()) ?? {};
-  if (!idToken) {
-    return null;
-  }
-  const { sub } = parseJwtPayload<CognitoIdTokenPayload>(idToken);
-  if (!sub) {
-    return null;
-  }
-  return bufferToBase64Url(encodeUserHandle(sub).buffer as ArrayBuffer);
+function encodeSignalUserId(userId: string): string {
+  return bufferToBase64Url(encodeUserHandle(userId).buffer as ArrayBuffer);
 }
 
 /**
@@ -684,9 +679,16 @@ async function getSignalUserId(): Promise<string | null> {
  */
 export async function signalAllAcceptedCredentials({
   allAcceptedCredentialIds,
+  userId,
   rpId,
 }: {
   allAcceptedCredentialIds: string[];
+  /**
+   * The relying party's WebAuthn user handle — the same value used as `user.id`
+   * at registration. For Cognito backends that key passkeys by the raw `sub`,
+   * pass the user's `sub`. Encoded internally so it matches stored passkeys.
+   */
+  userId: string;
   rpId?: string;
 }): Promise<void> {
   const capabilities = await getClientCapabilities();
@@ -698,13 +700,9 @@ export async function signalAllAcceptedCredentials({
   if (typeof pkc.signalAllAcceptedCredentials !== "function") {
     return;
   }
-  const userId = await getSignalUserId();
-  if (!userId) {
-    return;
-  }
   await pkc.signalAllAcceptedCredentials({
     rpId: getSignalRpId(rpId),
-    userId,
+    userId: encodeSignalUserId(userId),
     allAcceptedCredentialIds,
   });
 }
@@ -743,10 +741,17 @@ export async function signalUnknownCredential({
 export async function signalCurrentUserDetails({
   name,
   displayName,
+  userId,
   rpId,
 }: {
   name: string;
   displayName: string;
+  /**
+   * The relying party's WebAuthn user handle — the same value used as `user.id`
+   * at registration. For Cognito backends that key passkeys by the raw `sub`,
+   * pass the user's `sub`. Encoded internally so it matches stored passkeys.
+   */
+  userId: string;
   rpId?: string;
 }): Promise<void> {
   const capabilities = await getClientCapabilities();
@@ -758,13 +763,9 @@ export async function signalCurrentUserDetails({
   if (typeof pkc.signalCurrentUserDetails !== "function") {
     return;
   }
-  const userId = await getSignalUserId();
-  if (!userId) {
-    return;
-  }
   await pkc.signalCurrentUserDetails({
     rpId: getSignalRpId(rpId),
-    userId,
+    userId: encodeSignalUserId(userId),
     name,
     displayName,
   });

--- a/client/fido2.ts
+++ b/client/fido2.ts
@@ -619,6 +619,157 @@ export async function fido2UpdateCredential({
   }).then(throwIfNot2xx);
 }
 
+/**
+ * The WebAuthn Signal API (https://w3c.github.io/webauthn/#sctn-signalMethods)
+ * lets the relying party tell the browser/credential manager which credentials
+ * it still accepts, so revoked or renamed passkeys stop being offered. These
+ * static methods are recent and not yet in the TS DOM lib, so we type them here.
+ */
+interface SignalAllAcceptedCredentialsOptions {
+  rpId: string;
+  userId: string;
+  allAcceptedCredentialIds: string[];
+}
+
+interface SignalUnknownCredentialOptions {
+  rpId: string;
+  credentialId: string;
+}
+
+interface SignalCurrentUserDetailsOptions {
+  rpId: string;
+  userId: string;
+  name: string;
+  displayName: string;
+}
+
+interface PublicKeyCredentialWithSignal {
+  signalAllAcceptedCredentials(
+    options: SignalAllAcceptedCredentialsOptions
+  ): Promise<void>;
+  signalUnknownCredential(
+    options: SignalUnknownCredentialOptions
+  ): Promise<void>;
+  signalCurrentUserDetails(
+    options: SignalCurrentUserDetailsOptions
+  ): Promise<void>;
+}
+
+function getSignalRpId(rpId?: string): string {
+  const { fido2, location } = configure();
+  return rpId ?? fido2?.rp?.id ?? location.hostname;
+}
+
+/**
+ * Resolve the WebAuthn user handle (base64url) for the signed-in user. The
+ * handle is the raw Cognito user id encoded exactly as at registration via
+ * encodeUserHandle, so the browser matches it against stored passkeys.
+ */
+async function getSignalUserId(): Promise<string | null> {
+  const { idToken } = (await retrieveTokens()) ?? {};
+  if (!idToken) {
+    return null;
+  }
+  const { sub } = parseJwtPayload<CognitoIdTokenPayload>(idToken);
+  if (!sub) {
+    return null;
+  }
+  return bufferToBase64Url(encodeUserHandle(sub).buffer as ArrayBuffer);
+}
+
+/**
+ * Signal the full set of credential IDs the relying party still accepts so the
+ * browser/password manager drops revoked passkeys from autofill. Call after a
+ * passkey is deleted (or on sign-in). No-op where the Signal API is unsupported.
+ */
+export async function signalAllAcceptedCredentials({
+  allAcceptedCredentialIds,
+  rpId,
+}: {
+  allAcceptedCredentialIds: string[];
+  rpId?: string;
+}): Promise<void> {
+  const capabilities = await getClientCapabilities();
+  if (!capabilities?.signalAllAcceptedCredentials) {
+    return;
+  }
+  const pkc = PublicKeyCredential as typeof PublicKeyCredential &
+    Partial<PublicKeyCredentialWithSignal>;
+  if (typeof pkc.signalAllAcceptedCredentials !== "function") {
+    return;
+  }
+  const userId = await getSignalUserId();
+  if (!userId) {
+    return;
+  }
+  await pkc.signalAllAcceptedCredentials({
+    rpId: getSignalRpId(rpId),
+    userId,
+    allAcceptedCredentialIds,
+  });
+}
+
+/**
+ * Signal that a credential the relying party no longer recognizes should stop
+ * being offered. Call when a sign-in is rejected for an unknown credential.
+ * No-op where the Signal API is unsupported.
+ */
+export async function signalUnknownCredential({
+  credentialId,
+  rpId,
+}: {
+  credentialId: string;
+  rpId?: string;
+}): Promise<void> {
+  const capabilities = await getClientCapabilities();
+  if (!capabilities?.signalUnknownCredential) {
+    return;
+  }
+  const pkc = PublicKeyCredential as typeof PublicKeyCredential &
+    Partial<PublicKeyCredentialWithSignal>;
+  if (typeof pkc.signalUnknownCredential !== "function") {
+    return;
+  }
+  await pkc.signalUnknownCredential({
+    rpId: getSignalRpId(rpId),
+    credentialId,
+  });
+}
+
+/**
+ * Signal the user's current account name and display name so stored passkeys
+ * show up-to-date details. No-op where the Signal API is unsupported.
+ */
+export async function signalCurrentUserDetails({
+  name,
+  displayName,
+  rpId,
+}: {
+  name: string;
+  displayName: string;
+  rpId?: string;
+}): Promise<void> {
+  const capabilities = await getClientCapabilities();
+  if (!capabilities?.signalCurrentUserDetails) {
+    return;
+  }
+  const pkc = PublicKeyCredential as typeof PublicKeyCredential &
+    Partial<PublicKeyCredentialWithSignal>;
+  if (typeof pkc.signalCurrentUserDetails !== "function") {
+    return;
+  }
+  const userId = await getSignalUserId();
+  if (!userId) {
+    return;
+  }
+  await pkc.signalCurrentUserDetails({
+    rpId: getSignalRpId(rpId),
+    userId,
+    name,
+    displayName,
+  });
+}
+
 interface Fido2Options {
   challenge: string;
   timeout?: number;

--- a/client/fido2.ts
+++ b/client/fido2.ts
@@ -655,9 +655,16 @@ interface PublicKeyCredentialWithSignal {
   ): Promise<void>;
 }
 
-function getSignalRpId(rpId?: string): string {
-  const { fido2, location } = configure();
-  return rpId ?? fido2?.rp?.id ?? location.hostname;
+/**
+ * Resolve the rpId a signal should target. Unlike the start/list requests
+ * (which send rpId to the server), signals must match the rpId the credential
+ * was bound to at registration. Use an explicit rpId or the configured
+ * fido2.rp.id; do not fall back to location.hostname, which may differ from the
+ * registrable domain the passkey was bound to. Returns undefined when neither is
+ * available, in which case the caller no-ops rather than signalling a guess.
+ */
+function getSignalRpId(rpId?: string): string | undefined {
+  return rpId ?? configure().fido2?.rp?.id;
 }
 
 /**
@@ -700,8 +707,12 @@ export async function signalAllAcceptedCredentials({
   if (typeof pkc.signalAllAcceptedCredentials !== "function") {
     return;
   }
+  const resolvedRpId = getSignalRpId(rpId);
+  if (!resolvedRpId) {
+    return;
+  }
   await pkc.signalAllAcceptedCredentials({
-    rpId: getSignalRpId(rpId),
+    rpId: resolvedRpId,
     userId: encodeSignalUserId(userId),
     allAcceptedCredentialIds,
   });
@@ -728,8 +739,12 @@ export async function signalUnknownCredential({
   if (typeof pkc.signalUnknownCredential !== "function") {
     return;
   }
+  const resolvedRpId = getSignalRpId(rpId);
+  if (!resolvedRpId) {
+    return;
+  }
   await pkc.signalUnknownCredential({
-    rpId: getSignalRpId(rpId),
+    rpId: resolvedRpId,
     credentialId,
   });
 }
@@ -763,8 +778,12 @@ export async function signalCurrentUserDetails({
   if (typeof pkc.signalCurrentUserDetails !== "function") {
     return;
   }
+  const resolvedRpId = getSignalRpId(rpId);
+  if (!resolvedRpId) {
+    return;
+  }
   await pkc.signalCurrentUserDetails({
-    rpId: getSignalRpId(rpId),
+    rpId: resolvedRpId,
     userId: encodeSignalUserId(userId),
     name,
     displayName,


### PR DESCRIPTION
### Description

Adds the three WebAuthn **Signal API** wrappers over the W3C `PublicKeyCredential.signal*` static methods, so relying parties can keep the browser/credential-manager in sync after a passkey is revoked or renamed:

- `signalAllAcceptedCredentials({ allAcceptedCredentialIds, rpId? })` — prune revoked passkeys from autofill after a delete (or on sign-in).
- `signalUnknownCredential({ credentialId, rpId? })` — drop a credential the RP no longer recognizes (e.g. a stale failed sign-in).
- `signalCurrentUserDetails({ name, displayName, rpId? })` — refresh the stored account name/display name.

Each is **feature-gated** via the existing `getClientCapabilities()` and **no-ops** where the browser lacks support (Signal API is Chrome-only today), so callers can invoke them unconditionally.

The key design point: the WebAuthn **user handle is derived internally** from the signed-in id token (`idToken.sub`) and encoded with the same `encodeUserHandle` used at registration, then base64url-encoded. Relying parties never reconstruct the handle encoding themselves — which keeps the `userId` byte-for-byte consistent with what was stored at registration, so the browser matches it against existing passkeys.

### Changes

- `client/fido2.ts`: three exported `signal*` wrappers + internal `getSignalRpId`/`getSignalUserId` helpers and minimal type declarations for the not-yet-in-DOM-lib static methods. Auto-exported via `client/index.ts`'s `export * from "./fido2.js"`.
- `client/__tests__/signal-api.test.ts`: 6 tests — correct args incl. the exact base64url handle encoding, rpId override, capability no-op, and signed-out no-op.

### Testing

- `npx tsc -p client/tsconfig.json --noEmit` — clean
- `npx eslint` on changed files — clean
- `npx jest` — full suite **482 passed**, signal-api **6/6**

### Notes

Purely additive; no existing exports or behavior changed. The conditional-**create** `mediation` param is intentionally left to a separate PR to keep this focused on the Signal API.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive exports with safe no-ops when capabilities or rpId are missing; no changes to existing FIDO2 sign-in or registration flows.
> 
> **Overview**
> Adds **three exported client helpers** that wrap the W3C `PublicKeyCredential.signal*` methods so apps can keep passkey autofill in sync after revokes, unknown credentials, or profile renames: `signalAllAcceptedCredentials`, `signalUnknownCredential`, and `signalCurrentUserDetails`.
> 
> Each wrapper is **gated on `getClientCapabilities()`** (and a runtime check on the static method) and **no-ops** when the browser lacks support. **`rpId`** comes from an optional argument or `fido2.rp.id` only—there is **no `location.hostname` fallback**; missing `rpId` is a no-op. For signals that need a user id, callers pass the same **WebAuthn user handle** as registration (`user.id`); the library encodes it with **`encodeUserHandle` + base64url** so it matches stored passkeys.
> 
> **`client/__tests__/signal-api.test.ts`** adds six Jest tests for argument shaping, encoding, `rpId` override, capability no-ops, and missing `rpId` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 598a545df6ebcd7f7b5936a97424bb93fc300c4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->