### PR TITLE
fix(security): require https for cognitoIdpEndpoint

### DIFF
--- a/client/__tests__/oauth-endpoints.test.ts
+++ b/client/__tests__/oauth-endpoints.test.ts
@@ -121,7 +121,10 @@ describe("OAuth2 endpoints (Hosted UI domain)", () => {
       expect(config.hostedUi?.domain).toBeUndefined();
     });
 
-    it("throws when hostedUi is configured without domain and cognitoIdpEndpoint is a plaintext http:// URL", () => {
+    it("throws when cognitoIdpEndpoint is a plaintext http:// URL", () => {
+      // Passwords, SRP parameters and refresh/access tokens are POSTed to this
+      // endpoint, so a plaintext http:// endpoint is rejected outright at
+      // configure() time — before any hostedUi.domain validation is reached
       expect(() =>
         configure({
           cognitoIdpEndpoint: "http://cognito-proxy.example.com",
@@ -130,7 +133,25 @@ describe("OAuth2 endpoints (Hosted UI domain)", () => {
             redirectSignIn,
           },
         })
-      ).toThrow("hostedUi.domain is required");
+      ).toThrow("cognitoIdpEndpoint must not use plaintext http://");
+    });
+
+    it("accepts an https:// cognitoIdpEndpoint", () => {
+      const config = configure({
+        cognitoIdpEndpoint: "https://cognito-proxy.example.com",
+        clientId: "test-client-id",
+      });
+      expect(config.cognitoIdpEndpoint).toBe(
+        "https://cognito-proxy.example.com"
+      );
+    });
+
+    it("accepts a bare AWS region cognitoIdpEndpoint (not rejected as http://)", () => {
+      const config = configure({
+        cognitoIdpEndpoint: "eu-west-1",
+        clientId: "test-client-id",
+      });
+      expect(config.cognitoIdpEndpoint).toBe("eu-west-1");
     });
 
     it("leaves the previous configuration intact when configure() throws", () => {
@@ -217,20 +238,16 @@ describe("OAuth2 endpoints (Hosted UI domain)", () => {
       );
     });
 
-    it("refuses to build OAuth2 endpoints on a plaintext http:// cognitoIdpEndpoint", () => {
-      // Without hostedUi, configure() accepts a custom http:// IDP endpoint,
-      // but the OAuth2 endpoints must never be built on a non-TLS origin
-      // because authorization codes and tokens travel to it
-      configure({
-        cognitoIdpEndpoint: "http://cognito-proxy.example.com",
-        clientId: "test-client-id",
-      });
-      expect(() => getAuthorizeEndpoint()).toThrow(
-        "Cannot determine OAuth2 endpoint"
-      );
-      expect(() => getTokenEndpoint()).toThrow(
-        "Cannot determine OAuth2 endpoint"
-      );
+    it("refuses a plaintext http:// cognitoIdpEndpoint at configure() time", () => {
+      // A non-TLS origin is rejected outright by configure(), so the OAuth2
+      // endpoints can never be built on it — authorization codes, tokens,
+      // passwords and SRP parameters all travel to this origin
+      expect(() =>
+        configure({
+          cognitoIdpEndpoint: "http://cognito-proxy.example.com",
+          clientId: "test-client-id",
+        })
+      ).toThrow("cognitoIdpEndpoint must not use plaintext http://");
     });
 
     it("never produces https://<region>/oauth2/... for a region-only cognitoIdpEndpoint", () => {

--- a/client/__tests__/region-regex.test.ts
+++ b/client/__tests__/region-regex.test.ts
@@ -58,14 +58,28 @@ describe("AWS region detection in cognitoIdpEndpoint", () => {
       expect(config.cognitoIdpEndpoint).toBe(`https://${hostname}`);
     });
 
-    test.each(["https://example.com", "http://localhost:3000"])(
-      "leaves URL with protocol %s untouched",
+    test.each(["https://example.com", "https://localhost:3000"])(
+      "leaves https:// URL with protocol %s untouched",
       (url) => {
         const config = configure({
           cognitoIdpEndpoint: url,
           clientId: "test-client-id",
         });
         expect(config.cognitoIdpEndpoint).toBe(url);
+      }
+    );
+
+    // Passwords, SRP parameters and tokens are POSTed to cognitoIdpEndpoint,
+    // so a plaintext http:// endpoint is rejected outright at configure() time.
+    test.each(["http://example.com", "http://localhost:3000"])(
+      "rejects plaintext http:// URL %s",
+      (url) => {
+        expect(() =>
+          configure({
+            cognitoIdpEndpoint: url,
+            clientId: "test-client-id",
+          })
+        ).toThrow("cognitoIdpEndpoint must not use plaintext http://");
       }
     );
   });

--- a/client/config.ts
+++ b/client/config.ts
@@ -275,6 +275,20 @@ export function configure(config?: ConfigInput) {
       cognitoIdpEndpoint = `https://${cognitoIdpEndpoint}`;
     }
 
+    // Reject a plaintext http:// cognitoIdpEndpoint: every cognito-idp API call
+    // (InitiateAuth, RespondToAuthChallenge, GetTokensFromRefreshToken,
+    // RevokeToken, GetUser, SignUp, ChangePassword, ...) is POSTed here, so
+    // passwords (USER_PASSWORD_AUTH), SRP parameters, refresh/access tokens and
+    // any clientSecret travel to this origin — it must be https://. A bare AWS
+    // region (e.g. eu-west-1) is handled by the auto-prefix above and never
+    // reaches here as http://. This mirrors the http:// rejection already
+    // applied to hostedUi.domain.
+    if (cognitoIdpEndpoint.startsWith("http://")) {
+      throw new Error(
+        "Invalid configuration: cognitoIdpEndpoint must not use plaintext http:// — passwords, SRP parameters and refresh/access tokens are sent to this endpoint, so it must be https://. Use https:// or a bare AWS region (e.g. eu-west-1)."
+      );
+    }
+
     // Validate before assigning config_, so that a failed configure() is
     // atomic and leaves any previously loaded configuration unchanged
     if (


### PR DESCRIPTION
## Security finding (Cursor) — High

`cognitoIdpEndpoint` (`client/config.ts`) is used to build the URL for **every** Cognito IDP API call — `InitiateAuth`, `RespondToAuthChallenge`, `GetTokensFromRefreshToken`, `RevokeToken`, `GetUser`, `SignUp`, `ChangePassword`, etc. Passwords (`USER_PASSWORD_AUTH`), SRP parameters, refresh/access tokens, and any optional `clientSecret` are POSTed to this endpoint.

The auto-prefix logic in `configure()` only adds `https://` for a *bare, non-region* hostname; a full `http://` URL passed through unchanged. So a misconfigured (or attacker-supplied) plaintext `http://` endpoint would send credentials and tokens in the clear. Unlike `hostedUi.domain` — which already rejects `http://` at configuration time (`config.ts:293-296`) — `cognitoIdpEndpoint` silently accepted it.

## Fix

In `configure()`, after the existing auto-prefix step, reject a `cognitoIdpEndpoint` that starts with `http://`, throwing a clear error that explains passwords and tokens travel to this endpoint so HTTPS is required. This **mirrors the existing `hostedUi.domain` `http://` rejection** in both placement and error style.

- Bare AWS region shorthand (e.g. `eu-west-1`) is unaffected — it never reaches the check as `http://` because it is handled by the auto-prefix path.
- `https://` endpoints are accepted unchanged.

## Tests

- `client/__tests__/oauth-endpoints.test.ts`: updated the two cases that previously asserted `configure()` *accepted* an `http://` endpoint; added positive coverage that `https://` and a bare region are accepted.
- `client/__tests__/region-regex.test.ts`: split the "leaves URL with protocol untouched" case into `https://` (accepted) and `http://` (rejected).

Full client + root Jest suites pass (502 passed, 18 skipped); `tsc --noEmit`, ESLint, and Prettier are clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Security-hardening change to auth endpoint configuration; behavior change for anyone relying on `http://` IDP URLs (now fails at startup), with no impact on standard region or `https://` setups.
> 
> **Overview**
> **Blocks plaintext `http://` for `cognitoIdpEndpoint`** in `configure()`, matching the existing rule for `hostedUi.domain`. Full `http://` URLs used to pass through auto-prefix logic unchanged, so auth API calls could target a non-TLS origin.
> 
> After the existing hostname/region normalization step, any endpoint that still starts with `http://` throws with a message that credentials and tokens are POSTed to this URL. **`https://` URLs and bare AWS regions** (e.g. `eu-west-1`) are unchanged.
> 
> Tests now expect **configure-time failure** for `http://` (including cases that previously allowed configure and only failed when building OAuth endpoints), plus explicit acceptance of `https://` and region shorthand.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2673b4ed458b92b65824087e74954663595d8cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->