### PR TITLE
fix(client): bound each fetch attempt with a timeout so a hung request can't wedge auth

### DIFF
--- a/client/__tests__/retry.test.ts
+++ b/client/__tests__/retry.test.ts
@@ -45,14 +45,15 @@ describe("createFetchWithRetry", () => {
     expect(res).toBe(okResponse);
     expect(fetchFn).toHaveBeenCalledTimes(3);
 
-    // Every "abort" listener added during a backoff wait must be removed
-    // again once the timer fires, so a long-lived signal doesn't
-    // accumulate dead listeners across retries.
+    // "abort" listeners are registered on the caller signal both for each
+    // backoff wait and for each attempt's per-attempt-timeout controller. Every
+    // one must be removed again (on timer fire / in the attempt's finally), so a
+    // long-lived signal never accumulates dead listeners across retries.
     const abortAdds = addSpy.mock.calls.filter(([type]) => type === "abort");
     const abortRemoves = removeSpy.mock.calls.filter(
       ([type]) => type === "abort"
     );
-    expect(abortAdds.length).toBe(2);
+    expect(abortAdds.length).toBeGreaterThanOrEqual(2);
     expect(abortRemoves.length).toBe(abortAdds.length);
   });
 

--- a/client/retry.ts
+++ b/client/retry.ts
@@ -15,10 +15,32 @@
 import type { MinimalFetch, MinimalResponse } from "./config.js";
 
 /**
+ * Per-attempt request timeout. A black-holed connection (TLS established, no
+ * response, no error) makes `await fetch` hang forever, which — because auth
+ * requests run on the critical sign-in/refresh path — wedges the whole flow
+ * (e.g. a hung ConfirmDevice leaves signInStatus stuck "SIGNING_IN" and the
+ * app spinning). Bounding each attempt turns a hang into a retryable timeout.
+ */
+export const DEFAULT_FETCH_ATTEMPT_TIMEOUT_MS = 25000;
+
+/** Thrown when every attempt exceeded `perAttemptTimeoutMs`. */
+export class FetchAttemptTimeoutError extends Error {
+  constructor(timeoutMs: number) {
+    super(`Request timed out after ${timeoutMs}ms`);
+    this.name = "FetchAttemptTimeoutError";
+  }
+}
+
+/**
  * Return a fetch function that will retry on network errors, HTTP 5xx,
  * and specific retryable 400 errors (TooManyRequestsException,
  * LimitExceededException, CodeDeliveryFailureException), up to `maxRetries`
  * times with exponential backoff.
+ *
+ * Each attempt is bounded by `perAttemptTimeoutMs`: a request that never
+ * settles is aborted and retried (or, on the last attempt, surfaced as a
+ * `FetchAttemptTimeoutError`) rather than hanging forever. A caller-provided
+ * `signal` abort is always propagated and never retried.
  *
  * Uses `Response.clone()` to inspect 400 error bodies without consuming the
  * original response body.
@@ -27,7 +49,8 @@ export function createFetchWithRetry(
   fetchFn: MinimalFetch,
   debugFn?: (...args: unknown[]) => unknown,
   maxRetries = 3,
-  baseDelayMs = 1000
+  baseDelayMs = 1000,
+  perAttemptTimeoutMs = DEFAULT_FETCH_ATTEMPT_TIMEOUT_MS
 ): MinimalFetch {
   const retryableErrors = new Set([
     "TooManyRequestsException",
@@ -69,8 +92,25 @@ export function createFetchWithRetry(
         throw new DOMException("Aborted", "AbortError");
       }
 
+      // Bound this attempt: abort it if the caller aborts OR the per-attempt
+      // timeout fires. A timeout is retryable; a caller abort propagates.
+      const attemptController = new AbortController();
+      let timedOut = false;
+      const onCallerAbort = () => attemptController.abort();
+      const callerSignal = init?.signal;
+      if (callerSignal) {
+        callerSignal.addEventListener("abort", onCallerAbort, { once: true });
+      }
+      const timeoutId = setTimeout(() => {
+        timedOut = true;
+        attemptController.abort();
+      }, perAttemptTimeoutMs);
+
       try {
-        const res = await fetchFn(input, init);
+        const res = await fetchFn(input, {
+          ...init,
+          signal: attemptController.signal,
+        });
         if (res.ok) {
           return res;
         }
@@ -117,13 +157,24 @@ export function createFetchWithRetry(
         }
         return res;
       } catch (error: unknown) {
-        if (
-          init?.signal?.aborted ||
-          (error instanceof Error && error.name === "AbortError")
-        ) {
+        // A caller-initiated abort always propagates and is never retried.
+        if (callerSignal?.aborted) {
           throw error;
         }
-        if (attempt === maxRetries) {
+        // Our own per-attempt timeout is a transient failure: retry it, or on
+        // the last attempt surface a clear timeout instead of a raw AbortError.
+        if (timedOut) {
+          debugFn?.(
+            `fetchWithRetry attempt ${attempt}/${maxRetries} timed out after ${perAttemptTimeoutMs}ms`
+          );
+          if (attempt === maxRetries) {
+            throw new FetchAttemptTimeoutError(perAttemptTimeoutMs);
+          }
+        } else if (error instanceof Error && error.name === "AbortError") {
+          // An AbortError that is neither a caller abort nor our timeout is
+          // unexpected; do not silently retry it.
+          throw error;
+        } else if (attempt === maxRetries) {
           throw error;
         }
         debugFn?.(
@@ -134,6 +185,9 @@ export function createFetchWithRetry(
         const backoff = baseDelayMs * Math.pow(2, attempt - 1);
         debugFn?.(`Retrying in ${backoff}ms...`);
         await wait(backoff);
+      } finally {
+        clearTimeout(timeoutId);
+        callerSignal?.removeEventListener("abort", onCallerAbort);
       }
     }
     // Fallback

--- a/test/fetch-attempt-timeout.test.ts
+++ b/test/fetch-attempt-timeout.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Tests for the per-attempt request timeout in createFetchWithRetry.
+ *
+ * A black-holed connection (no response, no error) must not hang the auth flow
+ * forever: each attempt is bounded, a timeout is retried, and a caller-provided
+ * signal abort still propagates without being retried.
+ */
+import {
+  createFetchWithRetry,
+  FetchAttemptTimeoutError,
+  DEFAULT_FETCH_ATTEMPT_TIMEOUT_MS,
+} from "../client/retry.js";
+import type { MinimalResponse } from "../client/config.js";
+
+const okResponse = { ok: true, status: 200 } as unknown as MinimalResponse;
+
+// A fetch that never settles on its own — it only rejects when its signal is
+// aborted, exactly like a real fetch against a black-holed connection.
+function blackHoleFetch() {
+  return jest.fn(
+    (_input: string | URL, init?: { signal?: AbortSignal }) =>
+      new Promise<MinimalResponse>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () =>
+          reject(new DOMException("Aborted", "AbortError"))
+        );
+      })
+  );
+}
+
+describe("createFetchWithRetry per-attempt timeout", () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => jest.useRealTimers());
+
+  test("has a bounded default timeout", () => {
+    expect(DEFAULT_FETCH_ATTEMPT_TIMEOUT_MS).toBeGreaterThan(0);
+    expect(DEFAULT_FETCH_ATTEMPT_TIMEOUT_MS).toBeLessThanOrEqual(60000);
+  });
+
+  test("a never-settling request times out (does not hang) and throws after retries", async () => {
+    const fetchFn = blackHoleFetch();
+    const fetchWithRetry = createFetchWithRetry(fetchFn, undefined, 2, 10, 100);
+
+    const promise = fetchWithRetry("https://cognito.example/");
+    const settled = promise.catch((e) => e);
+
+    // Attempt 1 times out (100ms) -> backoff (10ms) -> attempt 2 times out.
+    await jest.advanceTimersByTimeAsync(100);
+    await jest.advanceTimersByTimeAsync(10);
+    await jest.advanceTimersByTimeAsync(100);
+
+    const result = await settled;
+    expect(result).toBeInstanceOf(FetchAttemptTimeoutError);
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+  });
+
+  test("a caller abort propagates as AbortError and is not retried", async () => {
+    const fetchFn = blackHoleFetch();
+    const fetchWithRetry = createFetchWithRetry(fetchFn, undefined, 3, 10, 100);
+    const controller = new AbortController();
+
+    const settled = fetchWithRetry("https://cognito.example/", {
+      signal: controller.signal,
+    }).catch((e: unknown) => e);
+
+    controller.abort();
+    await jest.advanceTimersByTimeAsync(0);
+
+    const result = await settled;
+    expect((result as Error).name).toBe("AbortError");
+    expect(result).not.toBeInstanceOf(FetchAttemptTimeoutError);
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+  });
+
+  test("a request that settles within the timeout succeeds without retry", async () => {
+    const fetchFn = jest.fn(async () => okResponse);
+    const fetchWithRetry = createFetchWithRetry(fetchFn, undefined, 3, 10, 100);
+
+    await expect(fetchWithRetry("https://cognito.example/")).resolves.toBe(
+      okResponse
+    );
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+  });
+
+  test("a timed-out attempt is retried and can then succeed", async () => {
+    let call = 0;
+    const fetchFn = jest.fn(
+      (_input: string | URL, init?: { signal?: AbortSignal }) => {
+        call += 1;
+        if (call === 1) {
+          return new Promise<MinimalResponse>((_resolve, reject) => {
+            init?.signal?.addEventListener("abort", () =>
+              reject(new DOMException("Aborted", "AbortError"))
+            );
+          });
+        }
+        return Promise.resolve(okResponse);
+      }
+    );
+    const fetchWithRetry = createFetchWithRetry(fetchFn, undefined, 3, 10, 100);
+
+    const settled = fetchWithRetry("https://cognito.example/");
+
+    await jest.advanceTimersByTimeAsync(100); // attempt 1 times out
+    await jest.advanceTimersByTimeAsync(10); // backoff, then attempt 2 resolves
+
+    await expect(settled).resolves.toBe(okResponse);
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+  });
+
+  test("clears the attempt timer on success (no dangling timers)", async () => {
+    const fetchFn = jest.fn(async () => okResponse);
+    const fetchWithRetry = createFetchWithRetry(fetchFn, undefined, 3, 10, 100);
+
+    await fetchWithRetry("https://cognito.example/");
+    expect(jest.getTimerCount()).toBe(0);
+  });
+});


