### PR TITLE
fix(security): require https for fido2.baseUrl

### DIFF
--- a/client/__tests__/fido2-baseurl-https.test.ts
+++ b/client/__tests__/fido2-baseurl-https.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Copyright Amazon.com, Inc. and its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You
+ * may not use this file except in compliance with the License. A copy of
+ * the License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+import { configure } from "../config.js";
+
+describe("fido2.baseUrl scheme validation", () => {
+  it("throws when fido2.baseUrl uses plaintext http://", () => {
+    // The user's ID token is sent as a Bearer credential to this URL, so a
+    // plaintext http:// base is rejected (mirrors the hostedUi.domain check)
+    expect(() =>
+      configure({
+        cognitoIdpEndpoint: "eu-west-1",
+        clientId: "test-client-id",
+        fido2: {
+          baseUrl: "http://fido2.example.com",
+        },
+      })
+    ).toThrow("fido2.baseUrl must not use plaintext http://");
+  });
+
+  it("accepts an https:// fido2.baseUrl", () => {
+    const config = configure({
+      cognitoIdpEndpoint: "eu-west-1",
+      clientId: "test-client-id",
+      fido2: {
+        baseUrl: "https://fido2.example.com",
+      },
+    });
+    expect(config.fido2?.baseUrl).toBe("https://fido2.example.com");
+  });
+});

--- a/client/config.ts
+++ b/client/config.ts
@@ -295,6 +295,16 @@ export function configure(config?: ConfigInput) {
         "Invalid configuration: hostedUi.domain must not use plaintext http:// — it is the OAuth2 base that authorization codes and tokens travel to. Use https:// or a bare domain (https:// is assumed)."
       );
     }
+    // Reject a plaintext http:// fido2.baseUrl: the user's ID token is sent as
+    // an `Authorization: Bearer <idToken>` credential to this URL for every
+    // FIDO2 backend call (register passkey, list/delete credentials), so it
+    // must be https://. This mirrors the http:// rejection applied to
+    // hostedUi.domain above.
+    if (config.fido2?.baseUrl?.startsWith("http://")) {
+      throw new Error(
+        "Invalid configuration: fido2.baseUrl must not use plaintext http:// — your ID token is sent as a Bearer credential to this URL, so it must be https://."
+      );
+    }
 
     // Wrap the user-provided or default fetch in retry logic (pass debug callback)
     const baseFetch = (config.fetch ?? Defaults.fetch).bind(globalThis);


### PR DESCRIPTION
## Security finding (Cursor) — Medium

`fido2.baseUrl` (`client/config.ts`) is the base URL used to build the URL for **every** FIDO2 backend API call — register passkey, list credentials, delete credentials (`client/fido2.ts`, `getFullFido2Url` and its callers around lines 429, 454, 492, 536, 588). Each of those requests sends the user's ID token as an `Authorization: Bearer <idToken>` header.

`configure()` validated `hostedUi.domain` against `http://` (`config.ts:293-296`) but left `fido2.baseUrl` unchecked, so a misconfigured (or attacker-supplied) plaintext `http://` base would send the bearer ID token in the clear.

## Fix

In `configure()`, right after the existing `hostedUi.domain` `http://` rejection, reject a `fido2.baseUrl` that starts with `http://`, throwing a clear error that explains the ID token is sent as a Bearer credential to this URL so HTTPS is required. This **mirrors the existing `hostedUi.domain` check** in placement and error style. `https://` bases are accepted unchanged.

## Tests

New `client/__tests__/fido2-baseurl-https.test.ts`:
- asserts a plaintext `http://` `fido2.baseUrl` throws at `configure()` time;
- asserts an `https://` `fido2.baseUrl` is accepted.

Full client + root Jest suites pass (500 passed, 18 skipped); `tsc --noEmit`, ESLint, and Prettier are clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tightens config validation only; legitimate setups using `https://` are unchanged, and misconfiguration fails fast at startup.
> 
> **Overview**
> **`configure()` now rejects plaintext `http://` for `fido2.baseUrl`**, matching the existing `hostedUi.domain` check. FIDO2 API calls send the user’s ID token as `Authorization: Bearer`, so a non-HTTPS base would expose that credential on the wire.
> 
> A new Jest file covers the throw path for `http://` and acceptance of `https://` at configuration time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb55b567fafa1b52314cac6dae0bea6db3c83db4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->