### PR TITLE
fix: use immediate ui mode for passkey requests

### DIFF
--- a/client/__tests__/mediation-integration.test.ts
+++ b/client/__tests__/mediation-integration.test.ts
@@ -273,7 +273,7 @@ describe("Mediation Integration Tests", () => {
       ).rejects.toThrow(Fido2ConfigError);
     });
 
-    it("uses immediate mediation without parameter overrides with known values", async () => {
+    it("maps immediate mediation to uiMode without parameter overrides", async () => {
       const getSpy = jest.fn().mockResolvedValue(MOCK_ASSERTION_CREDENTIAL);
 
       cleanup = setupWebAuthnMock({
@@ -293,15 +293,17 @@ describe("Mediation Integration Tests", () => {
         timeout: knownTimeout,
       });
 
-      expect(getSpy).toHaveBeenCalledWith(
+      const request = getSpy.mock.calls[0][0];
+      expect(request).toEqual(
         expect.objectContaining({
           publicKey: expect.objectContaining({
-            userVerification: knownUserVerification, // Not overridden for immediate
-            timeout: knownTimeout, // Not removed for immediate
+            userVerification: knownUserVerification,
+            timeout: knownTimeout,
           }),
-          mediation: "immediate",
+          uiMode: "immediate",
         })
       );
+      expect(request).not.toHaveProperty("mediation");
     });
 
     it("logs debug message for immediate mediation", async () => {
@@ -717,8 +719,7 @@ describe("Mediation Integration Tests", () => {
 
         // The conditional request was asked to abort (but won't comply)
         await jest.advanceTimersByTimeAsync(0);
-        const conditionalSignal = getSpy.mock.calls[0][0]
-          .signal as AbortSignal;
+        const conditionalSignal = getSpy.mock.calls[0][0].signal as AbortSignal;
         expect(conditionalSignal.aborted).toBe(true);
 
         // Just before the settlement timeout: still waiting

--- a/client/fido2.ts
+++ b/client/fido2.ts
@@ -51,6 +51,10 @@ export type MediationMode =
   | "required"
   | "silent";
 
+interface CredentialRequestOptionsWithUiMode extends CredentialRequestOptions {
+  uiMode?: "immediate";
+}
+
 /**
  * WebAuthn Client Capabilities as defined in the W3C spec.
  * @see https://w3c.github.io/webauthn/#sctn-client-capabilities
@@ -74,7 +78,7 @@ export interface WebAuthnClientCapabilities {
   signalCurrentUserDetails?: boolean;
   /** Client supports signalUnknownCredential() */
   signalUnknownCredential?: boolean;
-  /** Chrome-specific: immediate mediation support (Chrome 139+, origin trial) */
+  /** Client supports immediate UI mode for credential requests */
   immediateGet?: boolean;
   /** Extension support: prefixed with 'extension:' */
   [key: `extension:${string}`]: boolean | undefined;
@@ -181,7 +185,7 @@ export async function detectMediationCapabilities(): Promise<{
   // Check immediate mediation support using new getClientCapabilities API
   const capabilities = await getClientCapabilities();
   if (capabilities) {
-    // immediateGet is Chrome 139+ specific capability
+    // immediateGet indicates support for the immediate UI request mode
     immediate = capabilities.immediateGet === true;
 
     // Fallback: conditionalGet also indicates conditional mediation support
@@ -1158,13 +1162,14 @@ export async function fido2getCredential({
 
     let conditionalTracker: typeof pendingConditionalGet = undefined;
     try {
-      // Type assertion needed: 'immediate' mediation not yet in TS lib definitions (CredentialMediationRequirement)
-      // Runtime support: Chrome 139+, see https://developer.chrome.com/blog/webauthn-immediate-mediation
-      const getCredential = navigator.credentials.get({
+      const credentialRequestOptions: CredentialRequestOptionsWithUiMode = {
         publicKey,
         signal: effectiveSignal,
-        mediation: mediation as CredentialMediationRequirement,
-      });
+        ...(mediation === "immediate"
+          ? { uiMode: "immediate" }
+          : { mediation }),
+      };
+      const getCredential = navigator.credentials.get(credentialRequestOptions);
       if (conditionalAbort) {
         // Track this conditional request at module level, and clear the
         // tracker once it settles (for any reason)
@@ -1848,7 +1853,7 @@ export function authenticateWithFido2({
    * ```
    *
    * @see https://passkeys.dev/docs/use-cases/bootstrapping (conditional)
-   * @see https://developer.chrome.com/blog/webauthn-immediate-mediation (immediate)
+   * @see https://developer.chrome.com/docs/identity/immediate-ui-mode (immediate)
    */
   mediation?: MediationMode;
   /**

--- a/client/react/README.md
+++ b/client/react/README.md
@@ -169,7 +169,8 @@ function AutofillSignInButton() {
 `detectMediationCapabilities()` safely determines whether the browser supports
 conditional (autofill) or immediate (fast fail) mediation modes. Import
 `getClientCapabilities()` from the core package if you need the full WebAuthn
-capability matrix.
+capability matrix. The library maps `mediation: "immediate"` to the browser's
+standards-compliant `uiMode: "immediate"` request field.
 
 ### 3.2 SRP Password
 


### PR DESCRIPTION
### Description

Translate the library’s existing `mediation: "immediate"` option to the standards-compliant WebAuthn `uiMode: "immediate"` request field. Chrome no longer accepts `"immediate"` as a `CredentialMediationRequirement`, so forwarding it directly causes passkey sign-in to fail with a `TypeError` before an assertion is created.

### Linear

N/A

### Changes

- Preserve the public library API while mapping immediate requests to `uiMode` at the browser boundary.
- Omit the invalid `mediation` field for immediate requests while retaining existing behavior for other mediation modes.
- Add regression coverage and document the browser-level mapping.

### QA Plan

- [ ] In Chrome 149+, click a passkey sign-in button with a local passkey and verify the immediate credential picker appears and authentication completes.
- [ ] Repeat without a local passkey or dismiss the picker and verify the caller receives the expected `NotAllowedError` fallback behavior.
- [ ] Verify conditional passkey autofill still uses `mediation: "conditional"` and can be superseded by a button-triggered request.

### Evidence

[Need to add evidence]