### PR DESCRIPTION
### Problem

`createFetchWithRetry` awaited `fetch` with **no per-attempt timeout** ([`client/retry.ts`](client/retry.ts)). A black-holed connection (TLS established, no response, no error) makes `await fetch` hang forever. Because auth requests run on the critical sign-in/refresh path, a single hung call wedges the whole flow.

Found while debugging a webapp_v2 **forever-spinner after passkey sign-in**: on a new/unremembered device, Cognito returns `newDeviceMetadata`, so `processTokensInternal` calls `handleDeviceConfirmation` → `confirmDevice` (a `ConfirmDevice` POST) **before `storeTokens`**. If that request never settles, the FIDO2 sign-in never reaches `tokensCb`/`statusCb("SIGNED_IN_WITH_FIDO2")`, so `signingInStatus` stays busy (`COMPLETING_SIGN_IN_WITH_FIDO2`), the consumer's `signInStatus` stays `"SIGNING_IN"`, and the app spins indefinitely with no console error and no failed request (the request is *pending*). Reproduced live on `app.sandbox.meow.com`, single tab.

Device confirmation is best-effort per the code's own comment ("prepare for future MFA bypass, not required"), yet it was `await`ed on the blocking path with no bound.

### Fix

Bound every attempt with a composed `AbortController`:
- aborts on the **caller's** signal → propagated as `AbortError`, never retried;
- aborts on a **per-attempt timeout** → retried, or surfaced as `FetchAttemptTimeoutError` on the last attempt.

