### PR TITLE
feat(client): surface unknown-credential rejections for signalUnknownCredential

### DIFF
--- a/client/__tests__/fido2-credential-rejected.test.ts
+++ b/client/__tests__/fido2-credential-rejected.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Copyright Amazon.com, Inc. and its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You
+ * may not use this file except in compliance with the License. A copy of
+ * the License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+import { authenticateWithFido2 } from "../fido2.js";
+import {
+  Fido2CredentialRejectedError,
+  isFido2CredentialRejectedError,
+  Fido2AbortError,
+} from "../errors.js";
+import { configure } from "../config.js";
+import { respondToAuthChallenge } from "../cognito-api.js";
+
+jest.mock("../config");
+jest.mock("../cognito-api");
+jest.mock("../storage");
+
+const mockConfigure = configure as jest.MockedFunction<typeof configure>;
+const mockRespond = respondToAuthChallenge as jest.MockedFunction<
+  typeof respondToAuthChallenge
+>;
+
+const STALE_CREDENTIAL_ID = "stale-credential-id-b64url";
+
+function preparedBundle() {
+  // A PreparedFido2SignIn: the assertion is already produced, so the failure
+  // path runs through respondToAuthChallenge (the W5b discoverable scenario).
+  return {
+    username: "alice",
+    session: "session-token",
+    credential: {
+      credentialIdB64: STALE_CREDENTIAL_ID,
+      authenticatorDataB64: "auth-data",
+      clientDataJSON_B64: "client-data",
+      signatureB64: "signature",
+      userHandleB64: null,
+    },
+    existingDeviceKey: undefined,
+  };
+}
+
+function cognitoError(name: string, message: string): Error {
+  const err = new Error(message);
+  err.name = name;
+  return err;
+}
+
+async function runSignInExpectingError(statusCb?: jest.Mock): Promise<unknown> {
+  const { signedIn } = authenticateWithFido2({
+    username: "alice",
+    prepared: preparedBundle(),
+    statusCb,
+  });
+  return signedIn.then(
+    () => {
+      throw new Error("sign-in unexpectedly succeeded");
+    },
+    (err) => err
+  );
+}
+
+describe("Fido2CredentialRejectedError", () => {
+  it("carries the reason, credentialId, code and cause", () => {
+    const cause = new Error("origin");
+    const error = new Fido2CredentialRejectedError("server says unknown", {
+      reason: "unknown_credential",
+      credentialIdB64: "cred-1",
+      cause,
+    });
+
+    expect(error.name).toBe("Fido2CredentialRejectedError");
+    expect(error.code).toBe("CREDENTIAL_REJECTED");
+    expect(error.reason).toBe("unknown_credential");
+    expect(error.credentialIdB64).toBe("cred-1");
+    expect(error.cause).toBe(cause);
+    expect(error.userMessage).toMatch(/no longer registered/i);
+  });
+
+  it("isFido2CredentialRejectedError narrows only its own instances", () => {
+    const error = new Fido2CredentialRejectedError("x", {
+      reason: "unknown_credential",
+    });
+    expect(isFido2CredentialRejectedError(error)).toBe(true);
+    expect(isFido2CredentialRejectedError(new Error("nope"))).toBe(false);
+    expect(
+      isFido2CredentialRejectedError(
+        new Fido2AbortError("aborted", "cancelled")
+      )
+    ).toBe(false);
+  });
+});
+
+describe("authenticateWithFido2 unknown-credential re-tagging", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockConfigure.mockReturnValue({
+      debug: jest.fn(),
+      fetch: jest.fn(),
+      fido2: {
+        rp: { id: "meow.com", name: "Meow" },
+        baseUrl: "https://example.com/fido2",
+        timeout: 45000,
+        authenticatorSelection: { userVerification: "preferred" },
+        extensions: {},
+      },
+    } as unknown as ReturnType<typeof configure>);
+  });
+
+  it("re-tags an explicit unknown_credential verdict, carrying the rejected credentialId", async () => {
+    const original = cognitoError(
+      "UserLambdaValidationException",
+      '{"reason": "unknown_credential"}'
+    );
+    mockRespond.mockRejectedValueOnce(original);
+    const statusCb = jest.fn();
+
+    const error = await runSignInExpectingError(statusCb);
+
+    expect(isFido2CredentialRejectedError(error)).toBe(true);
+    const rejected = error as Fido2CredentialRejectedError;
+    expect(rejected.reason).toBe("unknown_credential");
+    expect(rejected.credentialIdB64).toBe(STALE_CREDENTIAL_ID);
+    expect(rejected.cause).toBe(original);
+    expect(statusCb).toHaveBeenCalledWith("FIDO2_SIGNIN_FAILED");
+  });
+
+  it("extracts the verdict even when Cognito wraps it with surrounding text and a trailing period", async () => {
+    mockRespond.mockRejectedValueOnce(
+      cognitoError(
+        "UserLambdaValidationException",
+        'VerifyAuthChallengeResponse failed with error {"reason": "unknown_credential"}.'
+      )
+    );
+
+    const error = await runSignInExpectingError();
+
+    expect(isFido2CredentialRejectedError(error)).toBe(true);
+    expect((error as Fido2CredentialRejectedError).credentialIdB64).toBe(
+      STALE_CREDENTIAL_ID
+    );
+  });
+
+  it("does NOT re-tag a generic NotAuthorizedException (wrong PIN, expired session)", async () => {
+    const original = cognitoError(
+      "NotAuthorizedException",
+      "Incorrect username or password."
+    );
+    mockRespond.mockRejectedValueOnce(original);
+
+    const error = await runSignInExpectingError();
+
+    expect(error).toBe(original);
+    expect(isFido2CredentialRejectedError(error)).toBe(false);
+  });
+
+  it("does NOT re-tag a UserLambdaValidationException with a different reason", async () => {
+    const original = cognitoError(
+      "UserLambdaValidationException",
+      '{"reason": "rate_limited"}'
+    );
+    mockRespond.mockRejectedValueOnce(original);
+
+    const error = await runSignInExpectingError();
+
+    expect(error).toBe(original);
+    expect(isFido2CredentialRejectedError(error)).toBe(false);
+  });
+
+  it("does NOT re-tag a UserLambdaValidationException whose message is not JSON", async () => {
+    const original = cognitoError(
+      "UserLambdaValidationException",
+      "Only FIDO2 authentication is supported"
+    );
+    mockRespond.mockRejectedValueOnce(original);
+
+    const error = await runSignInExpectingError();
+
+    expect(error).toBe(original);
+    expect(isFido2CredentialRejectedError(error)).toBe(false);
+  });
+
+  it("does NOT re-tag a deliberate abort, and reverts to SIGNED_OUT", async () => {
+    const original = cognitoError("AbortError", "The operation was aborted");
+    mockRespond.mockRejectedValueOnce(original);
+    const statusCb = jest.fn();
+
+    const error = await runSignInExpectingError(statusCb);
+
+    expect(error).toBe(original);
+    expect(isFido2CredentialRejectedError(error)).toBe(false);
+    expect(statusCb).toHaveBeenCalledWith("SIGNED_OUT");
+    expect(statusCb).not.toHaveBeenCalledWith("FIDO2_SIGNIN_FAILED");
+  });
+});

