### PR TITLE
fix: include generated declarations in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,20 +114,7 @@
   "files": [
     "dist",
     "react",
-    "cognito-api.d.ts",
-    "common.d.ts",
-    "config.d.ts",
-    "errors.d.ts",
-    "fido2.d.ts",
-    "index.d.ts",
-    "jwt-model.d.ts",
-    "model.d.ts",
-    "plaintext.d.ts",
-    "refresh.d.ts",
-    "srp.d.ts",
-    "storage.d.ts",
-    "util.d.ts",
-    "hosted-oauth.d.ts"
+    "*.d.ts"
   ],
   "dependencies": {
     "aws-jwt-verify": "^4.0.1",


### PR DESCRIPTION
### Description

Publish the complete generated root declaration set so package-root exports and declaration dependencies resolve for strict TypeScript consumers. This fixes the missing `lock.d.ts` declaration behind `activeLockBackend()` and prevents the same omission for future generated declarations.

### Linear

N/A

### Changes

- Replace the manually enumerated declaration allowlist with the generated root `*.d.ts` set.
- Include `lock.d.ts` plus existing transitive declarations required by public types.

### QA Plan

- [ ] Publish the next patch release from `main` after merge.
- [ ] Install that release in a strict TypeScript consumer and import `activeLockBackend()` from the package root.

### Evidence

[Need to add evidence]