Default `25s`, configurable via a new optional `perAttemptTimeoutMs` parameter (the `config.ts` call site is unchanged and gets the default). This is the one chokepoint every Cognito call flows through, so `ConfirmDevice`, `RespondToAuthChallenge`, and token refresh all fail fast instead of hanging.

### Tests

- New `test/fetch-attempt-timeout.test.ts` (6 tests, fake timers): a never-settling request times out (doesn't hang) and throws after retries; a caller abort propagates as `AbortError` without retry; a request within the timeout succeeds without retry; a timed-out attempt is retried and can then succeed; no dangling timers on success.
- Updated the existing `client/__tests__/retry.test.ts` listener-count assertion to the real invariant (abort-listener adds == removes, i.e. no leak) now that each attempt registers a balanced caller-abort listener.

### Notes

- **Pre-existing test flakiness (not from this change):** the real-timer suites under `test/refresh-*` / `test/process-tokens-scheduling` flake under parallel `jest` (different suites fail on different runs); clean `main` flakes the same way (e.g. `refresh-bugs.test.ts`). Every suite passes in isolation and all tests pass `--runInBand`. The suites this change actually touches pass deterministically.
- Consuming `webapp_v2` needs a version bump + publish (→ `1.0.103`) to pick this up.
- Optional follow-up: also thread `abort` into `handleDeviceConfirmation`/`confirmDevice` (`client/common.ts`, `client/device.ts`) so a caller can cancel device confirmation directly; the retry-layer timeout already resolves the hang for all callers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the shared retry wrapper on the auth critical path; behavior shifts from indefinite hangs to timeouts/retries, with new error type on exhaustion.
> 
> **Overview**
> **`createFetchWithRetry`** now caps each attempt with a **25s default** (`perAttemptTimeoutMs`, optional 5th parameter). Hung fetches are aborted via a per-attempt `AbortController`, **retried** like other transient failures, and after the last attempt throw **`FetchAttemptTimeoutError`** instead of hanging or surfacing a generic `AbortError`. **Caller `signal` aborts** still propagate immediately and are **never** retried.
> 
> Adds **`test/fetch-attempt-timeout.test.ts`** (black-hole fetch, caller abort, retry-then-success, timer cleanup) and relaxes **`retry.test.ts`** to assert balanced abort listener add/remove counts now that each attempt registers a caller-abort listener.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ca4085939491c994d46a1a22f3a13d4d40677d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->