--- a/client/errors.ts
+++ b/client/errors.ts
@@ -103,6 +103,45 @@ export class Fido2CredentialError extends Fido2Error {
 }
 
 /**
+ * Thrown when the relying party authoritatively rejects a sign-in because it
+ * does not recognize the presented credential — e.g. a discoverable passkey
+ * that was revoked server-side but is still offered by the platform
+ * authenticator at the login screen.
+ *
+ * Distinct from a cancelled or otherwise-failed ceremony: this is raised ONLY
+ * when the WebAuthn assertion succeeded (so `credentialIdB64` is known) and the
+ * server returned an explicit "unknown credential" verdict. That lets the
+ * caller safely prune the stale credential from autofill via the WebAuthn
+ * Signal API (`signalUnknownCredential`) without risking a valid passkey on a
+ * cancel/network/throttle failure, which keep the generic failure path.
+ */
+export class Fido2CredentialRejectedError extends Fido2Error {
+  /** Machine-readable verdict from the server, e.g. "unknown_credential". */
+  public readonly reason: string;
+  /** base64url id of the credential the server rejected (from this ceremony). */
+  public readonly credentialIdB64?: string;
+
+  constructor(
+    message: string,
+    {
+      reason,
+      credentialIdB64,
+      cause,
+    }: { reason: string; credentialIdB64?: string; cause?: unknown }
+  ) {
+    super(
+      message,
+      "CREDENTIAL_REJECTED",
+      "This passkey is no longer registered. Please try another way to sign in.",
+      cause
+    );
+    this.name = "Fido2CredentialRejectedError";
+    this.reason = reason;
+    this.credentialIdB64 = credentialIdB64;
+  }
+}
+
+/**
  * Thrown when FIDO2 configuration is missing or invalid
  *
  * Examples:
@@ -234,6 +273,18 @@ export function isFido2NotAllowedError(
 }
 
 /**
+ * Type guard for a server "unknown credential" rejection. When true, the
+ * relying party authoritatively did not recognize the presented credential and
+ * `error.credentialIdB64` is safe to pass to `signalUnknownCredential` so the
+ * platform authenticator prunes the stale passkey from autofill.
+ */
+export function isFido2CredentialRejectedError(
+  error: unknown
+): error is Fido2CredentialRejectedError {
+  return error instanceof Fido2CredentialRejectedError;
+}
+
+/**
  * Helper to convert DOMException (from WebAuthn API) to appropriate Fido2Error
  *
  * Based on WebAuthn Level 2 specification:
@@ -320,7 +371,6 @@ export function fromDOMException(error: DOMException): Fido2Error {
         "Something went wrong with your passkey",
         error
       );
-
   }
 
   // Catch any other DOMExceptions not in spec

--- a/client/fido2.ts
+++ b/client/fido2.ts
@@ -34,6 +34,7 @@ import { CognitoIdTokenPayload } from "./jwt-model.js";
 import { createDeviceSrpAuthHandler } from "./device.js";
 import {
   Fido2CredentialError,
+  Fido2CredentialRejectedError,
   Fido2ConfigError,
   Fido2ValidationError,
   Fido2AuthError,
@@ -1738,6 +1739,31 @@ export async function prepareFido2SignIn({
   };
 }
 
+/**
+ * Extract a server "unknown credential" verdict from a failed sign-in error.
+ *
+ * The Verify-Auth-Challenge Lambda raises a JSON verdict that Cognito surfaces
+ * as a UserLambdaValidationException; throwIfNot2xx may leave wrapping text (a
+ * trailing period, an unwrapped envelope on some runtimes), so we pull the
+ * first `{...}` object out of the message rather than parsing the whole string.
+ * Returns the reason only for the explicit "unknown_credential" verdict, so no
+ * other failure (cancel, network, throttle, bad signature) is ever re-tagged.
+ * The `[^{}]*` scan is linear — no ReDoS.
+ */
+function getUnknownCredentialReason(error: Error): string | undefined {
+  if (error.name !== "UserLambdaValidationException") return undefined;
+  const jsonMatch = error.message.match(/\{[^{}]*\}/);
+  if (!jsonMatch) return undefined;
+  try {
+    const parsed = JSON.parse(jsonMatch[0]) as { reason?: unknown };
+    return parsed.reason === "unknown_credential"
+      ? "unknown_credential"
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 export function authenticateWithFido2({
   username,
   credentials,
@@ -1876,6 +1902,10 @@ export function authenticateWithFido2({
       });
     }
 
+    // Captured once the WebAuthn ceremony produces an assertion, so the catch
+    // block (a separate scope from the try's `const preparedSignIn`) can attach
+    // it to an unknown-credential rejection for the Signal API.
+    let assertedCredentialIdB64: string | undefined;
     try {
       const preparedSignIn =
         prepared ??
@@ -1886,6 +1916,7 @@ export function authenticateWithFido2({
           mediation,
           signal: abort.signal,
         }));
+      assertedCredentialIdB64 = preparedSignIn.credential.credentialIdB64;
 
       if (username && username !== preparedSignIn.username) {
         throw new Fido2ValidationError(
@@ -2008,6 +2039,21 @@ export function authenticateWithFido2({
         statusCb?.("SIGNED_OUT");
       } else {
         statusCb?.("FIDO2_SIGNIN_FAILED");
+        // The relying party authoritatively rejected the presented credential
+        // (an unknown/revoked discoverable passkey). Re-tag so the caller can
+        // prune it from autofill via signalUnknownCredential. Gated on an
+        // assertion having been produced AND the explicit server verdict, so a
+        // cancel/network/throttle failure never re-tags.
+        if (assertedCredentialIdB64 && err instanceof Error) {
+          const rejectedReason = getUnknownCredentialReason(err);
+          if (rejectedReason) {
+            throw new Fido2CredentialRejectedError(err.message, {
+              reason: rejectedReason,
+              credentialIdB64: assertedCredentialIdB64,
+              cause: err,
+            });
+          }
+        }
       }
       throw err;
     }


### PR DESCRIPTION
## What

Adds a typed `Fido2CredentialRejectedError` (+ `isFido2CredentialRejectedError` guard) and makes `authenticateWithFido2` re-tag an **authoritative server "unknown credential" verdict** so callers can prune a stale passkey from autofill via `signalUnknownCredential`.

When the relying party rejects a sign-in because it does not recognize the presented credential (a discoverable passkey revoked server-side but still offered at the login screen), the Verify-Auth-Challenge Lambda raises a JSON verdict that Cognito surfaces as a `UserLambdaValidationException` carrying `{"reason":"unknown_credential"}`. `authenticateWithFido2` now re-tags **that and only that** as `Fido2CredentialRejectedError`, carrying the rejected `credentialIdB64` (captured client-side from this ceremony's assertion).

## Zero false positives

`signalUnknownCredential` tells the password manager to *delete/hide* the passkey, so a false positive destroys a valid credential. The re-tag is gated on:
- a produced assertion (`credentialIdB64` captured before `respondToAuthChallenge`), **and**
- `err.name === "UserLambdaValidationException"`, **and**
- the parsed reason `=== "unknown_credential"`.

Every other failure — cancel, abort/supersede, `AbortError`, network/throttle, wrong signature, generic `NotAuthorizedException`, a different `UserLambdaValidationException` reason, a non-JSON message — keeps the existing failure path untouched. The message is parsed by extracting the first `{...}` object (linear scan, no ReDoS), so it is robust to Cognito's wrapping text / trailing period.

## Tests

`client/__tests__/fido2-credential-rejected.test.ts` — 9 cases: error class/guard, the positive re-tag (asserts `credentialIdB64` + `cause`), wrapped-message + trailing-period extraction, and five must-not-re-tag failure modes. Full suite green (490 pass).

## Companion

Backend Verify-Auth-Challenge change (raises the verdict) and webapp_v2 wiring land in joinmeow/meow#15099. Publish as **1.0.102** after merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes FIDO2 sign-in error handling and credential-id signaling; false positives could prune valid passkeys from autofill, though gating on assertion + explicit server verdict limits that risk.
> 
> **Overview**
> Introduces **`Fido2CredentialRejectedError`** and **`isFido2CredentialRejectedError`** so apps can tell when the server definitively rejected a passkey (revoked discoverable credential still offered in autofill) versus a generic sign-in failure.
> 
> **`authenticateWithFido2`** now re-tags failures only when a WebAuthn assertion was already produced and Cognito returns **`UserLambdaValidationException`** with reason **`unknown_credential`**. The rejected **`credentialIdB64`** from that ceremony is attached so callers can safely invoke **`signalUnknownCredential`**. Verdict parsing pulls the first `{...}` from the error message so wrapped Lambda text still works; other errors (abort, `NotAuthorizedException`, other Lambda reasons) are unchanged.
> 
> Adds **`client/__tests__/fido2-credential-rejected.test.ts`** covering the positive re-tag path and several must-not-re-tag cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b57e4ca76e03075cab059155fbd108f52ce4c7ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->