### PR TITLE
fix(react): skip GetUser MFA-status fetch when token lacks user.admin scope

### DIFF
--- a/client/__tests__/react-mfa-scope-skip.test.tsx
+++ b/client/__tests__/react-mfa-scope-skip.test.tsx
@@ -1,0 +1,143 @@
+/**
+ * Copyright Amazon.com, Inc. and its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You
+ * may not use this file except in compliance with the License. A copy of
+ * the License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+import React from "react";
+import { renderHook, act } from "@testing-library/react";
+import {
+  PasswordlessContextProvider,
+  usePasswordless,
+} from "../react/hooks.js";
+import { configure } from "../config.js";
+import { retrieveTokens, TokensFromStorage } from "../storage.js";
+import { getUser } from "../cognito-api.js";
+
+// Mocks
+jest.mock("../config");
+jest.mock("../storage");
+jest.mock("../hosted-oauth");
+jest.mock("../cognito-api");
+jest.mock("../refresh");
+jest.mock("../fido2", () => {
+  const actual = jest.requireActual("../fido2");
+  return {
+    ...actual,
+    fido2ListCredentials: jest.fn(() =>
+      Promise.resolve({ authenticators: [] })
+    ),
+  };
+});
+
+const mockConfigure = configure as jest.MockedFunction<typeof configure>;
+const mockRetrieveTokens = retrieveTokens as jest.MockedFunction<
+  typeof retrieveTokens
+>;
+const mockGetUser = getUser as jest.MockedFunction<typeof getUser>;
+
+// Build a token that the parseJwtPayload mock in setup.ts can decode
+const makeJwt = (payload: Record<string, unknown>) =>
+  `eyJhbGciOiJub25lIn0.${btoa(JSON.stringify(payload))}.signature`;
+
+// A hosted-UI / OAuth access token: carries only the OAuth scopes that were
+// requested, NOT aws.cognito.signin.user.admin
+const makeOAuthTokens = (): TokensFromStorage => {
+  const expireAt = new Date(Date.now() + 3600_000);
+  return {
+    accessToken: makeJwt({
+      sub: "test-sub",
+      username: "test-user",
+      exp: Math.floor(expireAt.valueOf() / 1000),
+      iat: Math.floor(Date.now() / 1000),
+      scope: "openid email profile",
+    }),
+    idToken: undefined,
+    refreshToken: "refresh-token",
+    expireAt,
+    username: "test-user",
+    authMethod: "REDIRECT",
+  };
+};
+
+const makeWrapper = () =>
+  function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <PasswordlessContextProvider>{children}</PasswordlessContextProvider>
+    );
+  };
+
+describe("MFA status fetch skipped without aws.cognito.signin.user.admin scope", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+
+    mockConfigure.mockReturnValue({
+      clientId: "test-client-id",
+      debug: jest.fn(),
+      storage: {
+        getItem: jest.fn(),
+        setItem: jest.fn(),
+        removeItem: jest.fn(),
+      },
+    } as unknown as ReturnType<typeof configure>);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("never calls getUser and reports default MFA status", async () => {
+    mockRetrieveTokens.mockResolvedValue(makeOAuthTokens());
+
+    const wrapper = makeWrapper();
+    const { result } = renderHook(() => usePasswordless(), { wrapper });
+
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(0);
+    });
+
+    expect(mockGetUser).not.toHaveBeenCalled();
+    expect(result.current.mfaStatusReady).toBe(true);
+    expect(result.current.totpMfaStatus).toEqual(
+      expect.objectContaining({ enabled: false, preferred: false })
+    );
+
+    // GetUser can never succeed with this token, so nothing may be scheduled:
+    // no retry storm against Cognito
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(60_000);
+    });
+    expect(mockGetUser).not.toHaveBeenCalled();
+  });
+
+  it("refreshTotpMfaStatus is a no-op call to Cognito", async () => {
+    mockRetrieveTokens.mockResolvedValue(makeOAuthTokens());
+
+    const wrapper = makeWrapper();
+    const { result } = renderHook(() => usePasswordless(), { wrapper });
+
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(0);
+    });
+
+    await act(async () => {
+      await result.current.refreshTotpMfaStatus();
+    });
+
+    expect(mockGetUser).not.toHaveBeenCalled();
+    expect(result.current.mfaStatusReady).toBe(true);
+    expect(result.current.totpMfaStatus).toEqual(
+      expect.objectContaining({ enabled: false, preferred: false })
+    );
+  });
+});

--- a/client/__tests__/react-mfa-status-cooldown.test.tsx
+++ b/client/__tests__/react-mfa-status-cooldown.test.tsx
@@ -63,6 +63,7 @@ const makeTokens = (suffix: string): TokensFromStorage => {
       exp: Math.floor(expireAt.valueOf() / 1000),
       iat: Math.floor(Date.now() / 1000),
       jti: suffix,
+      scope: "aws.cognito.signin.user.admin",
     }),
     idToken: undefined,
     refreshToken: `refresh-token-${suffix}`,

--- a/client/__tests__/setup.ts
+++ b/client/__tests__/setup.ts
@@ -53,6 +53,7 @@ jest.mock("../util.js", () => {
           return {
             username: "test-user",
             exp: Math.floor(Date.now() / 1000) + 3600,
+            scope: "aws.cognito.signin.user.admin",
           };
         }
 

--- a/client/react/hooks.tsx
+++ b/client/react/hooks.tsx
@@ -1136,6 +1136,22 @@ function _usePasswordless() {
   // Track OAuth callback processing to prevent multiple executions
   const oauthProcessingRef = useRef(false);
 
+  // GetUser only works with tokens that carry this scope. Native sign-ins
+  // (SRP / FIDO2 / plaintext) get it implicitly; hosted-UI OAuth tokens only
+  // get it when it was explicitly requested. Fail open on parse errors so an
+  // unparseable token keeps the previous behavior (attempt the call).
+  const accessTokenHasUserAdminScope = (accessToken: string) => {
+    try {
+      const { scope } = parseJwtPayload<CognitoAccessTokenPayload>(accessToken);
+      return (
+        typeof scope === "string" &&
+        scope.split(" ").includes("aws.cognito.signin.user.admin")
+      );
+    } catch {
+      return true;
+    }
+  };
+
   // Fetch TOTP MFA status when the user is signed in – with rate limiting
   useEffect(() => {
     // Early return if not signed in or no token
@@ -1146,6 +1162,24 @@ function _usePasswordless() {
 
     // Skip if we've already fetched MFA status for this token value
     if (tokens.accessToken === lastFetchedMfaTokenRef.current) return;
+
+    // Hosted-UI / OAuth access tokens only carry the OAuth scopes that were
+    // requested, and GetUser requires aws.cognito.signin.user.admin — without
+    // it the call fails deterministically, so don't make (and retry) it.
+    // MFA for such sessions is the IdP's concern anyway.
+    if (!accessTokenHasUserAdminScope(tokens.accessToken)) {
+      const { debug } = configure();
+      debug?.(
+        "Access token lacks aws.cognito.signin.user.admin scope; skipping getUser MFA-status fetch"
+      );
+      lastFetchedMfaTokenRef.current = tokens.accessToken;
+      dispatch({
+        type: "SET_TOTP_MFA_STATUS",
+        payload: { enabled: false, preferred: false, availableMfaTypes: [] },
+      });
+      dispatch({ type: "SET_MFA_STATUS_READY", payload: true });
+      return;
+    }
 
     // Skip if we fetched recently (within cooldown period)
     if (timeSinceLastFetch < MFA_FETCH_COOLDOWN) {
@@ -2015,6 +2049,15 @@ function _usePasswordless() {
     /** Refresh the TOTP MFA status - use this after enabling/disabling MFA */
     refreshTotpMfaStatus: async () => {
       if (!tokens?.accessToken) return;
+
+      if (!accessTokenHasUserAdminScope(tokens.accessToken)) {
+        dispatch({
+          type: "SET_TOTP_MFA_STATUS",
+          payload: { enabled: false, preferred: false, availableMfaTypes: [] },
+        });
+        dispatch({ type: "SET_MFA_STATUS_READY", payload: true });
+        return;
+      }
 
       try {
         const user = await getUser({ accessToken: tokens.accessToken });


### PR DESCRIPTION
## Problem

On hosted-UI / OAuth (`signInWithRedirect`) sessions, the admin webapp's browser network tab fills with failing Cognito `GetUser` calls:

```
NotAuthorizedException: Access Token does not have required scopes
```

`usePasswordless` fetches TOTP MFA status via Cognito `GetUser` after sign-in. `GetUser` requires the `aws.cognito.signin.user.admin` scope. Native sign-ins (SRP / FIDO2 / plaintext via `InitiateAuth`) get that scope implicitly, but hosted-UI OAuth access tokens only carry the OAuth scopes that were requested at sign-in (e.g. `openid email profile`). So for redirect sessions the call fails deterministically — and the hook treats it as transient, retrying per token (up to `MAX_MFA_FETCH_RETRIES`) and again on every token refresh, hammering Cognito for a result it can never get.

## Fix

Decode the access token's `scope` claim before calling `getUser` in the MFA-status effect (and in `refreshTotpMfaStatus`). If `aws.cognito.signin.user.admin` isn't present:

- publish the default TOTP status (disabled) and set `mfaStatusReady` immediately, so the UI doesn't hang behind a loader, and
- skip the fetch entirely — no call, no retry loop.

This is also semantically correct: redirect sessions are federated/SSO, where MFA is the IdP's concern; Cognito-side TOTP status is not meaningful for them. Unparseable tokens **fail open** (attempt the call) to preserve prior behavior.

No backend / CDK change: this avoids the alternative of granting `aws.cognito.signin.user.admin` to the hosted-UI app client, which would also hand the browser token the full self-service Cognito user API.

## Tests

- New `client/__tests__/react-mfa-scope-skip.test.tsx`: an OAuth-scoped token (`openid email profile`) never triggers `getUser`, reports default MFA status, and schedules no retries; `refreshTotpMfaStatus` is a no-op against Cognito.
- Existing fetch-path fixtures (`setup.ts`, `react-mfa-status-cooldown.test.tsx`) updated to mint tokens carrying the scope so they still exercise the `getUser` path.
- Full suite: 61 suites pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only guard around an API that would always fail for OAuth tokens; native sign-in behavior is unchanged when the scope is present, with fail-open on JWT parse errors.
> 
> **Overview**
> Stops **repeated failing Cognito `GetUser` calls** on hosted-UI / OAuth sessions whose access tokens only include scopes like `openid email profile`, not `aws.cognito.signin.user.admin`.
> 
> `usePasswordless` now decodes the access token **`scope`** before MFA status work. When that admin scope is missing, it **does not call `getUser`**, sets **default TOTP MFA (disabled)** and **`mfaStatusReady: true`** immediately, and applies the same short-circuit in **`refreshTotpMfaStatus`**. Unparseable tokens still **attempt `getUser`** (fail open).
> 
> Tests add **`react-mfa-scope-skip.test.tsx`** for OAuth-scoped tokens; existing MFA cooldown fixtures gain the admin scope so they still exercise the fetch path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22c57a5494d26b1c2abc407bf5c61d2c53297ec8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->