### PR TITLE
fix: eliminate auth stalls and permanent spinners (orphaned locks, sign-out lock wait, MFA readiness race)

### DIFF
--- a/REFRESH.md
+++ b/REFRESH.md
@@ -19,7 +19,7 @@ graph TB
 
     subgraph "Coordination Layer"
         B1[activeRefreshSchedules Map]
-        B2[Storage Lock System]
+        B2[Cross-Tab Lock System]
         B3[Attempt Tracking]
         B4[Completion Tracking]
     end
@@ -156,11 +156,30 @@ if ("newDeviceMetadata" in tokens) {
 
 ## Multi-Tab Coordination
 
-### Storage-Based Lock System
+### Cross-Tab Lock System
 
 **Location**: `client/lock.ts`
 
-Prevents concurrent refreshes across tabs.
+Prevents concurrent refreshes across tabs. `withLock()` is the single entry
+point and picks one of two backends; `activeLockBackend()` reports which one is
+in use (useful for tagging telemetry, since the two have different failure
+modes).
+
+**Web Locks backend** (default wherever `navigator.locks` exists — a secure
+context in a modern browser):
+
+```typescript
+// Lock characteristics:
+- Browser-owned: released automatically on tab close, crash, or navigation,
+  so a tab killed mid-critical-section cannot orphan the lock
+- 45-second acquisition timeout (bounds waiting on a LIVE holder only)
+- No stale detection needed — orphans cannot exist
+- Not reentrant, and a held lock cannot be force-evicted: a hung critical
+  section must bound itself (the per-attempt fetch timeout does)
+```
+
+**Storage backend** (fallback for Node, SSR, insecure contexts, and browsers
+without the Web Locks API):
 
 ```typescript
 interface StorageLock {
@@ -169,11 +188,37 @@ interface StorageLock {
 }
 
 // Lock characteristics:
-- 15-second acquisition timeout
-- 30-second stale lock detection
+- 45-second acquisition timeout (MUST exceed the stale threshold)
+- 30-second stale lock detection, with heartbeat renewal by the holder
 - Storage events for fast release detection
 - Adaptive polling: 50ms → 75ms → ... → 500ms
 ```
+
+**Scope caveat**: the two backends scope locks differently. Web Locks are
+per-origin; the storage lock's scope is whatever `configure().storage` spans. If
+you configure a storage that reaches beyond one origin (e.g. a cookie shared
+across subdomains), the Web Locks path will not coordinate across those origins.
+If you configure per-tab storage (e.g. `sessionStorage`), the Web Locks path
+gains cross-tab coordination the storage lock never had. Both backends also
+ignore each other, so during a mixed-version rollout a tab on the old version
+and a tab on the new one do not coordinate on the same key. This is safe here:
+sign-out takes no lock at all, and a doubly-run refresh is bounded by the
+`lastRefreshAttempt` window, the refresh-token-reuse retry, and the sign-out
+tombstone re-validation.
+
+### What Is and Isn't Locked
+
+Only the refresh round-trip itself takes the per-user refresh lock, via
+`refreshTokens()`. Two things deliberately run **unlocked**:
+
+- **Scheduling** (`scheduleRefresh`) — computing a delay and arming a timer is
+  local, in-memory work. Holding a cross-tab lock for it let an orphaned lock
+  stall scheduling entirely.
+- **The local sign-out teardown** — the sign-out tombstone is authoritative, so
+  correctness does not depend on the lock. Waiting on one only meant a logout
+  spinner could hang behind another tab's orphaned lock. Refresh-token
+  revocation is bounded best-effort (5s) _after_ the local teardown, on both the
+  normal and `revokeTokensBeforeLocalRemoval` (hosted-UI) paths.
 
 ### Active Refresh Schedules Map
 
@@ -269,7 +314,8 @@ for (let attempt = 1; attempt <= 3; attempt++) {
 
 ### Handled Scenarios
 
-1. **Stale Locks**: Automatically cleared after 30 seconds
+1. **Stale Locks**: Impossible on the Web Locks backend (the browser releases
+   them on tab death); cleared after 30s on the storage backend
 2. **Race Conditions**: Unique lock IDs with timestamp verification
 3. **Network Failures**: 3 retries with exponential backoff
 4. **Token Rotation**: Handles RefreshTokenReuseException
@@ -297,7 +343,7 @@ for (let attempt = 1; attempt <= 3; attempt++) {
 
 | Operation        | Duration   | Notes             |
 | ---------------- | ---------- | ----------------- |
-| Lock Acquisition | 0-15s      | Usually <100ms    |
+| Lock Acquisition | 0-45s      | Usually <100ms    |
 | Refresh API Call | 200-3000ms | Network dependent |
 | Token Processing | <50ms      | Storage writes    |
 | Total Refresh    | 250-3500ms | Typical case      |
@@ -329,9 +375,14 @@ REFRESH_ATTEMPT_JITTER_MS = 100; // 0-100ms random
 // Watchdog
 WATCHDOG_INTERVAL_MS = 300000; // 5 minutes
 
-// Lock timeouts
-DEFAULT_LOCK_TIMEOUT_MS = 15000; // 15 seconds
-STALE_LOCK_THRESHOLD_MS = 30000; // 30 seconds
+// Lock timeouts (client/lock.ts)
+DEFAULT_TIMEOUT_MS = 45000; // 45s acquisition, both backends
+STALE_LOCK_TIMEOUT_MS = 30000; // 30s, storage backend only
+LOCK_HEARTBEAT_INTERVAL_MS = 10000; // 10s, storage backend only
+MAX_LOCK_HOLD_MS = 120000; // 2min renewal cap, storage backend only
+
+// Sign-out (client/common.ts)
+SIGN_OUT_REVOKE_DEADLINE_MS = 5000; // bounds best-effort revocation
 ```
 
 ### Per-User Isolation
@@ -347,7 +398,7 @@ All refresh operations are isolated per user:
 
 - **`client/refresh.ts`**: Core refresh logic and scheduling
 - **`client/common.ts`**: Token processing and schedule management
-- **`client/lock.ts`**: Storage-based locking mechanism
+- **`client/lock.ts`**: Cross-tab locking (Web Locks, storage-lock fallback)
 - **`client/retry.ts`**: Network retry logic
 - **`client/react/hooks.tsx`**: React integration and auto-refresh
 

--- a/REFRESH.md
+++ b/REFRESH.md
@@ -210,16 +210,22 @@ tombstone re-validation.
 
 - **Forced refreshes** (`force: true`, e.g. after a 401) need a genuinely fresh
   token, so they queue on the lock for up to the 45s acquisition timeout.
-- **Background/scheduled refreshes** are best-effort and use **try-immediate**
-  acquisition (`timeoutMs: 0` → Web Locks `ifAvailable`, or a single storage
-  attempt): if the lock is held, whoever holds it is refreshing this same
-  user's tokens, so the caller skips to recovery instead of queueing — it waits
-  2s, adopts the holder's refreshed tokens if they landed, and otherwise
-  **returns the still-valid cached token** rather than surfacing an error. A
-  spurious lock timeout (timers firing before the event loop resumes after
-  laptop sleep) must never masquerade as an auth failure while the session is
-  healthy. Only when the cached token is genuinely expired does the caller see
-  an error (and the scheduled path then retries with backoff).
+- **Non-forced refreshes with a still-valid cached access token** are
+  best-effort and use **try-immediate** acquisition (`timeoutMs: 0` → Web
+  Locks `ifAvailable`, or a single storage attempt): if the lock is held,
+  whoever holds it is refreshing this same user's tokens, so the caller skips
+  to recovery instead of queueing — it waits 2s, adopts the holder's refreshed
+  tokens if they landed, and otherwise **returns the still-valid cached
+  token** rather than surfacing an error. A spurious lock timeout (timers
+  firing before the event loop resumes after laptop sleep) must never
+  masquerade as an auth failure while the session is healthy. A scheduled
+  refresh that took the cached-token path re-arms only after the 5s
+  coordination window, so contention never becomes a tight poll.
+- **Non-forced refreshes with an expired (or missing) access token** have no
+  fallback — the refresh must actually produce tokens — so they **queue** like
+  a forced refresh does. Staying non-forced keeps the cross-tab coordination
+  check, so a refresh the previous lock holder just completed is adopted
+  rather than repeated.
 - **Detecting a lock timeout**: use the exported `isLockTimeoutError()` type
   guard, not `instanceof LockTimeoutError` — a bundler can duplicate the
   module, and an instance of one copy's class is not `instanceof` the other's.

--- a/REFRESH.md
+++ b/REFRESH.md
@@ -206,6 +206,24 @@ sign-out takes no lock at all, and a doubly-run refresh is bounded by the
 `lastRefreshAttempt` window, the refresh-token-reuse retry, and the sign-out
 tombstone re-validation.
 
+### Lock Acquisition Policy
+
+- **Forced refreshes** (`force: true`, e.g. after a 401) need a genuinely fresh
+  token, so they queue on the lock for up to the 45s acquisition timeout.
+- **Background/scheduled refreshes** are best-effort and use **try-immediate**
+  acquisition (`timeoutMs: 0` → Web Locks `ifAvailable`, or a single storage
+  attempt): if the lock is held, whoever holds it is refreshing this same
+  user's tokens, so the caller skips to recovery instead of queueing — it waits
+  2s, adopts the holder's refreshed tokens if they landed, and otherwise
+  **returns the still-valid cached token** rather than surfacing an error. A
+  spurious lock timeout (timers firing before the event loop resumes after
+  laptop sleep) must never masquerade as an auth failure while the session is
+  healthy. Only when the cached token is genuinely expired does the caller see
+  an error (and the scheduled path then retries with backoff).
+- **Detecting a lock timeout**: use the exported `isLockTimeoutError()` type
+  guard, not `instanceof LockTimeoutError` — a bundler can duplicate the
+  module, and an instance of one copy's class is not `instanceof` the other's.
+
 ### What Is and Isn't Locked
 
 Only the refresh round-trip itself takes the per-user refresh lock, via

--- a/client/__tests__/hosted-oauth.test.ts
+++ b/client/__tests__/hosted-oauth.test.ts
@@ -25,7 +25,7 @@ import {
 import { webcrypto } from "crypto";
 import { configure, getAuthorizeEndpoint } from "../config.js";
 import { processTokens } from "../common.js";
-import { withStorageLock, LockTimeoutError } from "../lock.js";
+import { withLock, LockTimeoutError } from "../lock.js";
 import type { ConfigWithDefaults } from "../config.js";
 
 // Mock dependencies
@@ -41,9 +41,7 @@ const mockGetAuthorizeEndpoint = getAuthorizeEndpoint as jest.MockedFunction<
 const mockProcessTokens = processTokens as jest.MockedFunction<
   typeof processTokens
 >;
-const mockWithStorageLock = withStorageLock as jest.MockedFunction<
-  typeof withStorageLock
->;
+const mockWithLock = withLock as jest.MockedFunction<typeof withLock>;
 
 interface MockLocation {
   href: string;
@@ -110,7 +108,7 @@ describe("OAuth Integration with processTokens", () => {
     };
 
     mockConfigure.mockReturnValue(mockConfig as ConfigWithDefaults);
-    mockWithStorageLock.mockImplementation(async (_, fn) => fn());
+    mockWithLock.mockImplementation(async (_, fn) => fn());
   });
 
   describe("handleCognitoOAuthCallback", () => {
@@ -720,7 +718,7 @@ describe("OAuth Integration with processTokens", () => {
 
     it("should scrub code and state from the URL when state validation hits a lock timeout", async () => {
       setupCodeFlowState();
-      mockWithStorageLock.mockRejectedValueOnce(
+      mockWithLock.mockRejectedValueOnce(
         new LockTimeoutError("test-lock-key", 15000)
       );
 
@@ -749,9 +747,7 @@ describe("OAuth Integration with processTokens", () => {
         if (key === "cognito_oauth_state") return Promise.resolve("test-state");
         return Promise.resolve(null);
       });
-      mockProcessTokens.mockRejectedValue(
-        new Error("token processing failed")
-      );
+      mockProcessTokens.mockRejectedValue(new Error("token processing failed"));
 
       await expect(handleCognitoOAuthCallback()).rejects.toThrow(
         "token processing failed"

--- a/client/__tests__/hosted-oauth.test.ts
+++ b/client/__tests__/hosted-oauth.test.ts
@@ -31,7 +31,13 @@ import type { ConfigWithDefaults } from "../config.js";
 // Mock dependencies
 jest.mock("../config");
 jest.mock("../common");
-jest.mock("../lock");
+// Partial mock: withLock is stubbed per-test, but LockTimeoutError and
+// isLockTimeoutError stay real so the code under test can recognize the
+// timeout errors these tests throw.
+jest.mock("../lock", () => ({
+  ...jest.requireActual<typeof import("../lock.js")>("../lock"),
+  withLock: jest.fn(),
+}));
 jest.mock("../storage");
 
 const mockConfigure = configure as jest.MockedFunction<typeof configure>;

--- a/client/__tests__/mediation-integration.test.ts
+++ b/client/__tests__/mediation-integration.test.ts
@@ -306,6 +306,68 @@ describe("Mediation Integration Tests", () => {
       expect(request).not.toHaveProperty("mediation");
     });
 
+    it("strips a non-empty allowCredentials for immediate mediation (discoverable-credential-only)", async () => {
+      // Chrome rejects uiMode:"immediate" requests that carry a non-empty
+      // allowCredentials with NotAllowedError (anti-tracking) — regardless of
+      // whether the user has a matching passkey. Sending the server-issued
+      // credential IDs (username-first flow) would therefore make every
+      // immediate request fail silently into the fallback path.
+      // https://developer.chrome.com/docs/identity/immediate-ui-mode
+      const debugSpy = jest.fn();
+      mockConfigure.mockReturnValue({
+        debug: debugSpy,
+        fido2: {
+          rp: { id: TEST_RP.id, name: TEST_RP.name },
+        },
+      } as any);
+      const getSpy = jest.fn().mockResolvedValue(MOCK_ASSERTION_CREDENTIAL);
+      cleanup = setupWebAuthnMock({
+        customCredentials: {
+          get: getSpy,
+          create: jest.fn(),
+        } as any,
+      });
+      const serverIssuedCredentials = [
+        { id: "AQIDBA", transports: ["internal"] as AuthenticatorTransport[] },
+      ];
+
+      await fido2getCredential({
+        challenge: TEST_CHALLENGES.basic,
+        mediation: "immediate",
+        credentials: serverIssuedCredentials,
+      });
+
+      const request = getSpy.mock.calls[0][0];
+      expect(request.uiMode).toBe("immediate");
+      expect(request.publicKey.allowCredentials).toBeUndefined();
+      expect(debugSpy).toHaveBeenCalledWith(
+        expect.stringContaining("discoverable-credential-only")
+      );
+    });
+
+    it("keeps allowCredentials for non-immediate requests with the same input", async () => {
+      const getSpy = jest.fn().mockResolvedValue(MOCK_ASSERTION_CREDENTIAL);
+      cleanup = setupWebAuthnMock({
+        customCredentials: {
+          get: getSpy,
+          create: jest.fn(),
+        } as any,
+      });
+
+      await fido2getCredential({
+        challenge: TEST_CHALLENGES.basic,
+        credentials: [
+          {
+            id: "AQIDBA",
+            transports: ["internal"] as AuthenticatorTransport[],
+          },
+        ],
+      });
+
+      const request = getSpy.mock.calls[0][0];
+      expect(request.publicKey.allowCredentials).toHaveLength(1);
+    });
+
     it("logs debug message for immediate mediation", async () => {
       const debugSpy = jest.fn();
       mockConfigure.mockReturnValue({

--- a/client/__tests__/mfa-status-ready.test.tsx
+++ b/client/__tests__/mfa-status-ready.test.tsx
@@ -299,6 +299,71 @@ describe("MFA status readiness (derived from token identity)", () => {
     expect(ready()).toBe("false");
   });
 
+  test("a same-user token rotation during refreshTotpMfaStatus cannot strand readiness", async () => {
+    // Readiness is keyed to the access token, so a manual refresh must discard
+    // its answer once the token rotates — committing the superseded token would
+    // derive readiness false with no later fetch to correct it, because the
+    // effect already fetched for the new token.
+    let releaseManualRefresh!: () => void;
+    const manualRefreshGate = new Promise<void>((resolve) => {
+      releaseManualRefresh = resolve;
+    });
+    let getUserCalls = 0;
+    const { fetchMock } = makeFetch({
+      getUser: async () => {
+        getUserCalls += 1;
+        // Call 1 = mount effect (token A); call 2 = the manual refresh (token A,
+        // gated); call 3 = the effect re-running for the rotated token B.
+        if (getUserCalls === 2) await manualRefreshGate;
+        return {
+          ok: true,
+          status: 200,
+          body: {
+            Username: USERNAME,
+            UserAttributes: [],
+            UserMFASettingList: [],
+          },
+        };
+      },
+    });
+    configure({
+      clientId: "testClient",
+      cognitoIdpEndpoint: "us-west-2",
+      storage: createMemoryStorage(),
+      fetch: fetchMock as unknown as MinimalFetch,
+    });
+    await seedSession(true, "a");
+
+    renderProbe();
+    await waitFor(() => expect(ready()).toBe("true"));
+    const firstToken = screen.getByTestId("token").textContent;
+
+    // Manual refresh for token A is now in flight and gated.
+    await act(async () => {
+      screen.getByTestId("refresh-mfa").click();
+    });
+
+    // Same user, new access token: the effect resolves readiness for B.
+    await act(async () => {
+      await seedSession(true, "b");
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId("token").textContent).not.toBe(firstToken)
+    );
+    // The effect re-fetches for the rotated token only after its 5s cooldown;
+    // that fetch must land BEFORE token A's answer, which is what makes a
+    // mis-keyed commit permanent.
+    await waitFor(() => expect(ready()).toBe("true"), { timeout: 10000 });
+
+    // Token A's late answer must not key readiness back to the old token.
+    await act(async () => {
+      releaseManualRefresh();
+      await Promise.resolve();
+    });
+
+    expect(ready()).toBe("true");
+  }, 20000);
+
   test("a getUser response that lands after sign-out cannot mark a signed-out session ready", async () => {
     let releaseGetUser!: () => void;
     const gate = new Promise<void>((r) => {

--- a/client/__tests__/mfa-status-ready.test.tsx
+++ b/client/__tests__/mfa-status-ready.test.tsx
@@ -1,0 +1,351 @@
+/**
+ * Copyright Amazon.com, Inc. and its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You
+ * may not use this file except in compliance with the License. A copy of
+ * the License is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+ * ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+import React from "react";
+import { render, screen, waitFor, act, cleanup } from "@testing-library/react";
+import { configure } from "../config.js";
+import type { MinimalFetch } from "../config.js";
+import { storeTokens } from "../storage.js";
+import {
+  PasswordlessContextProvider,
+  usePasswordless,
+} from "../react/hooks.js";
+
+// Phase 4: MFA readiness is DERIVED from the resolved access-token identity
+// (state.mfaStatusReadyForToken === current access token), not a plain boolean
+// that updateTokens could reset. This removes the permanent post-login spinner:
+// a stale updateTokens closure can no longer un-ready an already-resolved token,
+// and a getUser response for a superseded token cannot ready a newer one.
+
+const enc = (obj: unknown) =>
+  btoa(JSON.stringify(obj))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+const createJWT = (claims: Record<string, unknown>) =>
+  `${enc({ alg: "HS256", typ: "JWT" })}.${enc(claims)}.sig`;
+
+const USERNAME = "testuser";
+function accessToken(opts: { adminScope: boolean; jti?: string }) {
+  const now = Math.floor(Date.now() / 1000);
+  return createJWT({
+    sub: "user123",
+    username: USERNAME,
+    jti: opts.jti ?? "a",
+    scope: opts.adminScope
+      ? "aws.cognito.signin.user.admin openid"
+      : "openid email",
+    exp: now + 3600,
+    iat: now,
+  });
+}
+
+function createMemoryStorage() {
+  const store = new Map<string, string>();
+  return {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => {
+      store.set(k, v);
+    },
+    removeItem: (k: string) => {
+      store.delete(k);
+    },
+  };
+}
+
+// A fetch mock that answers GetUser (and lets the test observe / gate it), and
+// returns a benign 200 for anything else the provider touches on mount.
+function makeFetch(
+  opts: {
+    getUser?: () => Promise<{ ok: boolean; status: number; body: unknown }>;
+  } = {}
+) {
+  const state = { getUserCalls: 0 };
+  const fetchMock = jest.fn(
+    async (_url: unknown, init?: { headers?: Record<string, string> }) => {
+      const target = init?.headers?.["x-amz-target"] ?? "";
+      if (target.endsWith("GetUser")) {
+        state.getUserCalls++;
+        const res = opts.getUser
+          ? await opts.getUser()
+          : {
+              ok: true,
+              status: 200,
+              body: {
+                Username: USERNAME,
+                UserAttributes: [],
+                UserMFASettingList: [],
+              },
+            };
+        return {
+          ok: res.ok,
+          status: res.status,
+          json: async () => res.body,
+        };
+      }
+      return { ok: true, status: 200, json: async () => ({}) };
+    }
+  );
+  return { fetchMock, state };
+}
+
+function Probe() {
+  const {
+    mfaStatusReady,
+    tokens,
+    signOut,
+    totpMfaStatus,
+    refreshTotpMfaStatus,
+  } = usePasswordless();
+  return (
+    <div>
+      <span data-testid="ready">{String(mfaStatusReady)}</span>
+      <span data-testid="token">{tokens?.accessToken ?? "none"}</span>
+      <span data-testid="mfa-enabled">{String(totpMfaStatus.enabled)}</span>
+      <button data-testid="signout" onClick={() => void signOut()}>
+        out
+      </button>
+      <button
+        data-testid="refresh-mfa"
+        onClick={() => void refreshTotpMfaStatus()}
+      >
+        refresh
+      </button>
+    </div>
+  );
+}
+
+const renderProbe = () =>
+  render(
+    <PasswordlessContextProvider>
+      <Probe />
+    </PasswordlessContextProvider>
+  );
+
+const ready = () => screen.getByTestId("ready").textContent;
+
+async function seedSession(adminScope: boolean, jti = "a") {
+  await storeTokens({
+    accessToken: accessToken({ adminScope, jti }),
+    idToken: createJWT({
+      sub: "user123",
+      "cognito:username": USERNAME,
+      exp: Math.floor(Date.now() / 1000) + 3600,
+      iat: Math.floor(Date.now() / 1000),
+    }),
+    refreshToken: `refresh-${jti}`,
+    authMethod: "SRP",
+    expireAt: new Date(Date.now() + 3600_000),
+  });
+}
+
+describe("MFA status readiness (derived from token identity)", () => {
+  afterEach(() => {
+    cleanup();
+    jest.useRealTimers();
+  });
+
+  test("becomes ready once getUser resolves for the signed-in token", async () => {
+    const { fetchMock, state } = makeFetch();
+    configure({
+      clientId: "testClient",
+      cognitoIdpEndpoint: "us-west-2",
+      storage: createMemoryStorage(),
+      fetch: fetchMock as unknown as MinimalFetch,
+    });
+    await seedSession(true);
+
+    renderProbe();
+    await waitFor(() => expect(ready()).toBe("true"));
+    expect(state.getUserCalls).toBe(1);
+  });
+
+  test("a token lacking the admin scope reaches ready WITHOUT calling getUser", async () => {
+    const { fetchMock, state } = makeFetch();
+    configure({
+      clientId: "testClient",
+      cognitoIdpEndpoint: "us-west-2",
+      storage: createMemoryStorage(),
+      fetch: fetchMock as unknown as MinimalFetch,
+    });
+    await seedSession(false);
+
+    renderProbe();
+    await waitFor(() => expect(ready()).toBe("true"));
+    expect(state.getUserCalls).toBe(0);
+  });
+
+  test("a getUser failure still reaches ready (fail-open, never hangs)", async () => {
+    // json() rejecting makes getUser reject OUTSIDE the fetch retry wrapper, so
+    // it fails fast (a 5xx would be retried for seconds) and exercises the
+    // effect's catch → still-ready path.
+    const fetchMock = jest.fn(
+      async (_url: unknown, init?: { headers?: Record<string, string> }) => {
+        if ((init?.headers?.["x-amz-target"] ?? "").endsWith("GetUser")) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => {
+              throw new Error("boom");
+            },
+          };
+        }
+        return { ok: true, status: 200, json: async () => ({}) };
+      }
+    );
+    configure({
+      clientId: "testClient",
+      cognitoIdpEndpoint: "us-west-2",
+      storage: createMemoryStorage(),
+      fetch: fetchMock as unknown as MinimalFetch,
+    });
+    await seedSession(true);
+
+    renderProbe();
+    await waitFor(() => expect(ready()).toBe("true"));
+  });
+
+  test("sign-out clears readiness (derived false once tokens are gone)", async () => {
+    const { fetchMock } = makeFetch();
+    configure({
+      clientId: "testClient",
+      cognitoIdpEndpoint: "us-west-2",
+      storage: createMemoryStorage(),
+      fetch: fetchMock as unknown as MinimalFetch,
+    });
+    await seedSession(true);
+
+    renderProbe();
+    await waitFor(() => expect(ready()).toBe("true"));
+
+    await act(async () => {
+      screen.getByTestId("signout").click();
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId("token").textContent).toBe("none")
+    );
+    expect(ready()).toBe("false");
+  });
+
+  test("a refreshTotpMfaStatus response landing after sign-out cannot overwrite the reset MFA status", async () => {
+    // First GetUser (the mount effect) resolves immediately with MFA disabled;
+    // the second (manual refreshTotpMfaStatus) is gated and answers MFA
+    // ENABLED — but only after the user has signed out. Without the
+    // cross-session guard, that stale answer would overwrite the reset state.
+    let releaseSecond!: () => void;
+    const gate = new Promise<void>((r) => {
+      releaseSecond = r;
+    });
+    let getUserCalls = 0;
+    const { fetchMock } = makeFetch({
+      getUser: async () => {
+        getUserCalls++;
+        if (getUserCalls >= 2) await gate;
+        return {
+          ok: true,
+          status: 200,
+          body: {
+            Username: USERNAME,
+            UserAttributes: [],
+            UserMFASettingList: getUserCalls >= 2 ? ["SOFTWARE_TOKEN_MFA"] : [],
+            ...(getUserCalls >= 2 && {
+              PreferredMfaSetting: "SOFTWARE_TOKEN_MFA",
+            }),
+          },
+        };
+      },
+    });
+    configure({
+      clientId: "testClient",
+      cognitoIdpEndpoint: "us-west-2",
+      storage: createMemoryStorage(),
+      fetch: fetchMock as unknown as MinimalFetch,
+    });
+    await seedSession(true);
+
+    renderProbe();
+    await waitFor(() => expect(ready()).toBe("true"));
+
+    // Kick off the manual refresh (gated), then sign out while it is pending.
+    await act(async () => {
+      screen.getByTestId("refresh-mfa").click();
+    });
+    await act(async () => {
+      screen.getByTestId("signout").click();
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId("token").textContent).toBe("none")
+    );
+
+    // Stale MFA-ENABLED answer lands after the SIGN_OUT reset.
+    await act(async () => {
+      releaseSecond();
+      await Promise.resolve();
+    });
+
+    // The reset state must survive: no session-A bleed into the reset state.
+    expect(screen.getByTestId("mfa-enabled").textContent).toBe("false");
+    expect(ready()).toBe("false");
+  });
+
+  test("a getUser response that lands after sign-out cannot mark a signed-out session ready", async () => {
+    let releaseGetUser!: () => void;
+    const gate = new Promise<void>((r) => {
+      releaseGetUser = r;
+    });
+    const { fetchMock } = makeFetch({
+      getUser: async () => {
+        await gate;
+        return {
+          ok: true,
+          status: 200,
+          body: {
+            Username: USERNAME,
+            UserAttributes: [],
+            UserMFASettingList: ["SOFTWARE_TOKEN_MFA"],
+          },
+        };
+      },
+    });
+    configure({
+      clientId: "testClient",
+      cognitoIdpEndpoint: "us-west-2",
+      storage: createMemoryStorage(),
+      fetch: fetchMock as unknown as MinimalFetch,
+    });
+    await seedSession(true);
+
+    renderProbe();
+    // getUser is in flight and gated → not ready yet.
+    await waitFor(() =>
+      expect(screen.getByTestId("token").textContent).not.toBe("none")
+    );
+    expect(ready()).toBe("false");
+
+    // Sign out while getUser is pending, then let the stale response land.
+    await act(async () => {
+      screen.getByTestId("signout").click();
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId("token").textContent).toBe("none")
+    );
+    await act(async () => {
+      releaseGetUser();
+      await Promise.resolve();
+    });
+
+    // The signed-out session must not be marked ready by session A's response.
+    expect(ready()).toBe("false");
+  });
+});

--- a/client/__tests__/retry.test.ts
+++ b/client/__tests__/retry.test.ts
@@ -37,7 +37,9 @@ describe("createFetchWithRetry", () => {
       return Promise.resolve(okResponse);
     });
 
-    const fetchWithRetry = createFetchWithRetry(fetchFn, undefined, 3, 1);
+    // Short per-attempt timeout (50ms) so the successful attempt's
+    // body-guard relay detaches within the test.
+    const fetchWithRetry = createFetchWithRetry(fetchFn, undefined, 3, 1, 50);
     const res = await fetchWithRetry("https://example.com", {
       signal: controller.signal,
     });
@@ -46,15 +48,99 @@ describe("createFetchWithRetry", () => {
     expect(fetchFn).toHaveBeenCalledTimes(3);
 
     // "abort" listeners are registered on the caller signal both for each
-    // backoff wait and for each attempt's per-attempt-timeout controller. Every
-    // one must be removed again (on timer fire / in the attempt's finally), so a
-    // long-lived signal never accumulates dead listeners across retries.
-    const abortAdds = addSpy.mock.calls.filter(([type]) => type === "abort");
-    const abortRemoves = removeSpy.mock.calls.filter(
-      ([type]) => type === "abort"
+    // backoff wait and for each attempt's per-attempt-timeout controller.
+    // Failed attempts remove theirs before retrying. The SUCCESSFUL attempt
+    // deliberately keeps its relay armed to cover body reads, so right after
+    // the response returns exactly one listener is still live...
+    const abortAdds = () =>
+      addSpy.mock.calls.filter(([type]) => type === "abort").length;
+    const abortRemoves = () =>
+      removeSpy.mock.calls.filter(([type]) => type === "abort").length;
+    expect(abortAdds()).toBeGreaterThanOrEqual(2);
+    expect(abortRemoves()).toBe(abortAdds() - 1);
+
+    // ...and the per-attempt deadline removes it when it fires, so a
+    // long-lived signal never accumulates listeners indefinitely.
+    await new Promise((resolve) => setTimeout(resolve, 80));
+    expect(abortRemoves()).toBe(abortAdds());
+  });
+
+  test("a caller abort during res.json() cancels the body read", async () => {
+    // The response body stream is bound to the attempt's signal. Before this
+    // fix, the success path detached the caller-abort relay when headers
+    // arrived, so aborting during a body read was silently ignored.
+    const controller = new AbortController();
+    const fetchFn = jest
+      .fn()
+      .mockImplementation((_input: unknown, init?: { signal?: AbortSignal }) =>
+        Promise.resolve({
+          ok: true,
+          status: 200,
+          // Body that only settles when the attempt signal aborts — models a
+          // stream mid-transfer.
+          json: () =>
+            new Promise((_resolve, reject) => {
+              init?.signal?.addEventListener("abort", () =>
+                reject(new DOMException("Aborted", "AbortError"))
+              );
+            }),
+        })
+      );
+
+    const fetchWithRetry = createFetchWithRetry(fetchFn, undefined, 3, 1);
+    const res = await fetchWithRetry("https://example.com", {
+      signal: controller.signal,
+    });
+
+    const bodyRead = res.json();
+    const assertion = expect(bodyRead).rejects.toThrow("Aborted");
+    controller.abort();
+    await assertion;
+  });
+
+  test("a body stalled past the per-attempt deadline is aborted instead of hanging forever", async () => {
+    // Headers arrive promptly, then the server black-holes the body. The
+    // per-attempt deadline must keep covering the body read.
+    const fetchFn = jest
+      .fn()
+      .mockImplementation((_input: unknown, init?: { signal?: AbortSignal }) =>
+        Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () =>
+            new Promise((_resolve, reject) => {
+              init?.signal?.addEventListener("abort", () =>
+                reject(new DOMException("Aborted", "AbortError"))
+              );
+            }),
+        })
+      );
+
+    // 100ms per-attempt deadline.
+    const fetchWithRetry = createFetchWithRetry(fetchFn, undefined, 3, 1, 100);
+    const res = await fetchWithRetry("https://example.com", {});
+
+    await expect(res.json()).rejects.toThrow("Aborted");
+  });
+
+  test("a fully-consumed response is unaffected by the deadline firing afterwards", async () => {
+    const consumed: unknown[] = [];
+    const fetchFn = jest.fn().mockImplementation(() =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ fine: true }),
+      })
     );
-    expect(abortAdds.length).toBeGreaterThanOrEqual(2);
-    expect(abortRemoves.length).toBe(abortAdds.length);
+
+    const fetchWithRetry = createFetchWithRetry(fetchFn, undefined, 3, 1, 50);
+    const res = await fetchWithRetry("https://example.com", {});
+    consumed.push(await res.json());
+
+    // Let the deadline fire after consumption — nothing should throw, and the
+    // consumed body is intact (aborting a consumed response is a no-op).
+    await new Promise((resolve) => setTimeout(resolve, 80));
+    expect(consumed).toEqual([{ fine: true }]);
   });
 
   test("abort during backoff wait still rejects with AbortError", async () => {

--- a/client/common.ts
+++ b/client/common.ts
@@ -31,7 +31,7 @@ import {
 import { scheduleRefresh, cleanupUserRefreshState } from "./refresh.js";
 import { computeClockDriftMs, redactSecret } from "./util.js";
 import { handleDeviceConfirmation } from "./device.js";
-import { withLock, LockTimeoutError } from "./lock.js";
+import { withLock, isLockTimeoutError } from "./lock.js";
 import { parseJwtPayload } from "./util.js";
 import { CognitoAccessTokenPayload } from "./jwt-model.js";
 
@@ -499,7 +499,7 @@ export async function processTokens(
       abort
     );
   } catch (error) {
-    if (error instanceof LockTimeoutError) {
+    if (isLockTimeoutError(error)) {
       debug?.(
         "⏱️ [Process Tokens] Lock timeout - another auth operation in progress"
       );

--- a/client/common.ts
+++ b/client/common.ts
@@ -31,7 +31,7 @@ import {
 import { scheduleRefresh, cleanupUserRefreshState } from "./refresh.js";
 import { computeClockDriftMs, redactSecret } from "./util.js";
 import { handleDeviceConfirmation } from "./device.js";
-import { withStorageLock, LockTimeoutError } from "./lock.js";
+import { withLock, LockTimeoutError } from "./lock.js";
 import { parseJwtPayload } from "./util.js";
 import { CognitoAccessTokenPayload } from "./jwt-model.js";
 
@@ -238,10 +238,7 @@ async function processTokensInternal(
     }
   }
 
-  const {
-    clientId: clientIdForGuard,
-    storage: storageForGuard,
-  } = configure();
+  const { clientId: clientIdForGuard, storage: storageForGuard } = configure();
   const tombstoneKey = normalizedTokens.username
     ? signedOutTombstoneKey(clientIdForGuard, normalizedTokens.username)
     : undefined;
@@ -441,7 +438,10 @@ async function processTokensInternal(
       debug?.(
         "🔄 [Process Tokens] Fresh login detected, deferring token refresh scheduling"
       );
-      const deferralTimer = setTimeout(scheduleFn, FRESH_LOGIN_REFRESH_DELAY_MS);
+      const deferralTimer = setTimeout(
+        scheduleFn,
+        FRESH_LOGIN_REFRESH_DELAY_MS
+      );
       const entry = activeRefreshSchedules.get(normalizedTokens.username);
       if (entry?.abortController === scheduleAbort) {
         entry.deferralTimer = deferralTimer;
@@ -492,7 +492,7 @@ export async function processTokens(
   debug?.("🔒 [Process Tokens] Acquiring auth lock for user:", username);
 
   try {
-    return await withStorageLock(
+    return await withLock(
       lockKey,
       async () => processTokensInternal(tokens, abort, opts),
       undefined, // use default timeout
@@ -510,6 +510,12 @@ export async function processTokens(
     throw error;
   }
 }
+
+// Bound the best-effort refresh-token revocation during sign-out so a hung
+// network call can never keep the returned `signedOut` promise pending: the
+// local teardown (and the app's navigation) has already completed by the time
+// revocation runs, so this only caps how long the server-side call may take.
+const SIGN_OUT_REVOKE_DEADLINE_MS = 5000;
 
 /**
  * Sign the user out. This means: clear tokens from storage,
@@ -546,7 +552,6 @@ export const signOut = (props?: {
   const tokenRevocationTracker = new Set<string>();
 
   const amplifyKeyPrefix = `CognitoIdentityServiceProvider.${clientId}`;
-  const customKeyPrefix = `Passwordless.${clientId}`;
 
   // Resolve the session to tear down. Prefer retrieveTokensForRefresh so a
   // session whose access token has already expired (but is still refreshable)
@@ -570,131 +575,118 @@ export const signOut = (props?: {
     return username ? { username } : undefined;
   };
 
-  // Wrap sign-out in per-user storage lock
+  // The local sign-out runs WITHOUT the per-user refresh lock. Holding
+  // `.refreshLock` here is what let a single orphaned lock — a tab killed
+  // mid-refresh, whose lock record lingers until it goes stale — freeze
+  // `/logout` for the ~30s stale-takeover window. The lock was only ever
+  // belt-and-suspenders: the sign-out tombstone is authoritative. An in-flight
+  // refresh re-checks the tombstone immediately before AND after writing
+  // tokens back (processTokens' `sessionMustExistSince` guard) and also
+  // re-validates that the session still exists in storage after its network
+  // round-trip (refreshTokens), so sign-out wins the race whether or not it
+  // holds the lock. Refresh-token revocation is bounded best-effort, after the
+  // local teardown.
   const signedOut = (async () => {
-    // Determine lock key per user
-    const session0 = await resolveSignOutSession();
-    const userIdentifier = session0?.username;
-    const lockKey = userIdentifier
-      ? `${customKeyPrefix}.${userIdentifier}.refreshLock`
-      : undefined;
-    // Run sign-out logic under lock if we have a user
-    const doSignOut = async () => {
-      try {
-        debug?.("signOut: performing sign-out for user", userIdentifier);
+    const session = await resolveSignOutSession();
+    const userIdentifier = session?.username;
+    debug?.("signOut: performing sign-out for user", userIdentifier);
 
-        // Clean up any active refresh schedules for this user
-        if (userIdentifier) {
-          const activeSchedule = activeRefreshSchedules.get(userIdentifier);
-          if (activeSchedule) {
-            debug?.("signOut: cancelling active refresh schedule for user");
-            activeSchedule.abortController.abort();
-            // Also cancel a pending fresh-login deferral so it can't fire
-            // and schedule a refresh for the session we are signing out of
-            if (activeSchedule.deferralTimer) {
-              clearTimeout(activeSchedule.deferralTimer);
-            }
-            activeRefreshSchedules.delete(userIdentifier);
-          }
-
-          // Clean up this user's refresh state (timers, in-memory state).
-          // Deliberately NOT cleanupRefreshSystem: that would tear down the
-          // global visibilitychange/watchdog listeners for the rest of the
-          // page lifetime, breaking refresh for the next user that signs in.
-          cleanupUserRefreshState(userIdentifier);
+    // Cancel this user's in-memory refresh schedule and per-user state so
+    // nothing re-arms a refresh for the session being torn down. In-memory
+    // only — no lock required. cleanupUserRefreshState (NOT
+    // cleanupRefreshSystem) deliberately preserves the global
+    // visibilitychange/watchdog listeners so refresh keeps working for the
+    // next user that signs in.
+    if (userIdentifier) {
+      const activeSchedule = activeRefreshSchedules.get(userIdentifier);
+      if (activeSchedule) {
+        debug?.("signOut: cancelling active refresh schedule for user");
+        activeSchedule.abortController.abort();
+        // Also cancel a pending fresh-login deferral so it can't fire and
+        // schedule a refresh for the session we are signing out of
+        if (activeSchedule.deferralTimer) {
+          clearTimeout(activeSchedule.deferralTimer);
         }
-
-        const session = await resolveSignOutSession();
-        if (abort.signal.aborted) {
-          debug?.("Aborting sign-out");
-          currentStatus && statusCb?.(currentStatus);
-          return;
-        }
-        if (!session) {
-          debug?.("No session in storage to delete");
-          props?.tokensRemovedLocallyCb?.();
-          statusCb?.("SIGNED_OUT");
-          return;
-        }
-        const { username, refreshToken } = session;
-        const revokeRefreshTokenOnce = async () => {
-          if (
-            refreshToken &&
-            !tokenRevocationTracker.has(refreshToken) &&
-            !skipTokenRevocation
-          ) {
-            try {
-              tokenRevocationTracker.add(refreshToken);
-              await revokeToken({
-                abort: undefined,
-                refreshToken: refreshToken,
-              });
-              debug?.("Successfully revoked refresh token");
-            } catch (revokeError) {
-              debug?.(
-                "Error revoking token, but continuing sign-out process:",
-                revokeError
-              );
-            }
-          }
-        };
-
-        // Tombstone FIRST, before revocation and removals: an in-flight
-        // refresh re-checks it immediately before AND after writing tokens
-        // back, so whichever way the race interleaves, the sign-out wins
-        await storage.setItem(
-          signedOutTombstoneKey(clientId, username),
-          Date.now().toString()
-        );
-
-        if (props?.revokeTokensBeforeLocalRemoval) {
-          await revokeRefreshTokenOnce();
-        }
-        await removeSessionKeysFromStorage(username);
-        props?.tokensRemovedLocallyCb?.();
-
-        await revokeRefreshTokenOnce();
-
-        statusCb?.("SIGNED_OUT");
-      } catch (error) {
-        if (abort.signal.aborted) return;
-        debug?.("Error during sign-out:", error);
-        currentStatus && statusCb?.(currentStatus);
-        throw error;
+        activeRefreshSchedules.delete(userIdentifier);
       }
-    };
-    if (lockKey) {
-      debug?.("signOut: waiting for lock", lockKey);
-      try {
-        const result = await withStorageLock(
-          lockKey,
-          async () => {
-            debug?.("signOut: lock acquired", lockKey);
-            return doSignOut();
-          },
-          undefined,
-          abort.signal
-        );
-        debug?.("signOut: lock released", lockKey);
-        return result;
-      } catch (err) {
-        if (!(err instanceof LockTimeoutError)) {
-          throw err;
-        }
-        // Sign-out must eventually win. The holder is most likely a hung or
-        // throttled refresh in another tab (its heartbeat is capped, but we
-        // won't make the user wait that out): proceed without the lock. A
-        // concurrent refresh that loses this race re-validates the session
-        // before acting on its result.
-        debug?.(
-          "signOut: could not acquire lock, signing out without it",
-          lockKey
-        );
-        return doSignOut();
-      }
+      cleanupUserRefreshState(userIdentifier);
     }
-    debug?.("signOut: no lock key, running unlocked");
-    return doSignOut();
+
+    try {
+      if (abort.signal.aborted) {
+        debug?.("Aborting sign-out");
+        currentStatus && statusCb?.(currentStatus);
+        return;
+      }
+      if (!session) {
+        debug?.("No session in storage to delete");
+        props?.tokensRemovedLocallyCb?.();
+        statusCb?.("SIGNED_OUT");
+        return;
+      }
+      const { username, refreshToken } = session;
+      const revokeRefreshTokenOnce = async () => {
+        if (
+          refreshToken &&
+          !tokenRevocationTracker.has(refreshToken) &&
+          !skipTokenRevocation
+        ) {
+          tokenRevocationTracker.add(refreshToken);
+          // Bound the revoke so a hung network call cannot keep `signedOut`
+          // pending forever. RevokeToken invalidates the whole token family,
+          // so revoking this snapshot also kills any token a racing refresh
+          // rotated to.
+          const revokeAbort = new AbortController();
+          const revokeDeadline = setTimeout(
+            () => revokeAbort.abort(),
+            SIGN_OUT_REVOKE_DEADLINE_MS
+          );
+          try {
+            await revokeToken({
+              abort: revokeAbort.signal,
+              refreshToken: refreshToken,
+            });
+            debug?.("Successfully revoked refresh token");
+          } catch (revokeError) {
+            debug?.(
+              "Error revoking token, but continuing sign-out process:",
+              revokeError
+            );
+          } finally {
+            clearTimeout(revokeDeadline);
+          }
+        }
+      };
+
+      // Tombstone FIRST, before revocation and removals: an in-flight refresh
+      // re-checks it immediately before AND after writing tokens back, so
+      // whichever way the race interleaves, the sign-out wins.
+      await storage.setItem(
+        signedOutTombstoneKey(clientId, username),
+        Date.now().toString()
+      );
+
+      // Hosted-UI logout revokes before local removal so the network call
+      // completes while the page is still alive (revokeTokensBeforeLocalRemoval).
+      if (props?.revokeTokensBeforeLocalRemoval) {
+        await revokeRefreshTokenOnce();
+      }
+
+      await removeSessionKeysFromStorage(username);
+      // Fire the local-removal callback and mark signed-out BEFORE the
+      // best-effort revoke: this is the signal the app waits on to navigate
+      // away from a protected route, and it must not be gated on a network
+      // round-trip (or an orphaned lock).
+      props?.tokensRemovedLocallyCb?.();
+      statusCb?.("SIGNED_OUT");
+
+      await revokeRefreshTokenOnce();
+    } catch (error) {
+      if (abort.signal.aborted) return;
+      debug?.("Error during sign-out:", error);
+      currentStatus && statusCb?.(currentStatus);
+      throw error;
+    }
   })();
   return {
     signedOut,

--- a/client/fido2.ts
+++ b/client/fido2.ts
@@ -138,6 +138,13 @@ export async function getClientCapabilities(): Promise<WebAuthnClientCapabilitie
  * Feature detection for WebAuthn mediation capabilities.
  * Simplified helper that checks both conditional and immediate mediation support.
  *
+ * Note on `immediate`: capability means the browser understands immediate UI
+ * mode, not that a given request will succeed. Immediate mode is
+ * discoverable-credential-only (a non-empty allowCredentials is rejected with
+ * NotAllowedError — this library strips it), and Chrome also rejects ALL
+ * immediate-mode requests in incognito/private windows with NotAllowedError,
+ * so plan the fallback path accordingly.
+ *
  * @returns Object with capability flags
  *
  * @example
@@ -1042,6 +1049,7 @@ export async function fido2getCredential({
   // Adjust parameters based on mediation mode
   let effectiveUserVerification = userVerification;
   let effectiveTimeout = timeout;
+  let effectiveCredentials = credentials;
 
   if (mediation === "conditional") {
     // Conditional mediation: default userVerification to "preferred" (per passkeys.dev
@@ -1062,12 +1070,30 @@ export async function fido2getCredential({
           `Overriding timeout ${timeout}ms → undefined (browser default)`
       );
     }
+  } else if (mediation === "immediate") {
+    // Immediate UI mode is DISCOVERABLE-CREDENTIAL-ONLY: Chrome rejects any
+    // uiMode:"immediate" request carrying a non-empty allowCredentials with
+    // NotAllowedError (an anti-tracking measure), regardless of whether the
+    // user has a matching local passkey — indistinguishable from "no
+    // credentials", so users WITH working passkeys would silently fall through
+    // to the fallback. Strip the allow-list (mirroring how the conditional
+    // path strips timeout) so the request targets discoverable credentials
+    // for this rpId instead; the server-issued challenge still binds the
+    // assertion to the signed-in user.
+    // https://developer.chrome.com/docs/identity/immediate-ui-mode
+    if (credentials?.length) {
+      effectiveCredentials = undefined;
+      debug?.(
+        `⚠️ Immediate UI mode is discoverable-credential-only: dropping the ` +
+          `${credentials.length}-entry allowCredentials list (a non-empty list ` +
+          `is rejected with NotAllowedError by the browser)`
+      );
+    }
   }
-  // Immediate mediation uses parameters as-is (no overrides needed)
 
   const publicKey: CredentialRequestOptions["publicKey"] = {
     challenge: bufferFromBase64Url(challenge),
-    allowCredentials: credentials?.map((credential) => ({
+    allowCredentials: effectiveCredentials?.map((credential) => ({
       id: bufferFromBase64Url(credential.id),
       transports: credential.transports,
       type: "public-key" as const,
@@ -1812,6 +1838,14 @@ export function authenticateWithFido2({
    * - Enables intelligent fallback to password forms
    * - No cross-device/QR code prompts
    * - Requires: User gesture (button click)
+   * - DISCOVERABLE-CREDENTIAL-ONLY: the browser rejects an immediate-mode
+   *   request carrying a non-empty allowCredentials list with NotAllowedError
+   *   (anti-tracking), so this library strips the allow-list on this path —
+   *   server-issued credential IDs (username-first flows) are not sent
+   * - Incognito/private windows: Chrome always rejects immediate-mode
+   *   requests with NotAllowedError there, so users with working passkeys
+   *   silently take your fallback path — indistinguishable from "no local
+   *   credentials"
    *
    * Usage patterns:
    * ```typescript

--- a/client/hosted-oauth.ts
+++ b/client/hosted-oauth.ts
@@ -27,7 +27,7 @@ import {
   redactTokensFromObject,
 } from "./util.js";
 import { CognitoAccessTokenPayload } from "./jwt-model.js";
-import { withStorageLock, LockTimeoutError } from "./lock.js";
+import { withLock, LockTimeoutError } from "./lock.js";
 import { processTokens, signOut } from "./common.js";
 import { BusyState, IdleState, TokensFromSignIn } from "./model.js";
 
@@ -91,7 +91,7 @@ export async function signInWithRedirect({
   debug?.("🔒 [OAuth] Acquiring lock for OAuth state storage");
 
   try {
-    await withStorageLock(oauthLockKey, async () => {
+    await withLock(oauthLockKey, async () => {
       await cfg.storage.setItem(STATE_KEY, state);
       await cfg.storage.setItem(PKCE_KEY, verifier);
       await cfg.storage.setItem(OAUTH_IN_PROGRESS_KEY, "true");
@@ -306,7 +306,7 @@ export async function handleCognitoOAuthCallback(): Promise<TokensFromSignIn | n
   const oauthLockKey = `Passwordless.${cfg.clientId}.oauthLock`;
 
   try {
-    await withStorageLock(oauthLockKey, async () => {
+    await withLock(oauthLockKey, async () => {
       const storedState = await cfg.storage.getItem(STATE_KEY);
       debug?.(`Stored state from browser: ${storedState?.substring(0, 10)}...`);
 
@@ -602,7 +602,7 @@ async function exchangeCodeForTokens(code: string): Promise<TokensFromSignIn> {
   let verifier = "";
 
   try {
-    await withStorageLock(oauthLockKey, async () => {
+    await withLock(oauthLockKey, async () => {
       verifier = (await cfg.storage.getItem(PKCE_KEY)) ?? "";
       debug?.(`PKCE verifier retrieved: ${verifier ? "present" : "missing"}`);
     });
@@ -763,7 +763,7 @@ async function clear() {
   debug?.("🔒 [OAuth] Acquiring lock for clearing OAuth state");
 
   try {
-    await withStorageLock(oauthLockKey, async () => clearInternal());
+    await withLock(oauthLockKey, async () => clearInternal());
   } catch (error) {
     if (error instanceof LockTimeoutError) {
       debug?.(

--- a/client/hosted-oauth.ts
+++ b/client/hosted-oauth.ts
@@ -27,7 +27,7 @@ import {
   redactTokensFromObject,
 } from "./util.js";
 import { CognitoAccessTokenPayload } from "./jwt-model.js";
-import { withLock, LockTimeoutError } from "./lock.js";
+import { withLock, isLockTimeoutError } from "./lock.js";
 import { processTokens, signOut } from "./common.js";
 import { BusyState, IdleState, TokensFromSignIn } from "./model.js";
 
@@ -97,7 +97,7 @@ export async function signInWithRedirect({
       await cfg.storage.setItem(OAUTH_IN_PROGRESS_KEY, "true");
     });
   } catch (error) {
-    if (error instanceof LockTimeoutError) {
+    if (isLockTimeoutError(error)) {
       debug?.("⏱️ [OAuth] Lock timeout - another OAuth operation in progress");
       throw new Error(
         "Another OAuth operation is in progress. Please try again."
@@ -323,7 +323,7 @@ export async function handleCognitoOAuthCallback(): Promise<TokensFromSignIn | n
     // timeouts — so code/state/tokens don't linger in the address bar or
     // session history
     cleanupCallbackUrl();
-    if (error instanceof LockTimeoutError) {
+    if (isLockTimeoutError(error)) {
       debug?.("⏱️ [OAuth] Lock timeout during state validation");
       throw new Error("OAuth operation in progress. Please try again.");
     }
@@ -607,7 +607,7 @@ async function exchangeCodeForTokens(code: string): Promise<TokensFromSignIn> {
       debug?.(`PKCE verifier retrieved: ${verifier ? "present" : "missing"}`);
     });
   } catch (error) {
-    if (error instanceof LockTimeoutError) {
+    if (isLockTimeoutError(error)) {
       debug?.("⏱️ [OAuth] Lock timeout during PKCE retrieval");
       throw new Error("OAuth operation in progress. Please try again.");
     }
@@ -765,7 +765,7 @@ async function clear() {
   try {
     await withLock(oauthLockKey, async () => clearInternal());
   } catch (error) {
-    if (error instanceof LockTimeoutError) {
+    if (isLockTimeoutError(error)) {
       debug?.(
         "⏱️ [OAuth] Lock timeout during clear - another OAuth operation is in progress"
       );

--- a/client/index.ts
+++ b/client/index.ts
@@ -47,4 +47,8 @@ export * from "./storage.js";
 export * from "./util.js";
 export * from "./jwt-model.js";
 export * from "./hosted-oauth.js";
-export { activeLockBackend } from "./lock.js";
+export {
+  activeLockBackend,
+  isLockTimeoutError,
+  LockTimeoutError,
+} from "./lock.js";

--- a/client/index.ts
+++ b/client/index.ts
@@ -47,3 +47,4 @@ export * from "./storage.js";
 export * from "./util.js";
 export * from "./jwt-model.js";
 export * from "./hosted-oauth.js";
+export { activeLockBackend } from "./lock.js";

--- a/client/lock.ts
+++ b/client/lock.ts
@@ -435,9 +435,15 @@ async function withWebLock<T>(
   // One controller aborts the pending request on caller-abort OR the
   // acquisition deadline. `timedOut` distinguishes the two so the deadline maps
   // to LockTimeoutError (matching the storage backend's contract) while a
-  // caller abort propagates as AbortError.
+  // caller abort propagates as AbortError. `granted` gates BOTH translations:
+  // the deadline can fire in the microtask gap between the browser granting the
+  // lock and the callback clearing the timer, and once fn() is running any
+  // AbortError it throws is its own (e.g. an aborted fetch inside the critical
+  // section) and must propagate unchanged rather than be reported as a lock
+  // acquisition failure.
   const acquireController = new AbortController();
   let timedOut = false;
+  let granted = false;
   const onCallerAbort = () => acquireController.abort();
   abort?.addEventListener("abort", onCallerAbort, { once: true });
   const acquireTimer = setTimeout(() => {
@@ -456,13 +462,14 @@ async function withWebLock<T>(
         // Acquired — the acquisition deadline no longer applies to the lock we
         // now hold. The callback promise settling releases the lock, so a
         // throw from fn() still releases it.
+        granted = true;
         clearAcquireTimer();
         debug?.("withWebLock: acquired lock", key);
         return fn();
       }
     )) as T;
   } catch (err) {
-    if (err instanceof DOMException && err.name === "AbortError") {
+    if (!granted && err instanceof DOMException && err.name === "AbortError") {
       if (timedOut) {
         debug?.("withWebLock: timeout acquiring lock", key, { timeoutMs });
         throw new LockTimeoutError(key, timeoutMs);

--- a/client/lock.ts
+++ b/client/lock.ts
@@ -444,13 +444,7 @@ async function withWebLock<T>(
     timedOut = true;
     acquireController.abort();
   }, timeoutMs);
-  let timerCleared = false;
-  const clearAcquireTimer = () => {
-    if (!timerCleared) {
-      timerCleared = true;
-      clearTimeout(acquireTimer);
-    }
-  };
+  const clearAcquireTimer = () => clearTimeout(acquireTimer);
 
   try {
     // The DOM lib types LockManager.request as Promise<any>; the callback here
@@ -489,12 +483,9 @@ async function withWebLock<T>(
  * browsers). Both backends honor the caller `abort` and surface a
  * `LockTimeoutError` when acquisition exceeds `timeoutMs`.
  *
- * Mixed-version note: an old tab still on the storage lock and a new tab on Web
- * Locks do NOT coordinate on the same key. The webapp's client-version reload
- * narrows that window (stale tabs reload on their next route navigation), but an
- * idle old tab can linger on the legacy protocol. That skew is safe without the
- * lock: sign-out no longer takes one at all, and a doubly-run refresh is covered
- * by the version-independent lastRefreshAttempt coordination window, the
+ * Mixed-version caveat: a tab on the storage lock and a tab on Web Locks do not
+ * coordinate on the same key. Safe here because sign-out takes no lock, and a
+ * doubly-run refresh is bounded by the lastRefreshAttempt window, the
  * refresh-token-reuse retry, and the sign-out tombstone re-validation.
  */
 export async function withLock<T>(

--- a/client/lock.ts
+++ b/client/lock.ts
@@ -18,10 +18,29 @@ import { configure } from "./config.js";
  * Custom error class for lock acquisition timeouts
  */
 export class LockTimeoutError extends Error {
+  /**
+   * Type-guard marker. Check this (via isLockTimeoutError) instead of
+   * `instanceof`: a bundler can end up with two copies of this module — the
+   * app and a dependency each bundling their own — and an instance of one
+   * copy's class is not `instanceof` the other copy's.
+   */
+  readonly isLockTimeout = true;
   constructor(key: string, timeout: number) {
     super(`Timeout acquiring lock '${key}' after ${timeout}ms`);
     this.name = "LockTimeoutError";
   }
+}
+
+/**
+ * Whether `err` is a lock-acquisition timeout. Use this instead of
+ * `instanceof LockTimeoutError` — it stays correct when a bundler has
+ * duplicated this module and the error crossed the copy boundary.
+ */
+export function isLockTimeoutError(err: unknown): err is LockTimeoutError {
+  return (
+    err instanceof Error &&
+    (err as { isLockTimeout?: unknown }).isLockTimeout === true
+  );
 }
 
 const DEFAULT_RETRY_DELAY_MS = 50;
@@ -432,6 +451,25 @@ async function withWebLock<T>(
     throw new DOMException("Operation aborted", "AbortError");
   }
 
+  if (timeoutMs === 0) {
+    // Try-immediate: take the lock only if it is free right now, never queue.
+    // The Web Locks spec forbids combining `signal` with `ifAvailable`, so
+    // there is no pending wait to interrupt — the caller abort was already
+    // checked above, and once granted an abort has no effect anyway.
+    return (await globalThis.navigator.locks.request(
+      key,
+      { mode: "exclusive", ifAvailable: true },
+      async (lock) => {
+        if (!lock) {
+          debug?.("withWebLock: lock unavailable (try-immediate)", key);
+          throw new LockTimeoutError(key, 0);
+        }
+        debug?.("withWebLock: acquired lock", key);
+        return fn();
+      }
+    )) as T;
+  }
+
   // One controller aborts the pending request on caller-abort OR the
   // acquisition deadline. `timedOut` distinguishes the two so the deadline maps
   // to LockTimeoutError (matching the storage backend's contract) while a
@@ -489,6 +527,12 @@ async function withWebLock<T>(
  * to the storage lock otherwise (Node, SSR, insecure contexts, unsupported
  * browsers). Both backends honor the caller `abort` and surface a
  * `LockTimeoutError` when acquisition exceeds `timeoutMs`.
+ *
+ * `timeoutMs: 0` means try-immediate: take the lock only if it is free right
+ * now, otherwise throw `LockTimeoutError` without queueing (Web Locks:
+ * `ifAvailable`; storage: a single acquisition attempt). Use it for
+ * best-effort background work that should skip, not wait, when another
+ * context is already doing the job.
  *
  * Mixed-version caveat: a tab on the storage lock and a tab on Web Locks do not
  * coordinate on the same key. Safe here because sign-out takes no lock, and a

--- a/client/lock.ts
+++ b/client/lock.ts
@@ -26,12 +26,15 @@ export class LockTimeoutError extends Error {
 
 const DEFAULT_RETRY_DELAY_MS = 50;
 const STALE_LOCK_TIMEOUT_MS = 30000; // 30 seconds without a heartbeat renewal
-// The default acquisition timeout MUST exceed the stale threshold (plus a
-// takeover margin): a lock orphaned by an abruptly closed page keeps its
-// last timestamp forever, and a waiter that gives up before the orphan CAN
-// go stale is guaranteed a LockTimeoutError — worst case the OAuth
-// callback's token exchange right after a redirect, when the one-time
-// authorization code is already spent.
+// Default acquisition timeout for BOTH backends. Storage backend: it MUST
+// exceed the stale threshold (plus a takeover margin) — a lock orphaned by an
+// abruptly closed page keeps its last timestamp forever, and a waiter that
+// gives up before the orphan CAN go stale is guaranteed a LockTimeoutError;
+// worst case the OAuth callback's token exchange right after a redirect, when
+// the one-time authorization code is already spent. Web Locks backend: orphans
+// don't exist (the browser releases locks on tab death), so this only bounds
+// waiting on a LIVE holder — whose longest legitimate critical section (a
+// token refresh with retries on a slow network) fits comfortably within it.
 const DEFAULT_TIMEOUT_MS = STALE_LOCK_TIMEOUT_MS + 15000;
 const LOCK_HEARTBEAT_INTERVAL_MS = 10000; // renew held locks well within the stale timeout
 // Stop renewing the heartbeat after this long. A hung critical section
@@ -374,4 +377,137 @@ export async function withStorageLock<T>(
       debug?.("withStorageLock: error releasing lock", key, error);
     }
   }
+}
+
+/**
+ * Which cross-tab lock backend withLock will use in this context. Exposed so
+ * applications can tag telemetry (e.g. RUM auth events) with the backend in
+ * use — stalls have very different failure modes on the two paths (a storage
+ * lock can be orphaned by a dead tab; a Web Lock cannot).
+ */
+export function activeLockBackend(): "web-locks" | "storage" {
+  return webLocksAvailable() ? "web-locks" : "storage";
+}
+
+/**
+ * Whether the Web Locks API is usable in this context. It requires a secure
+ * context (https or localhost); in insecure contexts, Node, SSR, and older
+ * browsers `navigator.locks` is absent and we fall back to the storage lock.
+ */
+function webLocksAvailable(): boolean {
+  if (
+    typeof globalThis === "undefined" ||
+    typeof globalThis.navigator === "undefined"
+  ) {
+    return false;
+  }
+  const locks = (globalThis.navigator as { locks?: LockManager }).locks;
+  return typeof locks?.request === "function";
+}
+
+/**
+ * Acquire a cross-tab lock via the Web Locks API and run `fn` while holding it.
+ *
+ * The critical advantage over the storage lock: the browser owns the lock and
+ * releases it automatically when the document unloads or the agent is
+ * terminated (a refresh, navigation, tab close, or crash). A tab killed
+ * mid-critical-section therefore cannot orphan the lock and stall other tabs
+ * for the ~30s stale-takeover window — the failure class behind the login and
+ * logout stalls.
+ *
+ * `abort` and the acquisition `timeoutMs` bound ACQUISITION only: a pending
+ * `navigator.locks.request` is cancelled through its `signal`. Once the lock is
+ * held, aborting has no effect (per the Web Locks spec), so a hung critical
+ * section must bound itself (e.g. the per-attempt fetch timeout on the
+ * refresh/revoke calls).
+ */
+async function withWebLock<T>(
+  key: string,
+  fn: () => Promise<T>,
+  timeoutMs: number,
+  abort?: AbortSignal
+): Promise<T> {
+  const { debug } = configure();
+  if (abort?.aborted) {
+    throw new DOMException("Operation aborted", "AbortError");
+  }
+
+  // One controller aborts the pending request on caller-abort OR the
+  // acquisition deadline. `timedOut` distinguishes the two so the deadline maps
+  // to LockTimeoutError (matching the storage backend's contract) while a
+  // caller abort propagates as AbortError.
+  const acquireController = new AbortController();
+  let timedOut = false;
+  const onCallerAbort = () => acquireController.abort();
+  abort?.addEventListener("abort", onCallerAbort, { once: true });
+  const acquireTimer = setTimeout(() => {
+    timedOut = true;
+    acquireController.abort();
+  }, timeoutMs);
+  let timerCleared = false;
+  const clearAcquireTimer = () => {
+    if (!timerCleared) {
+      timerCleared = true;
+      clearTimeout(acquireTimer);
+    }
+  };
+
+  try {
+    // The DOM lib types LockManager.request as Promise<any>; the callback here
+    // returns fn()'s result, so the resolved value is T.
+    return (await globalThis.navigator.locks.request(
+      key,
+      { mode: "exclusive", signal: acquireController.signal },
+      async () => {
+        // Acquired — the acquisition deadline no longer applies to the lock we
+        // now hold. The callback promise settling releases the lock, so a
+        // throw from fn() still releases it.
+        clearAcquireTimer();
+        debug?.("withWebLock: acquired lock", key);
+        return fn();
+      }
+    )) as T;
+  } catch (err) {
+    if (err instanceof DOMException && err.name === "AbortError") {
+      if (timedOut) {
+        debug?.("withWebLock: timeout acquiring lock", key, { timeoutMs });
+        throw new LockTimeoutError(key, timeoutMs);
+      }
+      debug?.("withWebLock: acquisition aborted by caller", key);
+    }
+    throw err;
+  } finally {
+    clearAcquireTimer();
+    abort?.removeEventListener("abort", onCallerAbort);
+  }
+}
+
+/**
+ * Acquire a cross-tab lock and run `fn` while holding it. Uses the Web Locks
+ * API when available (browser-owned, auto-released on tab death) and falls back
+ * to the storage lock otherwise (Node, SSR, insecure contexts, unsupported
+ * browsers). Both backends honor the caller `abort` and surface a
+ * `LockTimeoutError` when acquisition exceeds `timeoutMs`.
+ *
+ * Mixed-version note: an old tab still on the storage lock and a new tab on Web
+ * Locks do NOT coordinate on the same key. The webapp's client-version reload
+ * narrows that window (stale tabs reload on their next route navigation), but an
+ * idle old tab can linger on the legacy protocol. That skew is safe without the
+ * lock: sign-out no longer takes one at all, and a doubly-run refresh is covered
+ * by the version-independent lastRefreshAttempt coordination window, the
+ * refresh-token-reuse retry, and the sign-out tombstone re-validation.
+ */
+export async function withLock<T>(
+  key: string,
+  fn: () => Promise<T>,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+  abort?: AbortSignal
+): Promise<T> {
+  const { debug } = configure();
+  if (webLocksAvailable()) {
+    debug?.("withLock: acquiring via Web Locks backend", key);
+    return withWebLock(key, fn, timeoutMs, abort);
+  }
+  debug?.("withLock: acquiring via storage-lock fallback", key);
+  return withStorageLock(key, fn, timeoutMs, abort);
 }

--- a/client/lock.ts
+++ b/client/lock.ts
@@ -409,6 +409,19 @@ export function activeLockBackend(): "web-locks" | "storage" {
 }
 
 /**
+ * Internal sentinel: navigator.locks exists but request() rejected with
+ * SecurityError BEFORE the lock was granted — an opaque origin (e.g. a
+ * sandboxed iframe without allow-same-origin) does this. The critical section
+ * has NOT run, so withLock can safely retry on the storage backend.
+ */
+class WebLocksUnusableError extends Error {
+  constructor(readonly reason: unknown) {
+    super("Web Locks API is unusable in this context");
+    this.name = "WebLocksUnusableError";
+  }
+}
+
+/**
  * Whether the Web Locks API is usable in this context. It requires a secure
  * context (https or localhost); in insecure contexts, Node, SSR, and older
  * browsers `navigator.locks` is absent and we fall back to the storage lock.
@@ -456,18 +469,31 @@ async function withWebLock<T>(
     // The Web Locks spec forbids combining `signal` with `ifAvailable`, so
     // there is no pending wait to interrupt — the caller abort was already
     // checked above, and once granted an abort has no effect anyway.
-    return (await globalThis.navigator.locks.request(
-      key,
-      { mode: "exclusive", ifAvailable: true },
-      async (lock) => {
-        if (!lock) {
-          debug?.("withWebLock: lock unavailable (try-immediate)", key);
-          throw new LockTimeoutError(key, 0);
+    let granted = false;
+    try {
+      return (await globalThis.navigator.locks.request(
+        key,
+        { mode: "exclusive", ifAvailable: true },
+        async (lock) => {
+          if (!lock) {
+            debug?.("withWebLock: lock unavailable (try-immediate)", key);
+            throw new LockTimeoutError(key, 0);
+          }
+          granted = true;
+          debug?.("withWebLock: acquired lock", key);
+          return fn();
         }
-        debug?.("withWebLock: acquired lock", key);
-        return fn();
+      )) as T;
+    } catch (err) {
+      if (
+        !granted &&
+        err instanceof DOMException &&
+        err.name === "SecurityError"
+      ) {
+        throw new WebLocksUnusableError(err);
       }
-    )) as T;
+      throw err;
+    }
   }
 
   // One controller aborts the pending request on caller-abort OR the
@@ -507,12 +533,18 @@ async function withWebLock<T>(
       }
     )) as T;
   } catch (err) {
-    if (!granted && err instanceof DOMException && err.name === "AbortError") {
-      if (timedOut) {
-        debug?.("withWebLock: timeout acquiring lock", key, { timeoutMs });
-        throw new LockTimeoutError(key, timeoutMs);
+    if (!granted && err instanceof DOMException) {
+      if (err.name === "AbortError") {
+        if (timedOut) {
+          debug?.("withWebLock: timeout acquiring lock", key, { timeoutMs });
+          throw new LockTimeoutError(key, timeoutMs);
+        }
+        debug?.("withWebLock: acquisition aborted by caller", key);
+      } else if (err.name === "SecurityError") {
+        // Opaque origin: request() rejects before any grant. fn() has not
+        // run — signal withLock to retry on the storage backend.
+        throw new WebLocksUnusableError(err);
       }
-      debug?.("withWebLock: acquisition aborted by caller", key);
     }
     throw err;
   } finally {
@@ -548,7 +580,23 @@ export async function withLock<T>(
   const { debug } = configure();
   if (webLocksAvailable()) {
     debug?.("withLock: acquiring via Web Locks backend", key);
-    return withWebLock(key, fn, timeoutMs, abort);
+    try {
+      return await withWebLock(key, fn, timeoutMs, abort);
+    } catch (err) {
+      if (!(err instanceof WebLocksUnusableError)) {
+        throw err;
+      }
+      // navigator.locks exists but rejected with SecurityError before any
+      // grant (opaque origin) — fn() has not run, so retrying on the storage
+      // backend is safe. Note the storage backend may be unusable there too
+      // (localStorage throws in sandboxed iframes) unless the app configured
+      // a custom storage; either way this surfaces a coherent storage error
+      // instead of a baffling SecurityError from a lock API.
+      debug?.(
+        "withLock: Web Locks unusable in this context; falling back to storage lock",
+        key
+      );
+    }
   }
   debug?.("withLock: acquiring via storage-lock fallback", key);
   return withStorageLock(key, fn, timeoutMs, abort);

--- a/client/react/README.md
+++ b/client/react/README.md
@@ -172,6 +172,15 @@ conditional (autofill) or immediate (fast fail) mediation modes. Import
 capability matrix. The library maps `mediation: "immediate"` to the browser's
 standards-compliant `uiMode: "immediate"` request field.
 
+Immediate UI mode is **discoverable-credential-only**: the browser rejects an
+immediate-mode request that carries a non-empty `allowCredentials` list with
+`NotAllowedError` (an anti-tracking measure), so the library strips the
+allow-list on this path — server-issued credential IDs from a username-first
+flow are not sent. Also note that Chrome rejects **all** immediate-mode
+requests in incognito/private windows with the same `NotAllowedError`, so
+users with working passkeys will silently take your fallback path there;
+design the fallback (password form, other factors) accordingly.
+
 ### 3.2 SRP Password
 
 ```mermaid

--- a/client/react/hooks.tsx
+++ b/client/react/hooks.tsx
@@ -678,6 +678,21 @@ function _usePasswordless() {
   const isHandlingIncompleteTokens = useRef(false);
   // Track which accessToken we have already used for GetUser, so we only
   // fetch MFA status once per token rotation (per page load).
+  //
+  // This ref is the single staleness owner for MFA fetches, shared by the mount
+  // effect and the manual refreshTotpMfaStatus(). Its contract:
+  //  - A fetcher CLAIMS the ref (sets it to the token it is about to fetch for)
+  //    before awaiting, and commits its response only while the ref still holds
+  //    that token — so the last claimer wins and earlier responses are dropped.
+  //  - A claimer MUST commit readiness on every outcome, including failure
+  //    (the catch paths dispatch SET_MFA_STATUS_READY_FOR_TOKEN too). Claiming
+  //    suppresses the effect's per-token dedup below, so a claimer that returns
+  //    without committing would leave readiness unresolved with nothing left to
+  //    resolve it — the permanent-spinner class this keying exists to prevent.
+  //  - Setting it to undefined (sign-out, or the retry path forcing a re-fetch
+  //    of the same token) releases the claim and invalidates any in-flight
+  //    response, which is why a retry can discard an otherwise successful
+  //    concurrent answer; the retry's own fetch then re-resolves it.
   const lastFetchedMfaTokenRef = useRef<string | undefined>();
   // Silent retry timer for MFA status fetch
   const mfaRetryTimeoutRef = useRef<

--- a/client/react/hooks.tsx
+++ b/client/react/hooks.tsx
@@ -278,8 +278,15 @@ interface PasswordlessState {
     preferred: boolean;
     availableMfaTypes: string[];
   };
-  /** True once we have a reliable MFA status from Cognito (via getUser) */
-  mfaStatusReady: boolean;
+  /**
+   * The access token that MFA status has been resolved for (getUser succeeded,
+   * failed open, or the token lacks the admin scope). Readiness is DERIVED from
+   * this equalling the current access token — so a stale updateTokens closure
+   * cannot un-ready an already-resolved token (the permanent post-login spinner
+   * bug), and a getUser response for a superseded token cannot ready a newer
+   * one.
+   */
+  mfaStatusReadyForToken?: string;
 }
 
 // Define action types
@@ -305,7 +312,7 @@ type PasswordlessAction =
   | { type: "INCREMENT_RECHECK_STATUS" }
   | { type: "SET_AUTH_METHOD"; payload: PasswordlessState["authMethod"] }
   | { type: "SET_TOTP_MFA_STATUS"; payload: PasswordlessState["totpMfaStatus"] }
-  | { type: "SET_MFA_STATUS_READY"; payload: boolean }
+  | { type: "SET_MFA_STATUS_READY_FOR_TOKEN"; payload: string | undefined }
   | { type: "RESET_REDIRECT_SIGNIN_STATUS" }
   | { type: "SIGN_OUT" };
 
@@ -321,7 +328,6 @@ const initialPasswordlessState: PasswordlessState = {
     preferred: false,
     availableMfaTypes: [],
   },
-  mfaStatusReady: false,
 };
 
 // Reducer function
@@ -406,8 +412,8 @@ function passwordlessReducer(
     case "SET_TOTP_MFA_STATUS":
       return { ...state, totpMfaStatus: action.payload };
 
-    case "SET_MFA_STATUS_READY":
-      return { ...state, mfaStatusReady: action.payload };
+    case "SET_MFA_STATUS_READY_FOR_TOKEN":
+      return { ...state, mfaStatusReadyForToken: action.payload };
 
     case "SIGN_OUT":
       // Reset all per-user state (tokens, deviceKey, TOTP MFA status, etc.)
@@ -450,8 +456,16 @@ function _usePasswordless() {
     recheckSignInStatus,
     authMethod,
     totpMfaStatus,
-    mfaStatusReady,
+    mfaStatusReadyForToken,
   } = state;
+
+  // MFA readiness is DERIVED, not stored: it holds only while the resolved
+  // token still equals the current access token. This makes it immune to a
+  // stale updateTokens closure (which used to reset a plain boolean to false
+  // for an already-resolved token and hang MfaGuard indefinitely) and to a
+  // getUser response for a superseded token.
+  const mfaStatusReady =
+    !!tokens?.accessToken && mfaStatusReadyForToken === tokens.accessToken;
 
   // Helper functions for common dispatch actions
   const setSigninInStatus = useCallback((status: BusyState | IdleState) => {
@@ -1177,7 +1191,10 @@ function _usePasswordless() {
         type: "SET_TOTP_MFA_STATUS",
         payload: { enabled: false, preferred: false, availableMfaTypes: [] },
       });
-      dispatch({ type: "SET_MFA_STATUS_READY", payload: true });
+      dispatch({
+        type: "SET_MFA_STATUS_READY_FOR_TOKEN",
+        payload: tokens.accessToken,
+      });
       return;
     }
 
@@ -1252,7 +1269,10 @@ function _usePasswordless() {
               availableMfaTypes: user.UserMFASettingList || [],
             },
           });
-          dispatch({ type: "SET_MFA_STATUS_READY", payload: true });
+          dispatch({
+            type: "SET_MFA_STATUS_READY_FOR_TOKEN",
+            payload: fetchedForToken,
+          });
           // Successful fetch – cancel any scheduled retry and reset the
           // per-token retry budget
           if (mfaRetryTimeoutRef.current) {
@@ -1270,7 +1290,10 @@ function _usePasswordless() {
               availableMfaTypes: [],
             },
           });
-          dispatch({ type: "SET_MFA_STATUS_READY", payload: true });
+          dispatch({
+            type: "SET_MFA_STATUS_READY_FOR_TOKEN",
+            payload: fetchedForToken,
+          });
           if (mfaRetryTimeoutRef.current) {
             clearTimeout(mfaRetryTimeoutRef.current);
             mfaRetryTimeoutRef.current = undefined;
@@ -1286,7 +1309,10 @@ function _usePasswordless() {
         const { debug } = configure();
         debug?.("getUser failed; retaining previous TOTP MFA status");
         // Ensure UI never hangs behind a loader due to a transient failure
-        dispatch({ type: "SET_MFA_STATUS_READY", payload: true });
+        dispatch({
+          type: "SET_MFA_STATUS_READY_FOR_TOKEN",
+          payload: fetchedForToken,
+        });
         // Schedule a simple early silent retry with jitter (6–8s), but cap
         // the number of retries per token so a persistently failing getUser
         // (e.g. a network outage, or a backend that keeps erroring) does not
@@ -1342,9 +1368,10 @@ function _usePasswordless() {
       if (!current || !next) {
         _setTokens(next);
         parseAndSetTokens(next);
-        if (!current || current.accessToken !== next?.accessToken) {
-          dispatch({ type: "SET_MFA_STATUS_READY", payload: false });
-        }
+        // No MFA-readiness reset here: readiness is derived from the resolved
+        // token identity, so a stale updateTokens closure re-setting the same
+        // token can no longer un-ready an already-resolved session, and a new
+        // token derives to not-ready until its own getUser resolves.
         return;
       }
 
@@ -1358,9 +1385,8 @@ function _usePasswordless() {
       if (hasChanges) {
         _setTokens(next);
         parseAndSetTokens(next);
-        if (current.accessToken !== next.accessToken) {
-          dispatch({ type: "SET_MFA_STATUS_READY", payload: false });
-        }
+        // Readiness is derived from the resolved token identity (see above),
+        // so no explicit reset is needed when the access token changes.
       }
       // If no changes, skip update to prevent re-renders
     },
@@ -2048,19 +2074,31 @@ function _usePasswordless() {
     mfaStatusReady,
     /** Refresh the TOTP MFA status - use this after enabling/disabling MFA */
     refreshTotpMfaStatus: async () => {
-      if (!tokens?.accessToken) return;
+      const accessToken = tokens?.accessToken;
+      const forUsername = tokens?.username;
+      if (!accessToken) return;
+      // Discard results that land after the session changed (sign-out or a
+      // different user signed in while getUser was in flight): session B's
+      // totpMfaStatus must never be overwritten with session A's answer.
+      // currentSignInUserRef is the authoritative marker (set in _setTokens,
+      // the single sink for every token change).
+      const sessionChanged = () => currentSignInUserRef.current !== forUsername;
 
-      if (!accessTokenHasUserAdminScope(tokens.accessToken)) {
+      if (!accessTokenHasUserAdminScope(accessToken)) {
         dispatch({
           type: "SET_TOTP_MFA_STATUS",
           payload: { enabled: false, preferred: false, availableMfaTypes: [] },
         });
-        dispatch({ type: "SET_MFA_STATUS_READY", payload: true });
+        dispatch({
+          type: "SET_MFA_STATUS_READY_FOR_TOKEN",
+          payload: accessToken,
+        });
         return;
       }
 
       try {
-        const user = await getUser({ accessToken: tokens.accessToken });
+        const user = await getUser({ accessToken });
+        if (sessionChanged()) return;
 
         // Simple approach - if we have a valid user with MFA settings, use them
         if (user && typeof user === "object" && !("__type" in user)) {
@@ -2077,7 +2115,10 @@ function _usePasswordless() {
               availableMfaTypes: user.UserMFASettingList || [],
             },
           });
-          dispatch({ type: "SET_MFA_STATUS_READY", payload: true });
+          dispatch({
+            type: "SET_MFA_STATUS_READY_FOR_TOKEN",
+            payload: accessToken,
+          });
         } else {
           // Default to no MFA
           dispatch({
@@ -2088,13 +2129,20 @@ function _usePasswordless() {
               availableMfaTypes: [],
             },
           });
-          dispatch({ type: "SET_MFA_STATUS_READY", payload: true });
+          dispatch({
+            type: "SET_MFA_STATUS_READY_FOR_TOKEN",
+            payload: accessToken,
+          });
         }
       } catch (error) {
+        if (sessionChanged()) return;
         const { debug } = configure();
         debug?.("refreshTotpMfaStatus failed; not marking ready");
         // Make the current (last-known) status consumable by the UI
-        dispatch({ type: "SET_MFA_STATUS_READY", payload: true });
+        dispatch({
+          type: "SET_MFA_STATUS_READY_FOR_TOKEN",
+          payload: accessToken,
+        });
       }
     },
     /**

--- a/client/react/hooks.tsx
+++ b/client/react/hooks.tsx
@@ -2075,14 +2075,13 @@ function _usePasswordless() {
     /** Refresh the TOTP MFA status - use this after enabling/disabling MFA */
     refreshTotpMfaStatus: async () => {
       const accessToken = tokens?.accessToken;
-      const forUsername = tokens?.username;
       if (!accessToken) return;
-      // Discard results that land after the session changed (sign-out or a
-      // different user signed in while getUser was in flight): session B's
-      // totpMfaStatus must never be overwritten with session A's answer.
-      // currentSignInUserRef is the authoritative marker (set in _setTokens,
-      // the single sink for every token change).
-      const sessionChanged = () => currentSignInUserRef.current !== forUsername;
+      // Shares the effect's staleness owner: a response is committed only while
+      // its token is still the one last fetched for. Keying on the username
+      // instead would let a same-user token rotation commit readiness for a
+      // superseded token, which no later fetch would correct.
+      lastFetchedMfaTokenRef.current = accessToken;
+      const isStale = () => lastFetchedMfaTokenRef.current !== accessToken;
 
       if (!accessTokenHasUserAdminScope(accessToken)) {
         dispatch({
@@ -2098,7 +2097,7 @@ function _usePasswordless() {
 
       try {
         const user = await getUser({ accessToken });
-        if (sessionChanged()) return;
+        if (isStale()) return;
 
         // Simple approach - if we have a valid user with MFA settings, use them
         if (user && typeof user === "object" && !("__type" in user)) {
@@ -2135,7 +2134,7 @@ function _usePasswordless() {
           });
         }
       } catch (error) {
-        if (sessionChanged()) return;
+        if (isStale()) return;
         const { debug } = configure();
         debug?.("refreshTotpMfaStatus failed; not marking ready");
         // Make the current (last-known) status consumable by the UI

--- a/client/refresh.ts
+++ b/client/refresh.ts
@@ -80,6 +80,10 @@ let autoCleanupHandler: (() => void) | undefined;
 
 // Max consecutive refresh failures before giving up
 const MAX_CONSECUTIVE_REFRESH_FAILURES = 5;
+// How long a scheduled refresh that found the lock contended (and fell back
+// to the cached token) waits before re-arming — matches the cross-tab
+// coordination window, so the holder has normally finished by then.
+const CONTENTION_REARM_DELAY_MS = 5000;
 
 // Generate unique tab ID for this tab
 const TAB_ID =
@@ -279,9 +283,11 @@ function logDebug(message: string, error?: unknown): void {
  * in-memory work, and holding `.refreshLock` here is what let an orphaned lock
  * from a dead tab stall scheduling. The immediate-refresh branch delegates to
  * refreshTokens(), which takes the lock itself and serializes across tabs. A
- * sign-out cancels an armed timer through the schedule's abort signal, and a
+ * sign-out cancels an armed timer through the schedule's abort signal; a
  * timer that fires for a torn-down session is discarded by refreshTokens'
- * re-validation.
+ * re-validation, and its failure path re-checks storage before arming any
+ * retry (a schedule can race sign-out and arm after teardown — harmless, but
+ * it must not spawn a retry chain for a session that no longer exists).
  */
 export async function scheduleRefresh({
   abort,
@@ -418,22 +424,16 @@ export async function scheduleRefresh({
       try {
         const latestTokens = await retrieveTokensForRefresh();
 
-        // An already-expired access token (e.g. the timer fired on wake from
-        // sleep, long past its due time) has no cached-token fallback: the
-        // refresh must actually happen. Force so it queues for the lock like
-        // the immediate-refresh branch does, instead of the best-effort
-        // try-lock-and-skip a due-at-half-life refresh gets.
-        const alreadyExpired =
-          !!latestTokens?.expireAt &&
-          latestTokens.expireAt.valueOf() <=
-            Date.now() - (latestTokens.clockDriftMs ?? 0);
-
-        await refreshTokens({
+        // No force here even when the token is already expired at fire time
+        // (wake from sleep): refreshTokens' lock policy queues on its own
+        // whenever no valid cached token exists, and staying non-forced keeps
+        // the coordination check, so a race with another waking tab adopts
+        // that tab's refresh instead of rotating twice.
+        const refreshed = await refreshTokens({
           abort,
           tokensCb,
           isRefreshingCb,
           tokens: latestTokens,
-          force: alreadyExpired,
         });
 
         // refreshTokens can succeed WITHOUT this tab having refreshed —
@@ -443,7 +443,27 @@ export async function scheduleRefresh({
         // until the watchdog. Re-arm here: when this tab DID refresh,
         // processTokens already registered the next timer and scheduleRefresh
         // dedups against it, so this is a no-op on that path.
-        void scheduleRefresh({ abort, tokensCb, isRefreshingCb });
+        const gotDifferentTokens =
+          refreshed.accessToken !== latestTokens?.accessToken;
+        if (gotDifferentTokens) {
+          void scheduleRefresh({ abort, tokensCb, isRefreshingCb });
+        } else if (
+          !abort?.aborted &&
+          username &&
+          refreshStateMap.get(username) === state
+        ) {
+          // Cached-token return: another context holds the lock and is
+          // refreshing right now. An immediate re-arm would compute a ~0
+          // delay (we are at the buffer boundary) and fire again after the
+          // recovery's 2s wait — a ~2s poll against the holder. Wait out the
+          // coordination window first; by then the holder has usually
+          // finished and the re-arm schedules off the fresh tokens. Tracked
+          // as retryTimer so sign-out/cleanup can cancel it.
+          state.retryTimer = setTimeoutWallClock(() => {
+            state.retryTimer = undefined;
+            void scheduleRefresh({ abort, tokensCb, isRefreshingCb });
+          }, CONTENTION_REARM_DELAY_MS);
+        }
       } catch (err) {
         logDebug("Error during scheduled refresh:", err);
 
@@ -465,6 +485,24 @@ export async function scheduleRefresh({
         ) {
           logDebug(
             "Session torn down (or no user) during the failed refresh; not scheduling a retry"
+          );
+          return;
+        }
+
+        // A sign-out can also race lock-free scheduling the other way round:
+        // this schedule read tokens just before sign-out cleared storage, and
+        // getRefreshState() recreated the map entry after teardown — so the
+        // identity check above passes. Re-check storage before arming a retry
+        // chain: with the session gone, every retry could only fail fast on
+        // "cannot determine user identity" (the tombstone and re-validation
+        // keep it harmless, but it is pure churn).
+        const sessionStillThere = await retrieveTokensForRefresh();
+        if (
+          !sessionStillThere?.refreshToken ||
+          sessionStillThere.username !== username
+        ) {
+          logDebug(
+            "Session no longer in storage after the failed refresh; not scheduling a retry"
           );
           return;
         }
@@ -904,6 +942,22 @@ export async function refreshTokens({
   };
 
   const { debug } = configure();
+  // Lock-wait policy. Best-effort try-lock (0) is only safe when a
+  // still-valid cached access token exists to fall back on: if the lock is
+  // held, whoever holds it IS refreshing this user's tokens, so the recovery
+  // below can adopt their result or return the cached token. With an expired
+  // (or missing) access token there is NO fallback — the refresh must
+  // actually produce tokens — so queue for the lock (undefined = default
+  // timeout); after acquiring, the coordination check adopts a refresh the
+  // holder just completed instead of repeating it. Forced refreshes (e.g.
+  // after a 401) always queue: they need a genuinely fresh token.
+  let lockWaitMs: number | undefined = undefined;
+  if (!force) {
+    const cached = await retrieveTokens();
+    if (cached?.accessToken && cached.username === userIdentifier) {
+      lockWaitMs = 0;
+    }
+  }
   debug?.("refreshTokens: waiting for lock", lockKey);
   try {
     const result = await withLock(
@@ -912,13 +966,7 @@ export async function refreshTokens({
         debug?.("refreshTokens: lock acquired", lockKey);
         return doRefresh();
       },
-      // A non-forced (background/scheduled) refresh is best-effort: if the
-      // lock is held, whoever holds it IS refreshing this user's tokens, so
-      // skip straight to the recovery below (adopt their result, or return
-      // the still-valid cached token) instead of queueing behind them.
-      // A forced refresh (e.g. after a 401) needs a fresh token and must
-      // wait its turn.
-      force ? undefined : 0,
+      lockWaitMs,
       abort
     );
     debug?.("refreshTokens: lock released", lockKey);

--- a/client/refresh.ts
+++ b/client/refresh.ts
@@ -418,11 +418,22 @@ export async function scheduleRefresh({
       try {
         const latestTokens = await retrieveTokensForRefresh();
 
+        // An already-expired access token (e.g. the timer fired on wake from
+        // sleep, long past its due time) has no cached-token fallback: the
+        // refresh must actually happen. Force so it queues for the lock like
+        // the immediate-refresh branch does, instead of the best-effort
+        // try-lock-and-skip a due-at-half-life refresh gets.
+        const alreadyExpired =
+          !!latestTokens?.expireAt &&
+          latestTokens.expireAt.valueOf() <=
+            Date.now() - (latestTokens.clockDriftMs ?? 0);
+
         await refreshTokens({
           abort,
           tokensCb,
           isRefreshingCb,
           tokens: latestTokens,
+          force: alreadyExpired,
         });
 
         // refreshTokens can succeed WITHOUT this tab having refreshed —

--- a/client/refresh.ts
+++ b/client/refresh.ts
@@ -273,7 +273,6 @@ function logDebug(message: string, error?: unknown): void {
   }
 }
 
-// Extract original implementation into a helper
 /**
  * Arm (or immediately run) this user's token refresh. Timer calculation and
  * registration run WITHOUT the refresh lock: arming a timer is purely local,
@@ -608,16 +607,11 @@ export interface RefreshTokensOptions {
    * Skip the cross-tab `shouldAttemptRefresh()` coordination/dedup check and
    * the in-process `isRefreshing` guard: the caller wants a refresh NOW
    * (e.g. after a 401), regardless of the 5s dedup window. Does NOT bypass
-   * the per-user refresh lock — a forced refresh still serializes with
-   * sign-out and any in-flight scheduled refresh.
+   * the per-user refresh lock, so it still serializes with other refreshes.
    */
   force?: boolean;
 }
 
-/**
- * Refresh tokens using the refresh token. Always goes through the per-user
- * refresh lock, so it serializes with sign-out and any in-flight refresh.
- */
 /**
  * Refresh this user's tokens under the per-user refresh lock, which serializes
  * refreshes across tabs. A sign-out that raced the network round-trip is
@@ -829,13 +823,11 @@ export async function refreshTokens({
         throw error;
       }
 
-      // The refresh round-trip may have raced a sign-out that proceeded
-      // without the refresh lock (signOut falls back to an unlocked
-      // teardown when lock acquisition times out). Re-validate that the
-      // session still exists in storage before writing anything back:
-      // storing now would resurrect the session the user just signed out
-      // of. (A rotated refresh token, if any, dies with this discard —
-      // RevokeToken revokes the whole token family, so it is unusable.)
+      // Sign-out does not take the refresh lock, so it can have landed during
+      // this round-trip. Re-validate the session before writing anything back:
+      // storing now would resurrect the session the user just signed out of.
+      // (A rotated refresh token dies with this discard — RevokeToken revokes
+      // the whole token family, so it is unusable.)
       const sessionStillExists = await retrieveTokensForRefresh();
       if (
         !sessionStillExists?.refreshToken ||
@@ -850,14 +842,10 @@ export async function refreshTokens({
         );
       }
 
-      // The network round-trip is done and the session re-validated, so the
-      // refresh itself is complete. Clear the in-progress flag now — BEFORE
-      // processTokens stores the new tokens and (fire-and-forget) schedules
-      // the next refresh: that scheduling checks state.isRefreshing and must
-      // see the refresh as finished, otherwise short-lived tokens never get
-      // their next timer armed. We still hold the refresh lock here, so no
-      // concurrent refresh can start in the meantime. The finally below
-      // re-clears the flag for the error paths above this point.
+      // Cleared before processTokens, which fire-and-forget schedules the next
+      // refresh and skips scheduling while this flag is set — otherwise
+      // short-lived tokens never get their next timer armed. Mutual exclusion
+      // is held by the refresh lock, not this flag.
       state.isRefreshing = false;
 
       let processedTokens: TokensFromRefresh;

--- a/client/refresh.ts
+++ b/client/refresh.ts
@@ -20,7 +20,7 @@ import { setTimeoutWallClock } from "./util.js";
 import { processTokens } from "./common.js";
 import { parseJwtPayload } from "./util.js";
 import { CognitoAccessTokenPayload } from "./jwt-model.js";
-import { withLock, LockTimeoutError } from "./lock.js";
+import { withLock, isLockTimeoutError } from "./lock.js";
 
 // Simple state tracking
 type RefreshState = {
@@ -424,6 +424,15 @@ export async function scheduleRefresh({
           isRefreshingCb,
           tokens: latestTokens,
         });
+
+        // refreshTokens can succeed WITHOUT this tab having refreshed —
+        // adopting another tab's result, or returning the still-valid cached
+        // token when the lock was contended. Those paths never reach
+        // processTokens, so no next timer is armed and the chain would stall
+        // until the watchdog. Re-arm here: when this tab DID refresh,
+        // processTokens already registered the next timer and scheduleRefresh
+        // dedups against it, so this is a no-op on that path.
+        void scheduleRefresh({ abort, tokensCb, isRefreshingCb });
       } catch (err) {
         logDebug("Error during scheduled refresh:", err);
 
@@ -892,19 +901,25 @@ export async function refreshTokens({
         debug?.("refreshTokens: lock acquired", lockKey);
         return doRefresh();
       },
-      undefined,
+      // A non-forced (background/scheduled) refresh is best-effort: if the
+      // lock is held, whoever holds it IS refreshing this user's tokens, so
+      // skip straight to the recovery below (adopt their result, or return
+      // the still-valid cached token) instead of queueing behind them.
+      // A forced refresh (e.g. after a 401) needs a fresh token and must
+      // wait its turn.
+      force ? undefined : 0,
       abort
     );
     debug?.("refreshTokens: lock released", lockKey);
     return result;
   } catch (err) {
     if (
-      err instanceof LockTimeoutError ||
+      isLockTimeoutError(err) ||
       (err instanceof Error &&
         err.message === "Another tab is handling refresh")
     ) {
       debug?.(
-        err instanceof LockTimeoutError
+        isLockTimeoutError(err)
           ? "refreshTokens: could not acquire lock, another process is refreshing"
           : "refreshTokens: another tab is handling refresh (coordination check)"
       );
@@ -976,6 +991,41 @@ export async function refreshTokens({
           );
         }
       } else {
+        // The holder didn't finish within the wait. For a background refresh,
+        // a still-valid cached token beats an error: retrieveTokens() already
+        // returned undefined if the access token were expired (skew-corrected),
+        // so a non-null result here IS valid. Surfacing an error instead would
+        // let a spurious lock timeout (e.g. a timer that fired while the event
+        // loop was parked through laptop sleep) look like an auth failure.
+        // tokensCb is deliberately NOT called: these are the tokens the caller
+        // already has, not a state change to propagate.
+        if (
+          !force &&
+          currentTokens?.accessToken &&
+          currentTokens.expireAt &&
+          currentTokens.refreshToken &&
+          currentTokens.username
+        ) {
+          debug?.(
+            "refreshTokens: lock unavailable but cached access token is still valid; returning it"
+          );
+          return {
+            accessToken: currentTokens.accessToken,
+            ...(currentTokens.idToken && { idToken: currentTokens.idToken }),
+            expireAt: currentTokens.expireAt,
+            username: currentTokens.username,
+            refreshToken: currentTokens.refreshToken,
+            ...(currentTokens.deviceKey && {
+              deviceKey: currentTokens.deviceKey,
+            }),
+            ...(currentTokens.authMethod && {
+              authMethod: currentTokens.authMethod,
+            }),
+            ...(currentTokens.clockDriftMs !== undefined && {
+              clockDriftMs: currentTokens.clockDriftMs,
+            }),
+          };
+        }
         debug?.(
           "refreshTokens: tokens were NOT refreshed by another tab (access token unchanged)"
         );

--- a/client/refresh.ts
+++ b/client/refresh.ts
@@ -1104,13 +1104,12 @@ if (isBrowserEnvironment()) {
     cleanupRefreshSystem();
   };
 
+  // Deliberately NO "unload" listener: its mere presence makes the page
+  // ineligible for the back/forward cache in desktop Chrome and Firefox, and
+  // pagehide fires in every case unload does (plus when the page enters
+  // bfcache), so it adds nothing. See https://web.dev/articles/bfcache
   globalThis.addEventListener("beforeunload", autoCleanupHandler);
   globalThis.addEventListener("pagehide", autoCleanupHandler);
-
-  // For SPA navigation - cleanup on unload
-  if (typeof globalThis.addEventListener === "function") {
-    globalThis.addEventListener("unload", autoCleanupHandler);
-  }
 
   // Simplified watchdog with cleanup support
   const WATCHDOG_INTERVAL_MS = 5 * 60 * 1000;
@@ -1149,8 +1148,8 @@ if (isBrowserEnvironment()) {
 /**
  * Clean up refresh state for a specific user (timers and in-memory state).
  * Call this on sign-out: it does NOT remove the global visibilitychange,
- * watchdog and unload listeners, so token refresh keeps working when
- * another user signs in afterwards.
+ * watchdog and page-lifecycle listeners, so token refresh keeps working
+ * when another user signs in afterwards.
  * @param username - Optional username to clean up specific user state
  */
 export function cleanupUserRefreshState(username?: string): void {
@@ -1187,9 +1186,9 @@ export function cleanupUserRefreshState(username?: string): void {
 /**
  * Clean up all refresh-related timers and event listeners.
  * Call this when unmounting the application (e.g. on page unload).
- * Note: this removes the GLOBAL visibilitychange, watchdog and unload
- * listeners for the rest of the page lifetime — for user sign-out use
- * cleanupUserRefreshState instead.
+ * Note: this removes the GLOBAL visibilitychange, watchdog and
+ * page-lifecycle listeners for the rest of the page lifetime — for user
+ * sign-out use cleanupUserRefreshState instead.
  * @param username - Optional username to clean up specific user state
  */
 export function cleanupRefreshSystem(username?: string): void {
@@ -1211,7 +1210,6 @@ export function cleanupRefreshSystem(username?: string): void {
   if (autoCleanupHandler && isBrowserEnvironment()) {
     globalThis.removeEventListener("beforeunload", autoCleanupHandler);
     globalThis.removeEventListener("pagehide", autoCleanupHandler);
-    globalThis.removeEventListener("unload", autoCleanupHandler);
     autoCleanupHandler = undefined;
   }
 

--- a/client/refresh.ts
+++ b/client/refresh.ts
@@ -20,7 +20,7 @@ import { setTimeoutWallClock } from "./util.js";
 import { processTokens } from "./common.js";
 import { parseJwtPayload } from "./util.js";
 import { CognitoAccessTokenPayload } from "./jwt-model.js";
-import { withStorageLock, LockTimeoutError } from "./lock.js";
+import { withLock, LockTimeoutError } from "./lock.js";
 
 // Simple state tracking
 type RefreshState = {
@@ -274,7 +274,17 @@ function logDebug(message: string, error?: unknown): void {
 }
 
 // Extract original implementation into a helper
-async function scheduleRefreshUnlocked({
+/**
+ * Arm (or immediately run) this user's token refresh. Timer calculation and
+ * registration run WITHOUT the refresh lock: arming a timer is purely local,
+ * in-memory work, and holding `.refreshLock` here is what let an orphaned lock
+ * from a dead tab stall scheduling. The immediate-refresh branch delegates to
+ * refreshTokens(), which takes the lock itself and serializes across tabs. A
+ * sign-out cancels an armed timer through the schedule's abort signal, and a
+ * timer that fires for a torn-down session is discarded by refreshTokens'
+ * re-validation.
+ */
+export async function scheduleRefresh({
   abort,
   tokensCb,
   isRefreshingCb,
@@ -347,22 +357,16 @@ async function scheduleRefreshUnlocked({
       );
 
       try {
-        await performRefresh({
+        // Route the immediate refresh through refreshTokens so it takes the
+        // per-user lock itself — scheduling no longer holds it. refreshTokens
+        // marks completion, and its processTokens schedules the next refresh.
+        await refreshTokens({
           abort,
           tokensCb,
           isRefreshingCb,
           tokens,
           force: true,
-          // This path runs inside scheduleRefresh's per-user refresh lock
-          // (same lock key), so re-acquiring would self-deadlock
-          skipLock: true,
         });
-
-        // Mark as completed
-        await markRefreshCompleted();
-
-        // processTokens already handles scheduling the next refresh,
-        // so we don't need to do it here
       } catch (err) {
         logDebug("Failed to refresh token:", err);
       }
@@ -470,7 +474,7 @@ async function scheduleRefreshUnlocked({
         // otherwise it fires for a session that may already be torn down.
         state.retryTimer = setTimeoutWallClock(() => {
           state.retryTimer = undefined;
-          void scheduleRefreshUnlocked({ abort, tokensCb, isRefreshingCb });
+          void scheduleRefresh({ abort, tokensCb, isRefreshingCb });
         }, backoffMs);
       }
     }, refreshDelay);
@@ -494,51 +498,6 @@ async function scheduleRefreshUnlocked({
     );
   } catch (err) {
     logDebug("Error scheduling refresh:", err);
-  }
-}
-
-// Simplified wrapper with per-user lock
-export async function scheduleRefresh(
-  args: Parameters<typeof scheduleRefreshUnlocked>[0] = {}
-): Promise<void> {
-  const { clientId, debug } = configure();
-  // Use retrieveTokensForRefresh first: the access token may already be
-  // expired while a refresh token still exists, and the per-user lock must
-  // still be honored then — e.g. signOut holds it during teardown, and the
-  // global watchdog/visibilitychange handlers must not schedule a refresh
-  // for a session that is being torn down
-  const tokens0 = (await retrieveTokensForRefresh()) ?? (await retrieveTokens());
-  const userIdentifier = tokens0?.username;
-  if (!userIdentifier) {
-    debug?.("scheduleRefresh: no user, running unlocked");
-    return scheduleRefreshUnlocked(args);
-  }
-
-  const lockKey = `Passwordless.${clientId}.${userIdentifier}.refreshLock`;
-  debug?.("scheduleRefresh: waiting for lock", lockKey);
-
-  try {
-    const result = await withStorageLock(
-      lockKey,
-      async () => {
-        debug?.("scheduleRefresh: lock acquired", lockKey);
-        return scheduleRefreshUnlocked(args);
-      },
-      undefined,
-      args.abort
-    );
-    debug?.("scheduleRefresh: lock released", lockKey);
-    return result;
-  } catch (err) {
-    if (err instanceof LockTimeoutError) {
-      debug?.(
-        "scheduleRefresh: could not acquire lock, another tab is handling refresh"
-      );
-      // This is fine - another tab is already refreshing
-      return;
-    }
-    // Re-throw other errors
-    throw err;
   }
 }
 
@@ -659,31 +618,20 @@ export interface RefreshTokensOptions {
  * Refresh tokens using the refresh token. Always goes through the per-user
  * refresh lock, so it serializes with sign-out and any in-flight refresh.
  */
-export async function refreshTokens(
-  args: RefreshTokensOptions = {}
-): Promise<TokensFromRefresh> {
-  // skipLock is INTERNAL and deliberately not part of the public options:
-  // exposing it would let a consumer bypass the per-user lock and recreate
-  // the sign-out/refresh resurrection race this path guards against.
-  return performRefresh(args);
-}
-
 /**
- * Internal refresh implementation. `skipLock` is private to this module: the
- * in-lock immediate-refresh path already holds the per-user refresh lock on
- * the same key, so re-acquiring would self-deadlock (storage locks are not
- * reentrant). No other caller may bypass the lock.
+ * Refresh this user's tokens under the per-user refresh lock, which serializes
+ * refreshes across tabs. A sign-out that raced the network round-trip is
+ * detected afterwards (session re-validation here plus the sign-out tombstone
+ * re-checked in processTokens) and the refreshed tokens are discarded rather
+ * than resurrecting the signed-out session.
  */
-async function performRefresh({
+export async function refreshTokens({
   abort,
   tokensCb,
   isRefreshingCb,
   tokens,
   force = false,
-  skipLock = false,
-}: RefreshTokensOptions & {
-  skipLock?: boolean;
-} = {}): Promise<TokensFromRefresh> {
+}: RefreshTokensOptions = {}): Promise<TokensFromRefresh> {
   const { clientId } = configure();
   let userIdentifier: string | undefined = tokens?.username;
   if (!userIdentifier) {
@@ -902,6 +850,16 @@ async function performRefresh({
         );
       }
 
+      // The network round-trip is done and the session re-validated, so the
+      // refresh itself is complete. Clear the in-progress flag now — BEFORE
+      // processTokens stores the new tokens and (fire-and-forget) schedules
+      // the next refresh: that scheduling checks state.isRefreshing and must
+      // see the refresh as finished, otherwise short-lived tokens never get
+      // their next timer armed. We still hold the refresh lock here, so no
+      // concurrent refresh can start in the meantime. The finally below
+      // re-clears the flag for the error paths above this point.
+      state.isRefreshing = false;
+
       let processedTokens: TokensFromRefresh;
       try {
         processedTokens = (await processTokens(tokensFromRefresh, abort, {
@@ -938,16 +896,9 @@ async function performRefresh({
   };
 
   const { debug } = configure();
-  if (skipLock) {
-    debug?.(
-      "refreshTokens: skipLock=true, caller already holds the lock",
-      lockKey
-    );
-    return doRefresh();
-  }
   debug?.("refreshTokens: waiting for lock", lockKey);
   try {
-    const result = await withStorageLock(
+    const result = await withLock(
       lockKey,
       async () => {
         debug?.("refreshTokens: lock acquired", lockKey);
@@ -1074,11 +1025,10 @@ export async function forceRefreshTokens(
     state.retryTimer = undefined;
   }
 
-  // force: true skips the dedup/coordination check, but the refresh still
-  // goes through the per-user lock (no skipLock) so it serializes with
-  // sign-out and any in-flight scheduled refresh — a forced refresh that
-  // wrote tokens back without the lock could resurrect a session a
-  // concurrent sign-out just removed
+  // force: true skips the dedup/coordination check, but refreshTokens still
+  // takes the per-user lock and re-validates against sign-out afterwards, so a
+  // forced refresh racing a concurrent sign-out cannot resurrect the session it
+  // just removed.
   const refreshed = await refreshTokens({
     ...(args ?? {}),
     force: true,
@@ -1087,9 +1037,7 @@ export async function forceRefreshTokens(
   // scheduleRefresh's tokensCb is nullable (scheduling can yield null tokens)
   // while the forced-refresh tokensCb is not; the spread is behaviourally the
   // same as before, the cast just bridges that variance difference
-  void scheduleRefresh(
-    { ...args } as Parameters<typeof scheduleRefresh>[0]
-  );
+  void scheduleRefresh({ ...args } as Parameters<typeof scheduleRefresh>[0]);
 
   return refreshed;
 }

--- a/client/retry.ts
+++ b/client/retry.ts
@@ -42,6 +42,12 @@ export class FetchAttemptTimeoutError extends Error {
  * `FetchAttemptTimeoutError`) rather than hanging forever. A caller-provided
  * `signal` abort is always propagated and never retried.
  *
+ * The deadline and the caller's abort both cover the response BODY too, not
+ * just the wait for headers: a returned response's body stream stays bound to
+ * the attempt's signal, so a caller abort cancels an in-flight `res.json()`,
+ * and a server that returns headers then stalls the body is aborted at the
+ * per-attempt deadline (surfacing to the body reader as an AbortError).
+ *
  * Uses `Response.clone()` to inspect 400 error bodies without consuming the
  * original response body.
  */
@@ -94,17 +100,43 @@ export function createFetchWithRetry(
 
       // Bound this attempt: abort it if the caller aborts OR the per-attempt
       // timeout fires. A timeout is retryable; a caller abort propagates.
+      //
+      // The deadline and the caller-abort relay deliberately survive a
+      // successful return: the response BODY stream is bound to
+      // attemptController.signal, so keeping them armed is what lets a caller
+      // abort cancel an in-flight res.json() and what bounds a server that
+      // returns headers and then stalls the body (aborting a fully-consumed
+      // response is a spec-level no-op, so this costs the happy path
+      // nothing). Cleanup is mutual and therefore self-limiting: the deadline
+      // firing removes the relay, the relay firing clears the deadline — a
+      // long-lived caller signal holds each request's listener for at most
+      // perAttemptTimeoutMs, never indefinitely. Note a body stalled past the
+      // deadline surfaces to the body reader as an AbortError (that is what
+      // an aborted stream throws), not FetchAttemptTimeoutError.
       const attemptController = new AbortController();
       let timedOut = false;
-      const onCallerAbort = () => attemptController.abort();
       const callerSignal = init?.signal;
+      // onCallerAbort captures timeoutId before its initialization below;
+      // safe because abort events only fire synchronously inside an abort()
+      // call, which cannot interleave with this block.
+      const onCallerAbort = () => {
+        clearTimeout(timeoutId);
+        attemptController.abort();
+      };
       if (callerSignal) {
         callerSignal.addEventListener("abort", onCallerAbort, { once: true });
       }
       const timeoutId = setTimeout(() => {
         timedOut = true;
+        callerSignal?.removeEventListener("abort", onCallerAbort);
         attemptController.abort();
       }, perAttemptTimeoutMs);
+      // For FAILED attempts only — a successful return leaves the guard armed
+      // to cover the caller's body reads (see above).
+      const disarmAttemptGuard = () => {
+        clearTimeout(timeoutId);
+        callerSignal?.removeEventListener("abort", onCallerAbort);
+      };
 
       try {
         const res = await fetchFn(input, {
@@ -157,6 +189,7 @@ export function createFetchWithRetry(
         }
         return res;
       } catch (error: unknown) {
+        disarmAttemptGuard();
         // A caller-initiated abort always propagates and is never retried.
         if (callerSignal?.aborted) {
           throw error;
@@ -185,9 +218,6 @@ export function createFetchWithRetry(
         const backoff = baseDelayMs * Math.pow(2, attempt - 1);
         debugFn?.(`Retrying in ${backoff}ms...`);
         await wait(backoff);
-      } finally {
-        clearTimeout(timeoutId);
-        callerSignal?.removeEventListener("abort", onCallerAbort);
       }
     }
     // Fallback

--- a/test/fetch-attempt-timeout.test.ts
+++ b/test/fetch-attempt-timeout.test.ts
@@ -107,11 +107,19 @@ describe("createFetchWithRetry per-attempt timeout", () => {
     expect(fetchFn).toHaveBeenCalledTimes(2);
   });
 
-  test("clears the attempt timer on success (no dangling timers)", async () => {
+  test("keeps the attempt timer armed across a successful return (it now bounds body reads), then self-clears", async () => {
     const fetchFn = jest.fn(async () => okResponse);
     const fetchWithRetry = createFetchWithRetry(fetchFn, undefined, 3, 10, 100);
 
     await fetchWithRetry("https://cognito.example/");
+    // The deadline deliberately survives the return: the response body stream
+    // is bound to the attempt's signal, so this timer is what bounds a server
+    // that sends headers and then stalls the body. Aborting a consumed
+    // response is a no-op, so the happy path is unaffected.
+    expect(jest.getTimerCount()).toBe(1);
+
+    // And it self-clears when it fires — nothing dangles indefinitely.
+    await jest.advanceTimersByTimeAsync(100);
     expect(jest.getTimerCount()).toBe(0);
   });
 });

--- a/test/refresh-auto-cleanup-verify.test.ts
+++ b/test/refresh-auto-cleanup-verify.test.ts
@@ -1,41 +1,81 @@
-describe("Verify Auto-Cleanup Setup", () => {
-  test("should have auto-cleanup listeners already registered", () => {
-    // The refresh module sets up listeners at initialization
-    // Let's verify they exist by checking the global object
+/* eslint-disable @typescript-eslint/no-var-requires --
+   jest.isolateModules only isolates modules loaded with require(); a static
+   import would resolve from the shared registry and defeat the whole point. */
+// Module-LOAD behavior of client/refresh.ts's page-lifecycle listeners.
+//
+// The listeners are registered at import time, which the other auto-cleanup
+// suite cannot observe (its spies install after the shared module instance
+// already loaded — it used to pre-seed a map and assert `has()`, which was
+// vacuous). jest.isolateModules gives a fresh module registry, so requiring
+// refresh.ts INSIDE it re-runs the top-level registration against our spies.
 
-    // We can't easily test this because the listeners are added
-    // at module load time and we can't intercept them
+describe("Refresh system page-lifecycle listeners (module load)", () => {
+  test("registers beforeunload + pagehide, and deliberately NO unload listener", () => {
+    const added: string[] = [];
+    const addSpy = jest
+      .spyOn(globalThis, "addEventListener")
+      .mockImplementation(((event: string) => {
+        added.push(event);
+      }) as typeof globalThis.addEventListener);
+    // Swallow the doc-level visibilitychange registration too, so the fresh
+    // module instance leaks no live listeners into this jsdom.
+    const docAddSpy = jest
+      .spyOn(document, "addEventListener")
+      .mockImplementation(() => {});
 
-    // Instead, let's trigger an event and see if cleanup happens
-    const beforeUnloadEvent = new Event("beforeunload");
-
-    // Create a spy on console methods to catch debug logs
-    const consoleSpy = jest.spyOn(console, "log").mockImplementation();
-
+    let freshRefresh: typeof import("../client/refresh.js") | undefined;
     try {
-      // Dispatch the event
-      globalThis.dispatchEvent(beforeUnloadEvent);
+      jest.isolateModules(() => {
+        // The fresh registry has a fresh (unconfigured) config module too;
+        // configure it so the teardown's debug logging can run.
+        const { configure } =
+          require("../client/config.js") as typeof import("../client/config.js");
+        configure({ clientId: "testClient", cognitoIdpEndpoint: "us-west-2" });
+        freshRefresh =
+          require("../client/refresh.js") as typeof import("../client/refresh.js");
+      });
 
-      // In a real scenario, this would trigger cleanup
-      // But in tests, we might not see it due to configuration
-
-      // The important thing is that the code is there
-      expect(true).toBe(true);
+      expect(added).toContain("beforeunload");
+      expect(added).toContain("pagehide");
+      // An "unload" listener makes the page ineligible for the back/forward
+      // cache in desktop Chrome and Firefox, and pagehide fires in every case
+      // unload does — so registering one is pure downside.
+      // https://web.dev/articles/bfcache
+      expect(added).not.toContain("unload");
     } finally {
-      consoleSpy.mockRestore();
+      addSpy.mockRestore();
+      docAddSpy.mockRestore();
+      // Tear down the fresh instance's watchdog timer.
+      freshRefresh?.cleanupRefreshSystem();
     }
   });
 
-  test("VERIFICATION: The auto-cleanup code exists in refresh.ts", () => {
-    // This test verifies that we added the auto-cleanup code
-    // The actual functionality is hard to test because it runs at module load
+  test("a pagehide event triggers the auto-cleanup handler", () => {
+    const logs: string[] = [];
+    let freshRefresh: typeof import("../client/refresh.js") | undefined;
+    // Isolate BOTH refresh.ts and its config module, so we can point the
+    // fresh instance's debug at our log capture.
+    jest.isolateModules(() => {
+      const { configure } =
+        require("../client/config.js") as typeof import("../client/config.js");
+      configure({
+        clientId: "testClient",
+        cognitoIdpEndpoint: "us-west-2",
+        debug: (...args: unknown[]) => {
+          logs.push(args.map(String).join(" "));
+        },
+      });
+      freshRefresh =
+        require("../client/refresh.js") as typeof import("../client/refresh.js");
+    });
 
-    // The key additions:
-    // 1. autoCleanupHandler variable
-    // 2. addEventListener for beforeunload, pagehide, unload
-    // 3. removeEventListener in cleanupRefreshSystem
-
-    // This is more of a documentation test
-    expect(true).toBe(true);
+    try {
+      globalThis.dispatchEvent(new Event("pagehide"));
+      expect(
+        logs.some((l) => l.includes("Auto-cleanup triggered on page unload"))
+      ).toBe(true);
+    } finally {
+      freshRefresh?.cleanupRefreshSystem();
+    }
   });
 });

--- a/test/refresh-auto-cleanup.test.ts
+++ b/test/refresh-auto-cleanup.test.ts
@@ -27,10 +27,11 @@ describe("Auto-Cleanup Functionality", () => {
   // so we need to track listeners that were already added
   const getPreExistingListeners = () => {
     const listeners = new Map<string, Set<EventListener>>();
-    // These are the events that refresh.ts registers on module load
+    // These are the events that refresh.ts registers on module load.
+    // Deliberately NOT "unload": its mere presence disqualifies the page
+    // from the back/forward cache (see refresh-auto-cleanup-verify.test.ts).
     listeners.set("beforeunload", new Set());
     listeners.set("pagehide", new Set());
-    listeners.set("unload", new Set());
     listeners.set("doc:visibilitychange", new Set());
     return listeners;
   };
@@ -107,8 +108,12 @@ describe("Auto-Cleanup Functionality", () => {
     // we just verify that the expected event types are present
     expect(eventListeners.has("beforeunload")).toBe(true);
     expect(eventListeners.has("pagehide")).toBe(true);
-    expect(eventListeners.has("unload")).toBe(true);
     expect(eventListeners.has("doc:visibilitychange")).toBe(true);
+    // Nothing may register an "unload" listener — it makes the page
+    // ineligible for the back/forward cache, and pagehide covers every case
+    // unload does. (Module-load registration itself is asserted for real in
+    // refresh-auto-cleanup-verify.test.ts.)
+    expect(eventListeners.has("unload")).toBe(false);
   });
 
   test("should trigger cleanup on beforeunload event", () => {

--- a/test/refresh-comprehensive.test.ts
+++ b/test/refresh-comprehensive.test.ts
@@ -4,6 +4,7 @@ import {
   refreshTokens,
   forceRefreshTokens,
   cleanupRefreshSystem,
+  cleanupUserRefreshState,
 } from "../client/refresh.js";
 import { storeTokens } from "../client/storage.js";
 import type { MinimalResponse } from "../client/config.js";
@@ -307,16 +308,16 @@ describe("Refresh System Comprehensive Tests", () => {
       // it would check if refresh is needed based on the time elapsed
 
       // Instead of testing the event directly, we can verify the behavior
-      // by checking that scheduleRefresh works correctly
+      // by checking that scheduleRefresh works correctly. Clear any timer a
+      // prior test left for this user first: refresh state is module-global
+      // and the suite's cleanupRefreshSystem() only resets the "default" user,
+      // so a stale future timer would otherwise make scheduling skip here.
+      cleanupUserRefreshState("testuser");
       await scheduleRefresh();
 
-      // Verify that refresh was scheduled
+      // Verify that a refresh was actually scheduled.
       expect(
-        debugLogs.some(
-          (log) =>
-            log.includes("Scheduling token refresh") ||
-            log.includes("scheduleRefresh")
-        )
+        debugLogs.some((log) => log.includes("Scheduling token refresh"))
       ).toBe(true);
     });
   });

--- a/test/refresh-lock-contention.test.ts
+++ b/test/refresh-lock-contention.test.ts
@@ -37,28 +37,28 @@ function createMemoryStorage() {
 const USERNAME = "testuser";
 const LOCK_KEY = `Passwordless.testClient.${USERNAME}.refreshLock`;
 
-const accessToken = (jti: string) =>
+const accessToken = (jti: string, expOffsetSec = 3600) =>
   createJWT({
     sub: "user123",
     username: USERNAME,
     jti,
-    exp: Math.floor(Date.now() / 1000) + 3600,
-    iat: Math.floor(Date.now() / 1000),
+    exp: Math.floor(Date.now() / 1000) + expOffsetSec,
+    iat: Math.floor(Date.now() / 1000) + Math.min(0, expOffsetSec) - 3600,
   });
 
-async function seedSession(jti = "cached") {
-  const token = accessToken(jti);
+async function seedSession(jti = "cached", expOffsetSec = 3600) {
+  const token = accessToken(jti, expOffsetSec);
   await storeTokens({
     accessToken: token,
     idToken: createJWT({
       sub: "user123",
       "cognito:username": USERNAME,
-      exp: Math.floor(Date.now() / 1000) + 3600,
+      exp: Math.floor(Date.now() / 1000) + expOffsetSec,
       iat: Math.floor(Date.now() / 1000),
     }),
     refreshToken: `refresh-${jti}`,
     authMethod: "SRP",
-    expireAt: new Date(Date.now() + 3600_000),
+    expireAt: new Date(Date.now() + expOffsetSec * 1000),
   });
   return token;
 }
@@ -140,6 +140,48 @@ describe("refreshTokens under lock contention", () => {
       clearInterval(renewer);
     }
   }, 15000);
+
+  test("a non-forced refresh with an EXPIRED access token queues for the lock instead of erroring after the 2s recovery", async () => {
+    // The blocker case: an expired token has no cached-return fallback, so
+    // best-effort try-lock would error into the caller (the React
+    // incomplete-tokens effect treats that as terminal and signs the user
+    // out). With no valid cached token, refreshTokens must queue for the
+    // lock like it always used to, then perform the refresh.
+    const storage = createMemoryStorage();
+    const fetchMock = jest.fn(
+      async (_url: unknown, init?: { headers?: Record<string, string> }) => {
+        if (isRefreshApiCall(init)) return refreshResponse();
+        return { ok: true, status: 200, json: async () => ({}) };
+      }
+    );
+    configure({
+      clientId: "testClient",
+      cognitoIdpEndpoint: "us-west-2",
+      storage,
+      useGetTokensFromRefreshToken: true,
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    // Access token expired an hour ago; refresh token still usable.
+    await seedSession("expired", -3600);
+
+    // Another tab holds the lock past the 2s recovery window, then releases.
+    storage.setItem(
+      LOCK_KEY,
+      JSON.stringify({ id: "other-tab", timestamp: Date.now() })
+    );
+    setTimeout(() => storage.removeItem(LOCK_KEY), 3000);
+
+    const result = await refreshTokens();
+
+    // Queued past the release, then performed a REAL refresh.
+    expect(result.accessToken).toBeTruthy();
+    expect(result.accessToken).not.toContain('"jti":"expired"');
+    expect(
+      fetchMock.mock.calls.some(([, init]) =>
+        isRefreshApiCall(init as { headers?: Record<string, string> })
+      )
+    ).toBe(true);
+  }, 20000);
 
   test("a forced refresh queues for the lock and performs a real refresh once the holder releases", async () => {
     const storage = createMemoryStorage();

--- a/test/refresh-lock-contention.test.ts
+++ b/test/refresh-lock-contention.test.ts
@@ -1,0 +1,178 @@
+import { configure } from "../client/config.js";
+import { refreshTokens, cleanupUserRefreshState } from "../client/refresh.js";
+import { storeTokens } from "../client/storage.js";
+
+// Lock-contention behavior of refreshTokens:
+//  - A NON-FORCED (background/scheduled) refresh is best-effort: it try-locks
+//    (timeout 0) instead of queueing, and when the holder doesn't finish in the
+//    2s recovery wait it returns the still-valid cached token rather than
+//    surfacing an error. A spurious lock timeout (e.g. timers firing before the
+//    event loop resumes after laptop sleep) must never look like an auth
+//    failure while the session is healthy.
+//  - A FORCED refresh (post-401) needs a genuinely fresh token, so it still
+//    queues on the lock and performs the network refresh once it acquires.
+
+const createJWT = (claims: Record<string, unknown>) => {
+  const enc = (obj: unknown) =>
+    btoa(JSON.stringify(obj))
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+  return `${enc({ alg: "HS256", typ: "JWT" })}.${enc(claims)}.signature`;
+};
+
+function createMemoryStorage() {
+  const store = new Map<string, string>();
+  return {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      store.set(key, value);
+    },
+    removeItem: (key: string) => {
+      store.delete(key);
+    },
+  };
+}
+
+const USERNAME = "testuser";
+const LOCK_KEY = `Passwordless.testClient.${USERNAME}.refreshLock`;
+
+const accessToken = (jti: string) =>
+  createJWT({
+    sub: "user123",
+    username: USERNAME,
+    jti,
+    exp: Math.floor(Date.now() / 1000) + 3600,
+    iat: Math.floor(Date.now() / 1000),
+  });
+
+async function seedSession(jti = "cached") {
+  const token = accessToken(jti);
+  await storeTokens({
+    accessToken: token,
+    idToken: createJWT({
+      sub: "user123",
+      "cognito:username": USERNAME,
+      exp: Math.floor(Date.now() / 1000) + 3600,
+      iat: Math.floor(Date.now() / 1000),
+    }),
+    refreshToken: `refresh-${jti}`,
+    authMethod: "SRP",
+    expireAt: new Date(Date.now() + 3600_000),
+  });
+  return token;
+}
+
+const isRefreshApiCall = (init?: { headers?: Record<string, string> }) =>
+  init?.headers?.["x-amz-target"]?.endsWith("GetTokensFromRefreshToken") ??
+  false;
+
+const refreshResponse = () => ({
+  ok: true,
+  status: 200,
+  json: async () => ({
+    AuthenticationResult: {
+      AccessToken: accessToken("rotated"),
+      IdToken: accessToken("rotated-id"),
+      ExpiresIn: 3600,
+      TokenType: "Bearer",
+      RefreshToken: "refresh-rotated",
+    },
+  }),
+});
+
+describe("refreshTokens under lock contention", () => {
+  afterEach(() => {
+    cleanupUserRefreshState(USERNAME);
+    jest.useRealTimers();
+  });
+
+  test("a non-forced refresh returns the still-valid cached token instead of erroring when the lock is held", async () => {
+    const storage = createMemoryStorage();
+    const fetchMock = jest.fn(
+      async (_url: unknown, init?: { headers?: Record<string, string> }) => {
+        if (isRefreshApiCall(init)) return refreshResponse();
+        return { ok: true, status: 200, json: async () => ({}) };
+      }
+    );
+    configure({
+      clientId: "testClient",
+      cognitoIdpEndpoint: "us-west-2",
+      storage,
+      useGetTokensFromRefreshToken: true,
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    const cachedToken = await seedSession();
+
+    // Another tab holds the refresh lock and keeps it fresh via heartbeat
+    // renewal for the whole test — the holder never finishes.
+    storage.setItem(
+      LOCK_KEY,
+      JSON.stringify({ id: "other-tab", timestamp: Date.now() })
+    );
+    const renewer = setInterval(() => {
+      storage.setItem(
+        LOCK_KEY,
+        JSON.stringify({ id: "other-tab", timestamp: Date.now() })
+      );
+    }, 1000);
+
+    try {
+      const start = Date.now();
+      const result = await refreshTokens();
+      const durationMs = Date.now() - start;
+
+      // Got the cached (still-valid) session back, not an error…
+      expect(result.accessToken).toBe(cachedToken);
+      expect(result.username).toBe(USERNAME);
+      // …without queueing for the 45s acquisition timeout (try-immediate plus
+      // the fixed 2s did-another-tab-finish wait).
+      expect(durationMs).toBeLessThan(10_000);
+      // And no network refresh happened in this tab.
+      expect(
+        fetchMock.mock.calls.some(([, init]) =>
+          isRefreshApiCall(init as { headers?: Record<string, string> })
+        )
+      ).toBe(false);
+      // The other tab's lock was never touched.
+      expect(JSON.parse(storage.getItem(LOCK_KEY)!).id).toBe("other-tab");
+    } finally {
+      clearInterval(renewer);
+    }
+  }, 15000);
+
+  test("a forced refresh queues for the lock and performs a real refresh once the holder releases", async () => {
+    const storage = createMemoryStorage();
+    const fetchMock = jest.fn(
+      async (_url: unknown, init?: { headers?: Record<string, string> }) => {
+        if (isRefreshApiCall(init)) return refreshResponse();
+        return { ok: true, status: 200, json: async () => ({}) };
+      }
+    );
+    configure({
+      clientId: "testClient",
+      cognitoIdpEndpoint: "us-west-2",
+      storage,
+      useGetTokensFromRefreshToken: true,
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    const cachedToken = await seedSession();
+
+    // Another tab holds the lock briefly, then releases it.
+    storage.setItem(
+      LOCK_KEY,
+      JSON.stringify({ id: "other-tab", timestamp: Date.now() })
+    );
+    setTimeout(() => storage.removeItem(LOCK_KEY), 500);
+
+    const result = await refreshTokens({ force: true });
+
+    // The forced refresh waited for the release and got a FRESH token.
+    expect(result.accessToken).not.toBe(cachedToken);
+    expect(
+      fetchMock.mock.calls.some(([, init]) =>
+        isRefreshApiCall(init as { headers?: Record<string, string> })
+      )
+    ).toBe(true);
+  }, 15000);
+});

--- a/test/scheduleRefresh.test.ts
+++ b/test/scheduleRefresh.test.ts
@@ -1,111 +1,43 @@
 import { configure } from "../client/config.js";
-import { scheduleRefresh } from "../client/refresh.js";
+import { scheduleRefresh, cleanupUserRefreshState } from "../client/refresh.js";
 
 // Helper to create a JWT for testing; expiry offset in seconds from now
 const createJWT = (expOffsetSeconds = 3600) => {
-  const header = btoa(JSON.stringify({ alg: "HS256", typ: "JWT" }))
-    .replace(/\+/g, "-")
-    .replace(/\//g, "_")
-    .replace(/=+$/, "");
-  const payload = btoa(
-    JSON.stringify({
-      sub: "test-sub",
-      username: "testuser",
-      exp: Math.floor(Date.now() / 1000) + expOffsetSeconds,
-      iat: Math.floor(Date.now() / 1000),
-    })
-  )
-    .replace(/\+/g, "-")
-    .replace(/\//g, "_")
-    .replace(/=+$/, "");
-  return `${header}.${payload}.signature`;
+  const enc = (obj: unknown) =>
+    btoa(JSON.stringify(obj))
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+  return `${enc({ alg: "HS256", typ: "JWT" })}.${enc({
+    sub: "test-sub",
+    username: "testuser",
+    exp: Math.floor(Date.now() / 1000) + expOffsetSeconds,
+    iat: Math.floor(Date.now() / 1000),
+  })}.signature`;
 };
 const createValidJWT = () => createJWT(3600);
 
-describe("ScheduleRefresh Lock", () => {
-  beforeEach(() => {
-    // Configure with in-memory storage and no user signed in
-    configure({ clientId: "testClient", cognitoIdpEndpoint: "us-west-2" });
+const AMPLIFY_PREFIX = "CognitoIdentityServiceProvider.testClient";
+const LOCK_KEY = "Passwordless.testClient.testuser.refreshLock";
+
+// Phase 3: scheduling no longer takes the per-user refresh lock. Arming a
+// timer is purely local, in-memory work; only the immediate-refresh branch
+// (which delegates to refreshTokens) takes the lock, and it does so itself.
+describe("ScheduleRefresh (lock-free scheduling)", () => {
+  afterEach(() => {
+    // Clear any timer a scheduling test armed so it can't leak across tests.
+    cleanupUserRefreshState("testuser");
+    jest.useRealTimers();
   });
 
-  test("should resolve immediately when no user is signed in", async () => {
+  test("resolves immediately when no user is signed in", async () => {
+    configure({ clientId: "testClient", cognitoIdpEndpoint: "us-west-2" });
     const startTime = Date.now();
     await scheduleRefresh();
-    const duration = Date.now() - startTime;
-
-    expect(duration).toBeLessThan(100);
+    expect(Date.now() - startTime).toBeLessThan(100);
   });
 
-  test("should return silently when lock is held by another (renewing) tab", async () => {
-    // A lock held by a LIVE tab is renewed via heartbeat; scheduleRefresh
-    // waits out its acquisition timeout and then returns silently, assuming
-    // the other tab is handling the refresh. (A lock that is NOT renewed
-    // goes stale after 30s and is taken over instead — that liveness
-    // behavior is covered in lock-liveness.test.ts.)
-    jest.useFakeTimers();
-    try {
-      const { storage } = configure();
-      const amplifyKeyPrefix = `CognitoIdentityServiceProvider.testClient`;
-      const customKeyPrefix = `Passwordless.testClient`;
-
-      await storage.setItem(`${amplifyKeyPrefix}.LastAuthUser`, "testuser");
-      await storage.setItem(
-        `${amplifyKeyPrefix}.testuser.accessToken`,
-        createValidJWT()
-      );
-      await storage.setItem(
-        `${amplifyKeyPrefix}.testuser.refreshToken`,
-        "test-refresh-token"
-      );
-      await storage.setItem(
-        `${customKeyPrefix}.testuser.expireAt`,
-        new Date(Date.now() + 3600000).toISOString()
-      );
-
-      const userKey = `Passwordless.testClient.testuser.refreshLock`;
-      await storage.setItem(
-        userKey,
-        JSON.stringify({ id: "other-tab-lock", timestamp: Date.now() })
-      );
-      // The other tab renews its heartbeat, so the lock never goes stale
-      const renewer = setInterval(() => {
-        void storage.setItem(
-          userKey,
-          JSON.stringify({ id: "other-tab-lock", timestamp: Date.now() })
-        );
-      }, 5_000);
-
-      try {
-        const outcome: { done: boolean; error?: unknown } = { done: false };
-        scheduleRefresh().then(
-          () => {
-            outcome.done = true;
-          },
-          (error) => {
-            outcome.done = true;
-            outcome.error = error;
-          }
-        );
-        // Drive past the lock acquisition timeout (45s)
-        for (let i = 0; i < 90 && !outcome.done; i++) {
-          await jest.advanceTimersByTimeAsync(1000);
-        }
-
-        expect(outcome.done).toBe(true);
-        expect(outcome.error).toBeUndefined();
-      } finally {
-        clearInterval(renewer);
-      }
-    } finally {
-      jest.useRealTimers();
-    }
-  });
-
-  test("should honor the per-user lock when the access token is expired", async () => {
-    // Regression: scheduleRefresh used to derive the lock user via
-    // retrieveTokens(), which returns undefined for an expired access token,
-    // so the global watchdog/visibilitychange handlers would take the
-    // unlocked path and race a concurrent signOut holding the lock.
+  test("arms a distant refresh without creating or waiting on a cross-tab lock", async () => {
     const debug = jest.fn();
     configure({
       clientId: "testClient",
@@ -113,22 +45,93 @@ describe("ScheduleRefresh Lock", () => {
       debug,
     });
     const { storage } = configure();
-    const amplifyKeyPrefix = `CognitoIdentityServiceProvider.testClient`;
-
-    await storage.setItem(`${amplifyKeyPrefix}.LastAuthUser`, "testuser");
+    await storage.setItem(`${AMPLIFY_PREFIX}.LastAuthUser`, "testuser");
     await storage.setItem(
-      `${amplifyKeyPrefix}.testuser.accessToken`,
+      `${AMPLIFY_PREFIX}.testuser.accessToken`,
+      createValidJWT()
+    );
+    await storage.setItem(
+      `${AMPLIFY_PREFIX}.testuser.refreshToken`,
+      "test-refresh-token"
+    );
+
+    // Another tab holds the refresh lock. Old scheduling waited out its 45s
+    // acquisition timeout here; lock-free scheduling must ignore it entirely.
+    await storage.setItem(
+      LOCK_KEY,
+      JSON.stringify({ id: "other-tab", timestamp: Date.now() })
+    );
+
+    const start = Date.now();
+    await scheduleRefresh();
+
+    expect(Date.now() - start).toBeLessThan(3000);
+    const messages = debug.mock.calls.map((args) => String(args[0]));
+    // Scheduling neither waited on nor created a lock...
+    expect(messages.some((m) => m.includes("waiting for lock"))).toBe(false);
+    expect(JSON.parse((await storage.getItem(LOCK_KEY))!).id).toBe("other-tab");
+    // ...and a future refresh was armed.
+    expect(messages.some((m) => m.includes("Scheduling token refresh"))).toBe(
+      true
+    );
+  });
+
+  test("still acts for a user whose access token is already expired, taking the lock at the refresh step", async () => {
+    // Regression: scheduling used to resolve the user via retrieveTokens(),
+    // which drops an expired access token, so an expired-but-refreshable
+    // session was skipped. It must still act — here, an immediate refresh that
+    // serializes through the per-user lock via refreshTokens().
+    const debug = jest.fn();
+    const fetchMock = jest.fn(
+      async (_url: unknown, init?: { headers?: Record<string, string> }) => {
+        if (
+          init?.headers?.["x-amz-target"]?.endsWith("GetTokensFromRefreshToken")
+        ) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({
+              AuthenticationResult: {
+                AccessToken: createJWT(3600),
+                IdToken: createJWT(3600),
+                ExpiresIn: 3600,
+                TokenType: "Bearer",
+                RefreshToken: "rotated-refresh-token",
+              },
+            }),
+          };
+        }
+        return { ok: true, status: 200, json: async () => ({}) };
+      }
+    );
+    configure({
+      clientId: "testClient",
+      cognitoIdpEndpoint: "us-west-2",
+      debug,
+      useGetTokensFromRefreshToken: true,
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    const { storage } = configure();
+    await storage.setItem(`${AMPLIFY_PREFIX}.LastAuthUser`, "testuser");
+    await storage.setItem(
+      `${AMPLIFY_PREFIX}.testuser.accessToken`,
       createJWT(-3600) // expired 1 hour ago
     );
     await storage.setItem(
-      `${amplifyKeyPrefix}.testuser.refreshToken`,
+      `${AMPLIFY_PREFIX}.testuser.refreshToken`,
       "test-refresh-token"
     );
 
     await scheduleRefresh();
 
     const messages = debug.mock.calls.map((args) => String(args[0]));
-    expect(messages).not.toContain("scheduleRefresh: no user, running unlocked");
-    expect(messages).toContain("scheduleRefresh: waiting for lock");
+    // Took the immediate-refresh branch (not the "no user" no-op)...
+    expect(messages.some((m) => m.includes("refreshing immediately"))).toBe(
+      true
+    );
+    // ...which serializes across tabs through the per-user refresh lock.
+    expect(
+      messages.some((m) => m.includes("refreshTokens: waiting for lock"))
+    ).toBe(true);
   });
 });

--- a/test/signout-unlocked-teardown.test.ts
+++ b/test/signout-unlocked-teardown.test.ts
@@ -143,15 +143,20 @@ describe("SignOut unlocked local teardown", () => {
     });
     await seedSession();
 
-    const callback = jest.fn();
+    // Resolve off the callback itself rather than a fixed sleep: the assertion
+    // is about ordering, so waiting a wall-clock guess would flake under load.
+    let markCallbackFired!: () => void;
+    const callbackFired = new Promise<void>((resolve) => {
+      markCallbackFired = resolve;
+    });
+    const callback = jest.fn(() => markCallbackFired());
     let resolved = false;
     const { signedOut } = signOut({ tokensRemovedLocallyCb: callback });
     void signedOut.then(() => {
       resolved = true;
     });
 
-    // Give the local teardown time to run; revocation is still gated.
-    await new Promise((r) => setTimeout(r, 50));
+    await callbackFired;
 
     // Local removal + navigation callback have already happened...
     expect(callback).toHaveBeenCalledTimes(1);

--- a/test/signout-unlocked-teardown.test.ts
+++ b/test/signout-unlocked-teardown.test.ts
@@ -1,0 +1,246 @@
+import { configure } from "../client/config.js";
+import { signOut } from "../client/common.js";
+import { storeTokens } from "../client/storage.js";
+
+// Phase 2 regression coverage: the LOCAL sign-out (tombstone, key removal,
+// tokensRemovedLocallyCb, SIGNED_OUT status) must complete promptly WITHOUT
+// waiting on the per-user refresh lock. A tab killed mid-refresh leaves an
+// orphaned `.refreshLock` that stays fresh under an active heartbeat renewer;
+// the old lock-wrapped teardown blocked /logout for the whole stale-takeover
+// window. Revocation is bounded best-effort AFTER the local teardown.
+
+const createJWT = (claims: Record<string, unknown>) => {
+  const enc = (obj: unknown) =>
+    btoa(JSON.stringify(obj))
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+  return `${enc({ alg: "HS256", typ: "JWT" })}.${enc(claims)}.signature`;
+};
+
+function createMemoryStorage() {
+  const store = new Map<string, string>();
+  return {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      store.set(key, value);
+    },
+    removeItem: (key: string) => {
+      store.delete(key);
+    },
+  };
+}
+
+const USERNAME = "testuser";
+const AMPLIFY_PREFIX = "CognitoIdentityServiceProvider.testClient";
+const LOCK_KEY = `Passwordless.testClient.${USERNAME}.refreshLock`;
+const TOMBSTONE_KEY = `Passwordless.testClient.${USERNAME}.signedOutAt`;
+
+const isRevokeCall = (init?: { headers?: Record<string, string> }) =>
+  init?.headers?.["x-amz-target"]?.endsWith("RevokeToken") ?? false;
+
+const okResponse = () => ({ ok: true, status: 200, json: async () => ({}) });
+
+async function seedSession(refreshToken = "original-refresh-token") {
+  const now = Date.now();
+  await storeTokens({
+    accessToken: createJWT({
+      sub: "user123",
+      username: USERNAME,
+      scope: "openid",
+      exp: Math.floor((now + 3600_000) / 1000),
+      iat: Math.floor(now / 1000),
+    }),
+    idToken: createJWT({
+      sub: "user123",
+      "cognito:username": USERNAME,
+      exp: Math.floor((now + 3600_000) / 1000),
+      iat: Math.floor(now / 1000),
+    }),
+    refreshToken,
+    authMethod: "SRP",
+    expireAt: new Date(now + 3600_000),
+  });
+}
+
+describe("SignOut unlocked local teardown", () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test("tears the session down promptly while another owner holds and heartbeat-renews the refresh lock", async () => {
+    const storage = createMemoryStorage();
+    const fetchMock = jest.fn().mockResolvedValue(okResponse());
+    configure({
+      clientId: "testClient",
+      cognitoIdpEndpoint: "us-west-2",
+      storage,
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    await seedSession();
+
+    // Another tab holds the refresh lock and keeps renewing it, so it never
+    // goes stale. The old teardown would block here until the 45s acquisition
+    // timeout, then fall back to the unlocked path (~45s of spinner).
+    storage.setItem(
+      LOCK_KEY,
+      JSON.stringify({ id: "other-tab", timestamp: Date.now() })
+    );
+    const renewer = setInterval(() => {
+      storage.setItem(
+        LOCK_KEY,
+        JSON.stringify({ id: "other-tab", timestamp: Date.now() })
+      );
+    }, 1000);
+
+    try {
+      const callback = jest.fn();
+      const statuses: string[] = [];
+      const start = Date.now();
+      const { signedOut } = signOut({
+        tokensRemovedLocallyCb: callback,
+        statusCb: (s) => statuses.push(s),
+      });
+      await signedOut;
+      const durationMs = Date.now() - start;
+
+      // The whole point of Phase 2: no stale-takeover / lock-timeout wait.
+      expect(durationMs).toBeLessThan(3000);
+      expect(callback).toHaveBeenCalledTimes(1);
+      expect(statuses).toContain("SIGNED_OUT");
+
+      // Local session is gone and the tombstone was planted.
+      expect(storage.getItem(`${AMPLIFY_PREFIX}.LastAuthUser`)).toBeNull();
+      expect(
+        storage.getItem(`${AMPLIFY_PREFIX}.${USERNAME}.refreshToken`)
+      ).toBeNull();
+      expect(storage.getItem(TOMBSTONE_KEY)).toBeTruthy();
+
+      // Sign-out never touched the other tab's lock.
+      expect(JSON.parse(storage.getItem(LOCK_KEY)!).id).toBe("other-tab");
+    } finally {
+      clearInterval(renewer);
+    }
+  }, 15000);
+
+  test("fires tokensRemovedLocallyCb (the navigation signal) before server revocation resolves", async () => {
+    const storage = createMemoryStorage();
+    let releaseRevoke!: () => void;
+    const revokeGate = new Promise<void>((resolve) => {
+      releaseRevoke = resolve;
+    });
+    const fetchMock = jest.fn(
+      (_url: unknown, init?: { headers?: Record<string, string> }) =>
+        isRevokeCall(init)
+          ? revokeGate.then(() => okResponse())
+          : Promise.resolve(okResponse())
+    );
+    configure({
+      clientId: "testClient",
+      cognitoIdpEndpoint: "us-west-2",
+      storage,
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    await seedSession();
+
+    const callback = jest.fn();
+    let resolved = false;
+    const { signedOut } = signOut({ tokensRemovedLocallyCb: callback });
+    void signedOut.then(() => {
+      resolved = true;
+    });
+
+    // Give the local teardown time to run; revocation is still gated.
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Local removal + navigation callback have already happened...
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(storage.getItem(`${AMPLIFY_PREFIX}.LastAuthUser`)).toBeNull();
+    // ...but signedOut is still pending on the outstanding revocation.
+    expect(resolved).toBe(false);
+
+    releaseRevoke();
+    await signedOut;
+    expect(resolved).toBe(true);
+    expect(
+      fetchMock.mock.calls.some(([, init]) =>
+        isRevokeCall(init as { headers?: Record<string, string> })
+      )
+    ).toBe(true);
+  });
+
+  test("bounds a hung revocation so signedOut cannot hang forever, and stays signed out", async () => {
+    jest.useFakeTimers();
+    const storage = createMemoryStorage();
+    // RevokeToken never responds on its own; it only settles when its signal
+    // aborts (mirrors a black-holed connection).
+    const fetchMock = jest.fn(
+      (
+        _url: unknown,
+        init?: { headers?: Record<string, string>; signal?: AbortSignal }
+      ) => {
+        if (isRevokeCall(init)) {
+          return new Promise((_resolve, reject) => {
+            init?.signal?.addEventListener("abort", () =>
+              reject(new DOMException("Aborted", "AbortError"))
+            );
+          });
+        }
+        return Promise.resolve(okResponse());
+      }
+    );
+    configure({
+      clientId: "testClient",
+      cognitoIdpEndpoint: "us-west-2",
+      storage,
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    await seedSession();
+
+    const callback = jest.fn();
+    let resolved = false;
+    const { signedOut } = signOut({ tokensRemovedLocallyCb: callback });
+    void signedOut.then(() => {
+      resolved = true;
+    });
+
+    // Local teardown completes without advancing the clock.
+    await jest.advanceTimersByTimeAsync(1);
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(storage.getItem(`${AMPLIFY_PREFIX}.LastAuthUser`)).toBeNull();
+    expect(resolved).toBe(false);
+
+    // The 5s revoke deadline aborts the hung call; signedOut then resolves.
+    await jest.advanceTimersByTimeAsync(5100);
+    expect(resolved).toBe(true);
+
+    // A failed revocation must never resurrect the local session.
+    expect(storage.getItem(`${AMPLIFY_PREFIX}.LastAuthUser`)).toBeNull();
+    expect(
+      storage.getItem(`${AMPLIFY_PREFIX}.${USERNAME}.refreshToken`)
+    ).toBeNull();
+    expect(storage.getItem(TOMBSTONE_KEY)).toBeTruthy();
+  });
+
+  test("a second sign-out after the session is gone is an immediate no-op that still fires its callback once", async () => {
+    const storage = createMemoryStorage();
+    const fetchMock = jest.fn().mockResolvedValue(okResponse());
+    configure({
+      clientId: "testClient",
+      cognitoIdpEndpoint: "us-west-2",
+      storage,
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    await seedSession();
+
+    await signOut({ skipTokenRevocation: true }).signedOut;
+    expect(storage.getItem(`${AMPLIFY_PREFIX}.LastAuthUser`)).toBeNull();
+
+    const secondCallback = jest.fn();
+    const start = Date.now();
+    await signOut({ tokensRemovedLocallyCb: secondCallback }).signedOut;
+
+    expect(Date.now() - start).toBeLessThan(1000);
+    expect(secondCallback).toHaveBeenCalledTimes(1);
+  }, 10000);
+});

--- a/test/web-locks-backend.test.ts
+++ b/test/web-locks-backend.test.ts
@@ -1,0 +1,271 @@
+import { configure } from "../client/config.js";
+import {
+  withLock,
+  LockTimeoutError,
+  activeLockBackend,
+} from "../client/lock.js";
+
+// Phase 1: withLock uses the Web Locks API when available (browser-owned,
+// auto-released on tab death) and falls back to the storage lock otherwise.
+// jsdom has no navigator.locks, so we install a faithful in-memory mock to
+// exercise the Web Locks path; without it, withLock takes the storage fallback.
+
+interface MockLockOptions {
+  mode?: "exclusive" | "shared";
+  signal?: AbortSignal;
+}
+
+// Minimal, spec-faithful LockManager: exclusive requests on a name serialize;
+// a pending (queued) request rejects with AbortError when its signal aborts;
+// aborting after the grant has no effect; the held lock releases when the
+// callback promise settles (resolve OR reject).
+function createWebLocksMock() {
+  const entries = new Map<
+    string,
+    { held: boolean; queue: Array<() => void> }
+  >();
+  const getEntry = (name: string) => {
+    let e = entries.get(name);
+    if (!e) {
+      e = { held: false, queue: [] };
+      entries.set(name, e);
+    }
+    return e;
+  };
+  const request = jest.fn(
+    (
+      name: string,
+      options: MockLockOptions,
+      callback: (lock: unknown) => Promise<unknown>
+    ) =>
+      new Promise((resolve, reject) => {
+        const entry = getEntry(name);
+        const signal = options?.signal;
+        let granted = false;
+
+        const run = async () => {
+          granted = true;
+          entry.held = true;
+          signal?.removeEventListener("abort", onAbort);
+          try {
+            resolve(
+              await callback({ name, mode: options?.mode ?? "exclusive" })
+            );
+          } catch (err) {
+            reject(err);
+          } finally {
+            entry.held = false;
+            const next = entry.queue.shift();
+            if (next) next();
+          }
+        };
+        const onAbort = () => {
+          if (granted) return;
+          const i = entry.queue.indexOf(run);
+          if (i >= 0) entry.queue.splice(i, 1);
+          reject(new DOMException("The operation was aborted", "AbortError"));
+        };
+
+        if (signal?.aborted) {
+          reject(new DOMException("The operation was aborted", "AbortError"));
+          return;
+        }
+        signal?.addEventListener("abort", onAbort, { once: true });
+
+        if (!entry.held) {
+          run();
+        } else {
+          entry.queue.push(run);
+        }
+      })
+  );
+  return { request };
+}
+
+let mock: ReturnType<typeof createWebLocksMock> | undefined;
+function installWebLocksMock() {
+  mock = createWebLocksMock();
+  Object.defineProperty(globalThis.navigator, "locks", {
+    value: mock,
+    configurable: true,
+    writable: true,
+  });
+  return mock;
+}
+function uninstallWebLocksMock() {
+  if (mock && "locks" in globalThis.navigator) {
+    delete (globalThis.navigator as { locks?: unknown }).locks;
+  }
+  mock = undefined;
+}
+
+function createEnumerableStorage() {
+  const backing = new Map<string, string>();
+  return {
+    backing,
+    storage: {
+      getItem: (k: string) => backing.get(k) ?? null,
+      setItem: (k: string, v: string) => {
+        backing.set(k, v);
+      },
+      removeItem: (k: string) => {
+        backing.delete(k);
+      },
+    },
+  };
+}
+
+const LOCK_KEY = "Passwordless.testClient.testuser.refreshLock";
+
+describe("withLock backend selection", () => {
+  afterEach(() => {
+    uninstallWebLocksMock();
+    jest.useRealTimers();
+  });
+
+  test("uses the Web Locks backend and writes NO storage lock record when available", async () => {
+    const m = installWebLocksMock();
+    const { backing, storage } = createEnumerableStorage();
+    configure({
+      clientId: "testClient",
+      cognitoIdpEndpoint: "us-west-2",
+      storage,
+    });
+
+    let sawLockRecordMidSection = false;
+    const result = await withLock(LOCK_KEY, async () => {
+      // The storage backend would have a record for LOCK_KEY here.
+      sawLockRecordMidSection = backing.has(LOCK_KEY);
+      return "done";
+    });
+
+    expect(result).toBe("done");
+    expect(m.request).toHaveBeenCalledTimes(1);
+    expect(m.request.mock.calls[0][0]).toBe(LOCK_KEY);
+    expect(sawLockRecordMidSection).toBe(false);
+    // No lingering storage lock record either.
+    expect(backing.has(LOCK_KEY)).toBe(false);
+  });
+
+  test("falls back to the storage lock when Web Locks is unavailable", async () => {
+    // No mock installed → navigator.locks absent → storage backend.
+    const { backing, storage } = createEnumerableStorage();
+    configure({
+      clientId: "testClient",
+      cognitoIdpEndpoint: "us-west-2",
+      storage,
+    });
+
+    let sawStorageRecord = false;
+    await withLock(LOCK_KEY, async () => {
+      sawStorageRecord = backing.has(LOCK_KEY);
+    });
+
+    // The storage backend writes (and then removes) a lock record.
+    expect(sawStorageRecord).toBe(true);
+    expect(backing.has(LOCK_KEY)).toBe(false);
+  });
+
+  test("serializes two exclusive contenders on the same key", async () => {
+    installWebLocksMock();
+    configure({ clientId: "testClient", cognitoIdpEndpoint: "us-west-2" });
+
+    let active = 0;
+    let maxActive = 0;
+    const task = async () => {
+      active++;
+      maxActive = Math.max(maxActive, active);
+      await new Promise((r) => setTimeout(r, 20));
+      active--;
+    };
+
+    await Promise.all([withLock(LOCK_KEY, task), withLock(LOCK_KEY, task)]);
+    expect(maxActive).toBe(1);
+  });
+
+  test("maps the acquisition deadline to LockTimeoutError (pending request only)", async () => {
+    jest.useFakeTimers();
+    installWebLocksMock();
+    configure({ clientId: "testClient", cognitoIdpEndpoint: "us-west-2" });
+
+    let releaseHolder!: () => void;
+    const holderGate = new Promise<void>((r) => {
+      releaseHolder = r;
+    });
+    const holder = withLock(LOCK_KEY, async () => {
+      await holderGate;
+    });
+    await Promise.resolve(); // let the holder acquire
+
+    let waiterErr: unknown;
+    const waiter = withLock(LOCK_KEY, async () => "never", 1000).catch((e) => {
+      waiterErr = e;
+    });
+
+    await jest.advanceTimersByTimeAsync(1000);
+    await waiter;
+    expect(waiterErr).toBeInstanceOf(LockTimeoutError);
+
+    releaseHolder();
+    await holder;
+  });
+
+  test("propagates a caller abort as AbortError, not LockTimeoutError", async () => {
+    installWebLocksMock();
+    configure({ clientId: "testClient", cognitoIdpEndpoint: "us-west-2" });
+
+    let releaseHolder!: () => void;
+    const holderGate = new Promise<void>((r) => {
+      releaseHolder = r;
+    });
+    const holder = withLock(LOCK_KEY, async () => {
+      await holderGate;
+    });
+    await Promise.resolve();
+
+    const abort = new AbortController();
+    let waiterErr: unknown;
+    const waiter = withLock(
+      LOCK_KEY,
+      async () => "never",
+      60000,
+      abort.signal
+    ).catch((e) => {
+      waiterErr = e;
+    });
+    abort.abort();
+    await waiter;
+
+    expect(waiterErr).toBeInstanceOf(DOMException);
+    expect((waiterErr as DOMException).name).toBe("AbortError");
+    expect(waiterErr).not.toBeInstanceOf(LockTimeoutError);
+
+    releaseHolder();
+    await holder;
+  });
+
+  test("activeLockBackend reports which backend withLock will use", () => {
+    // No mock → storage fallback (jsdom has no navigator.locks).
+    expect(activeLockBackend()).toBe("storage");
+    installWebLocksMock();
+    expect(activeLockBackend()).toBe("web-locks");
+  });
+
+  test("releases the lock when the callback rejects, so the next contender can acquire", async () => {
+    installWebLocksMock();
+    configure({ clientId: "testClient", cognitoIdpEndpoint: "us-west-2" });
+
+    await expect(
+      withLock(LOCK_KEY, async () => {
+        throw new Error("boom");
+      })
+    ).rejects.toThrow("boom");
+
+    // The lock must have been released despite the throw.
+    let ran = false;
+    await withLock(LOCK_KEY, async () => {
+      ran = true;
+    });
+    expect(ran).toBe(true);
+  });
+});

--- a/test/web-locks-backend.test.ts
+++ b/test/web-locks-backend.test.ts
@@ -340,6 +340,66 @@ describe("withLock backend selection", () => {
     expect(isLockTimeoutError(undefined)).toBe(false);
   });
 
+  test("falls back to the storage lock when request() rejects with SecurityError before any grant (opaque origin)", async () => {
+    // A sandboxed iframe without allow-same-origin exposes navigator.locks
+    // but rejects every request() with SecurityError. The critical section
+    // has not run, so withLock must retry it on the storage backend rather
+    // than surface a baffling SecurityError.
+    const securityMock = {
+      request: jest.fn(() =>
+        Promise.reject(
+          new DOMException("The request was denied", "SecurityError")
+        )
+      ),
+    };
+    Object.defineProperty(globalThis.navigator, "locks", {
+      value: securityMock,
+      configurable: true,
+      writable: true,
+    });
+    mock = securityMock as unknown as ReturnType<typeof createWebLocksMock>;
+    const { backing, storage } = createEnumerableStorage();
+    configure({
+      clientId: "testClient",
+      cognitoIdpEndpoint: "us-west-2",
+      storage,
+    });
+
+    let sawStorageRecord = false;
+    const result = await withLock(LOCK_KEY, async () => {
+      sawStorageRecord = backing.has(LOCK_KEY);
+      return "via-storage";
+    });
+
+    expect(result).toBe("via-storage");
+    expect(securityMock.request).toHaveBeenCalledTimes(1);
+    // fn ran exactly once, under the STORAGE lock.
+    expect(sawStorageRecord).toBe(true);
+    expect(backing.has(LOCK_KEY)).toBe(false);
+  });
+
+  test("a SecurityError thrown INSIDE the critical section propagates (no storage retry, fn must not run twice)", async () => {
+    installWebLocksMock();
+    const { backing, storage } = createEnumerableStorage();
+    configure({
+      clientId: "testClient",
+      cognitoIdpEndpoint: "us-west-2",
+      storage,
+    });
+
+    let runs = 0;
+    const err = await withLock(LOCK_KEY, async () => {
+      runs++;
+      throw new DOMException("thrown by fn", "SecurityError");
+    }).catch((e: unknown) => e);
+
+    expect(runs).toBe(1);
+    expect(err).toBeInstanceOf(DOMException);
+    expect((err as DOMException).name).toBe("SecurityError");
+    // Never re-ran on the storage backend.
+    expect(backing.has(LOCK_KEY)).toBe(false);
+  });
+
   test("an AbortError thrown INSIDE the critical section is not reported as a lock timeout", async () => {
     // The acquisition deadline can fire in the gap between the browser granting
     // the lock and our callback clearing the timer (the browser grants, then

--- a/test/web-locks-backend.test.ts
+++ b/test/web-locks-backend.test.ts
@@ -2,6 +2,7 @@ import { configure } from "../client/config.js";
 import {
   withLock,
   LockTimeoutError,
+  isLockTimeoutError,
   activeLockBackend,
 } from "../client/lock.js";
 
@@ -13,6 +14,7 @@ import {
 interface MockLockOptions {
   mode?: "exclusive" | "shared";
   signal?: AbortSignal;
+  ifAvailable?: boolean;
 }
 
 // Minimal, spec-faithful LockManager: exclusive requests on a name serialize;
@@ -42,6 +44,15 @@ function createWebLocksMock() {
         const entry = getEntry(name);
         const signal = options?.signal;
         let granted = false;
+
+        // Spec: with ifAvailable, a held lock invokes the callback with null
+        // instead of queueing the request.
+        if (options?.ifAvailable && entry.held) {
+          Promise.resolve()
+            .then(() => callback(null))
+            .then(resolve, reject);
+          return;
+        }
 
         const run = async () => {
           granted = true;
@@ -267,6 +278,66 @@ describe("withLock backend selection", () => {
       ran = true;
     });
     expect(ran).toBe(true);
+  });
+
+  test("timeoutMs 0 (try-immediate) acquires a free lock and runs the callback", async () => {
+    const m = installWebLocksMock();
+    configure({ clientId: "testClient", cognitoIdpEndpoint: "us-west-2" });
+
+    const result = await withLock(LOCK_KEY, async () => "ran", 0);
+
+    expect(result).toBe("ran");
+    // ifAvailable was requested — a free lock is granted, never queued.
+    expect(m.request.mock.calls[0][1]).toMatchObject({ ifAvailable: true });
+  });
+
+  test("timeoutMs 0 (try-immediate) throws LockTimeoutError at once when the lock is held, without queueing", async () => {
+    installWebLocksMock();
+    configure({ clientId: "testClient", cognitoIdpEndpoint: "us-west-2" });
+
+    let releaseHolder!: () => void;
+    const holderGate = new Promise<void>((r) => {
+      releaseHolder = r;
+    });
+    const holder = withLock(LOCK_KEY, async () => {
+      await holderGate;
+      return "holder-done";
+    });
+    await Promise.resolve(); // let the holder acquire
+
+    // No timers are driven: the rejection must be immediate, not a timeout.
+    let ran = false;
+    const err = await withLock(
+      LOCK_KEY,
+      async () => {
+        ran = true;
+      },
+      0
+    ).catch((e: unknown) => e);
+
+    expect(isLockTimeoutError(err)).toBe(true);
+    expect(ran).toBe(false);
+
+    // The holder was never disturbed by the try-immediate attempt.
+    releaseHolder();
+    await expect(holder).resolves.toBe("holder-done");
+  });
+
+  test("isLockTimeoutError recognizes an instance from a duplicated module copy (where instanceof fails)", () => {
+    // Simulate a bundler shipping two copies of lock.ts: the "foreign" copy's
+    // LockTimeoutError shares the shape (name + isLockTimeout marker) but not
+    // the prototype, so instanceof is false. The type guard must still match.
+    const foreign = Object.assign(
+      new Error("Timeout acquiring lock 'k' after 5ms"),
+      { name: "LockTimeoutError", isLockTimeout: true }
+    );
+
+    expect(foreign instanceof LockTimeoutError).toBe(false);
+    expect(isLockTimeoutError(foreign)).toBe(true);
+
+    // And it stays a guard, not a name-sniffer: plain errors don't match.
+    expect(isLockTimeoutError(new Error("Timeout acquiring lock"))).toBe(false);
+    expect(isLockTimeoutError(undefined)).toBe(false);
   });
 
   test("an AbortError thrown INSIDE the critical section is not reported as a lock timeout", async () => {

--- a/test/web-locks-backend.test.ts
+++ b/test/web-locks-backend.test.ts
@@ -268,4 +268,52 @@ describe("withLock backend selection", () => {
     });
     expect(ran).toBe(true);
   });
+
+  test("an AbortError thrown INSIDE the critical section is not reported as a lock timeout", async () => {
+    // The acquisition deadline can fire in the gap between the browser granting
+    // the lock and our callback clearing the timer (the browser grants, then
+    // queues a task to invoke the callback). Aborting after the grant has no
+    // effect on the held lock per spec — but the deadline flag is set. If fn()
+    // then throws its own AbortError (e.g. an aborted fetch inside the critical
+    // section), it must propagate unchanged rather than be translated into a
+    // LockTimeoutError the caller would treat as "another tab is refreshing".
+    const grantThenDelayCallback = {
+      request: jest.fn(
+        (
+          _name: string,
+          _options: MockLockOptions,
+          callback: (lock: unknown) => Promise<unknown>
+        ) =>
+          // Lock is granted here; the callback runs a macrotask later, which is
+          // the window the acquisition timer can fire in.
+          new Promise((resolve, reject) => {
+            setTimeout(() => {
+              void callback({}).then(resolve, reject);
+            }, 50);
+          })
+      ),
+    };
+    Object.defineProperty(globalThis.navigator, "locks", {
+      value: grantThenDelayCallback,
+      configurable: true,
+      writable: true,
+    });
+    mock = grantThenDelayCallback as unknown as ReturnType<
+      typeof createWebLocksMock
+    >;
+    configure({ clientId: "testClient", cognitoIdpEndpoint: "us-west-2" });
+
+    // 10ms deadline expires during the 50ms grant→callback gap.
+    const err = await withLock(
+      LOCK_KEY,
+      async () => {
+        throw new DOMException("The operation was aborted", "AbortError");
+      },
+      10
+    ).catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(DOMException);
+    expect((err as DOMException).name).toBe("AbortError");
+    expect(err).not.toBeInstanceOf(LockTimeoutError);
+  });
 });


### PR DESCRIPTION
## Summary

Three independent defects caused the auth stalls and permanent spinners. They can overlap and amplify each other, but each is fixed on its own terms.

**1. Orphaned locks caused bounded stalls (8–45s).** Cross-tab locks were stored in `localStorage`, so a tab killed mid-critical-section (refresh, navigation, close, crash) left its lock record behind and every waiter blocked for the ~30s stale-takeover window. RUM showed a `/logout` view transitioning to `/login` 31.9s later, with the Cognito revoke itself taking only ~0.33s — the delay was lock-shaped, not network-shaped.

`withLock` now dispatches to the **Web Locks API** where available: the browser owns the lock and releases it on document unload or agent termination, so orphans cannot exist. The storage lock is retained as the fallback for Node, SSR, insecure contexts, and unsupported browsers, and all three lock families (`authLock`, `refreshLock`, `oauthLock`) route through the one entry point. `activeLockBackend()` is exported so the app can tag telemetry with the backend in use.

**2. Sign-out waited on an orphanable lock.** `doSignOut()` ran inside `.refreshLock`, and the app's navigation signal (`tokensRemovedLocallyCb`) fired inside it — so one fresh orphan held the logout spinner for the whole stale window. The local teardown no longer takes a lock at all. This is safe because the sign-out tombstone is authoritative: an in-flight refresh re-checks it immediately before *and* after writing tokens back (`processTokens`' `sessionMustExistSince` guard) and re-validates that the session still exists after its network round-trip. Refresh-token revocation is bounded best-effort (5s) *after* the local teardown, so a hung revoke can no longer keep `signedOut` pending.

**3. Scheduling held the lock just to arm a timer.** Timer calculation and registration are local, in-memory work and now run unlocked; only the immediate-refresh branch takes the lock, via `refreshTokens()` itself (`skipLock` removed, `performRefresh` merged into `refreshTokens`).

### Latent bug found while doing (3)

`state.isRefreshing` stayed `true` across the post-refresh `processTokens`, which arms the *next* schedule — so with short-lived access tokens (Cognito allows 5 minutes) the next refresh timer was silently never armed. Lock-acquisition jitter had been masking it. The flag is now cleared once the round-trip completes and the session is re-validated, while the refresh lock is still held.

**4. MFA readiness race caused a permanent post-login spinner.** `mfaStatusReady` was a stored boolean that `updateTokens` reset whenever its captured tokens snapshot differed from the incoming one. During login the original sign-in callback could resume with a stale closure (captured `tokens === undefined`) *after* `GetUser` had already marked the committed token ready — resetting readiness for a token whose identity never changes again, so the MFA effect never re-fired and the guard span forever.

Readiness is now **derived**: state stores `mfaStatusReadyForToken` and `mfaStatusReady` is that token equalling the current access token. A stale callback cannot un-ready a resolved token, a `GetUser` response for a superseded token cannot ready a newer one, and sign-out derives to `false` the moment tokens are gone.

## Review round (commit 3)

A `/code-review` pass with independent reviewers caught a bug introduced by (4) itself: `refreshTotpMfaStatus` keyed its staleness check on the **username** while writing a **token-keyed** readiness value. A same-user token rotation while `GetUser` was in flight committed the superseded token as the key; the effect had already fetched for the new token, so its own guard blocked any re-fetch and `mfaStatusReady` stayed false permanently — the same stall class this PR removes. It now shares the effect's token-keyed staleness owner, with a regression test that fails against the username-keyed version. That round also removed an orphaned JSDoc left by the `performRefresh` merge and corrected comments this branch had falsified.

## Review round (commit 4)

A second review pass found one real defect and three documentation gaps.

**Defect — `withWebLock` could misreport a mid-critical-section abort as a lock timeout.** The acquisition deadline can fire in the gap between the browser granting the lock and the callback clearing the timer (the browser grants, then queues a task to invoke the callback). The `catch` translated *any* `AbortError` to `LockTimeoutError` while `timedOut` was set — so an `AbortError` thrown by `fn()` itself (an aborted fetch inside the critical section) would surface to the caller as "another tab holds the lock". Both the translation and the debug line are now gated on a `granted` flag, so only a failed *acquisition* is ever translated. The regression test drives the grant→callback gap and fails against the previous code.

**Behavior note this PR had not called out:** the 5s revoke deadline also bounds the `revokeTokensBeforeLocalRemoval` (hosted-UI) path, which was previously unbounded and runs *before* local removal. That is intended — it is the same hang class — but it is a behavior change on that path, not only on the default one.

**Docs:** `REFRESH.md` still described a storage-only lock system with a 15s timeout. It now covers both backends, the constants as they actually are, and what is deliberately *not* locked (scheduling, and the local sign-out teardown). It also documents a **scope caveat** the code change introduces: Web Locks are per-origin, while the storage lock's scope is whatever `configure().storage` spans. An app that configures storage reaching beyond one origin (a cookie shared across subdomains) loses cross-origin coordination on the new path; an app on per-tab storage (`sessionStorage`) *gains* cross-tab coordination it never had. Finally, the MFA staleness ref now documents its ownership contract — a claimer must commit readiness on every outcome, including failure, because claiming the ref suppresses the effect's per-token dedup.

## Ecosystem-alignment round (commit 5)

A comparison against the SDKs that shipped this same localStorage→Web Locks migration (auth0-spa-js v2.15.0, Clerk clerk-js, WorkOS authkit-js) and against Supabase's post-migration experience produced three upgrades:

**Background refreshes now try-immediate the lock instead of queueing** — when it is safe to. `withLock` gained `timeoutMs: 0` semantics (Web Locks `ifAvailable: true`; a single attempt on the storage backend). The policy as finally landed (refined in the QA round below) is keyed on **fallback availability, not just force**: a non-forced refresh with a *still-valid* cached access token try-locks and skips to recovery; a non-forced refresh with an *expired or missing* access token queues like a forced one, because there is nothing to fall back on. Forced refreshes (post-401) always queue. This is the pattern Supabase converged on for its auto-refresh tick: a periodic best-effort job should never stack up in the lock queue.

**On lock contention with a healthy session, return the cached token instead of erroring.** WorkOS hit the exact failure class this PR chases ([authkit-js#117](https://github.com/workos/authkit-js/pull/117)): after laptop sleep, acquisition timers fire before the event loop resumes, so a "lock timeout" can be spurious. The recovery path now returns the still-valid cached token (retrieveTokens is already skew-corrected-expiry-gated, so non-null ⇒ valid) rather than surfacing an error that upstream code could read as an auth failure. Only a genuinely expired token still errors, feeding the existing backoff retry. The scheduled timer re-arms the next schedule after these adopt/cached successes — they never reach processTokens, which is what normally arms it — and the re-arm dedups against an already-registered timer.

**`isLockTimeoutError()` type guard replaces `instanceof LockTimeoutError`.** Supabase's auth-js deliberately ships an `isAcquireTimeout` flag because `instanceof` breaks when a bundler ends up with two copies of the module. Same hazard applies to this package as a transitive dependency; all seven internal call sites now use the guard, and it is exported (along with `LockTimeoutError` itself) for consumers.

## bfcache fix (commit 6)

The refresh system's auto-cleanup registered an **`unload` listener**, whose mere presence makes the page ineligible for the back/forward cache in desktop Chrome and Firefox ([web.dev/articles/bfcache](https://web.dev/articles/bfcache): "Never add an `unload` event listener! Use the `pagehide` event instead"). `pagehide` fires in every case `unload` does — plus when the page enters bfcache — so the listener added nothing; it (and its dead `typeof addEventListener` guard) are removed. `beforeunload` stays: it does not disqualify bfcache in modern browsers. Related in spirit to this PR: a bfcache-restored page is exactly the kind of resumed context whose refresh scheduling must come back cleanly.

The auto-cleanup tests turned out to assert nothing real (module-load registration predates any test spy; one suite pre-seeded a map and asserted `has()`, the other was `expect(true)`). The verify suite now re-loads `refresh.ts` under `jest.isolateModules` with spies already installed, asserting `beforeunload` + `pagehide` are registered, `unload` is **not**, and that a real `pagehide` dispatch triggers the cleanup handler.

## Immediate UI mode fix (commit 7)

Another silent-spinner-adjacent bug, this one in the passkey path: Chrome rejects a `uiMode: "immediate"` request carrying a **non-empty `allowCredentials`** with `NotAllowedError` (anti-tracking), regardless of whether the user has a matching local passkey ([Chrome docs](https://developer.chrome.com/docs/identity/immediate-ui-mode)). The request builder populated the allow-list for every mediation mode, so a username-first flow (server-issued credential IDs) plus `mediation: "immediate"` failed **unconditionally** — and since immediate mode's legitimate "no local credentials" signal is the same `NotAllowedError`, users *with* working passkeys silently fell through to the password fallback.

The immediate path now strips the allow-list (mirroring how the conditional path strips `timeout`), with a debug warning; the request becomes discoverable-credential-only as the mode requires, and the server-issued challenge still binds the assertion to the signed-in user. Docs (`authenticateWithFido2`, `detectMediationCapabilities`, React README) now state the discoverable-only constraint and that Chrome also rejects **all** immediate-mode requests in incognito/private windows — another silent-fallback path to design for.

## Full-QA round (commits 8–10)

A final pass: re-verification of the whole diff by an independent adversarial reviewer, plus a sweep of the ecosystem/Cognito research for unapplied items.

**Blocker found and fixed — the try-immediate policy broke non-forced refreshes with an expired token.** The best-effort try-lock was keyed on `force` alone, but best-effort is only safe when a valid cached token exists to fall back on. With an expired token under contention (two tabs waking from sleep), the hook-exposed `refreshTokens()` — and the incomplete-tokens effect, whose catch **signs the user out** — would error after the 2s recovery instead of queueing and adopting the winner's tokens as they always had. `refreshTokens` now chooses its lock wait upfront: try-immediate only with a valid cached token for this user, full queue otherwise. Staying non-forced on the queued path preserves the coordination check (adopt, don't double-rotate); an intermediate force-when-expired approach was superseded for exactly that reason. Regression test: expired token + contended lock queues past the holder's release and performs a real refresh.

**Contention poll bounded.** A scheduled refresh firing at the buffer boundary that took the cached-token path would re-arm with a ~0 delay and poll the lock holder every ~2s. It now re-arms after the 5s coordination window, tracked as `retryTimer` so teardown cancels it.

**Doomed retry chains stopped.** Lock-free scheduling can race sign-out and arm a timer after teardown (`getRefreshState` recreates the per-user entry, defeating the identity check). The timer's failure path now re-checks storage before arming backoff retries — with the session gone, the chain could only fail fast on "cannot determine user identity" (tombstone and re-validation always kept it harmless; now it's not even churn).

**Opaque-origin hardening (from the research sweep).** `navigator.locks` *exists* in a sandboxed iframe without `allow-same-origin` but rejects every `request()` with `SecurityError`. A pre-grant `SecurityError` (gated on the `granted` flag, so the critical section provably never ran) now falls back to the storage backend; a `SecurityError` thrown *by* the critical section propagates unchanged — tested both ways, including that `fn` runs exactly once.

**Verified, no change needed:** hosted-UI sign-out already routes through Cognito's `/logout` endpoint (covers the Managed Login cookie-resurrection issue); `RefreshTokenReuseException` retry and `DeviceKey` forwarding on `GetTokensFromRefreshToken` are correct; the single `credentials.get()` assembly point means no flow bypasses the immediate-mode strip.

**Known accepted trade-offs:** concurrent expired-token wakeups through `scheduleRefresh`'s immediate branch (`force: true`) can rotate twice, serialized on the lock and recovered by the reuse-retry — mitigated by visibility gating; Chrome builds from the `mediation:"immediate"` origin-trial era (139–148, auto-updated away) silently ignore `uiMode` and degrade to a modal discoverable-credential picker. Supabase's zone.js wrapper and `{steal: true}` eviction remain deliberately unadopted (React-focused library; steal-cascade risk).

## Fetch attempt guard through body reads (commit 11)

The pre-existing gap the QA reviewer found in the fetch-retry wrapper (#107) is fixed here too rather than deferred. The per-attempt timeout issued the request with the attempt controller's signal but disarmed both the deadline and the caller-abort relay when **headers** arrived — while the response **body** stream stayed bound to that signal, which nothing would ever abort. So a caller abort during `res.json()` was silently ignored (pre-#107 behavior lost), and #107's hang class was only half-fixed: headers-then-stalled-body hung the read forever.

The guard now survives a successful return, covering body reads; aborting a fully-consumed response is a spec-level no-op, so the happy path is unaffected. Cleanup is mutual and self-limiting (deadline firing removes the relay; relay firing clears the deadline), so a long-lived caller signal holds each request's listener for at most `perAttemptTimeoutMs` — no unbounded accumulation, no `AbortSignal.any` dependency. A body stalled past the deadline surfaces as an `AbortError` (what an aborted stream throws), noted in the JSDoc. Both new body tests fail against the previous code.

## Test plan

- Full suite: **536 passing**, build + lint + prettier clean.
- New `test/refresh-lock-contention.test.ts` — a non-forced refresh under a heartbeat-renewed foreign lock returns the cached token in seconds with no network refresh; an expired-token non-forced refresh queues past the holder's release and performs a real refresh; a forced refresh queues and refreshes once the holder releases.
- New `test/web-locks-backend.test.ts` — backend selection, serialization, deadline→`LockTimeoutError`, caller-abort propagation, release-on-throw, no storage record on the Web Locks path, and an `AbortError` from inside the critical section *not* being translated.
- New `test/signout-unlocked-teardown.test.ts` — the headline case (teardown while another owner holds *and heartbeat-renews* the lock) completes in **3ms** vs. the previous ~45s.
- New `client/__tests__/mfa-status-ready.test.tsx` — 7 tests through the real provider, including a `GetUser` response landing after sign-out and the token-rotation regression above.
- Existing suites that encoded removed behavior were updated, not weakened: `scheduleRefresh` asserted debug lines for a lock that no longer exists; `hosted-oauth` mocked `withStorageLock` directly.

## Risks / notes

- **Mixed-version window:** a tab on the storage lock and a tab on Web Locks do not coordinate on the same key. Safe because new-version sign-out takes no lock, and a doubly-run refresh is bounded by the version-independent `lastRefreshAttempt` window, refresh-token-reuse retry, and tombstone re-validation.
- **We do not force-evict a hung Web Locks holder** (the storage backend's 120s renewal cap has no equivalent here). An earlier revision of this description claimed the API offers no way to; that was wrong — `navigator.locks.request` accepts `{ steal: true }`, which releases the current holder and grants immediately. We deliberately don't use it: the spec warns the evicted code keeps running with no guarantee it is no longer touching the resource, and Supabase's experience ([supabase-js#2106](https://github.com/supabase/supabase-js/pull/2106)) is that naive stealing cascades (A steals B, B steals back, `fn()` runs twice concurrently). Bounded instead by the per-attempt fetch timeout (25s × ≤3), the 45s acquisition timeout, and gracefully-handled `LockTimeoutError` paths at every call site. Worth revisiting as a recovery-only path if telemetry shows real stuck holders.
- Browser QA across the flow matrix (two tabs; a tab killed while holding each lock family) is still to be done against a published build.

